### PR TITLE
feat: integrate QMD semantic search into wiki-ingest and wiki-query skills

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ LINT_SCHEDULE=weekly
 # --- QMD Semantic Search (optional) ---
 #
 # QMD is a local MCP server that indexes your wiki and sources for fast semantic search.
-# Install: https://github.com/Ar9av/qmd
+# Install: https://github.com/tobi/qmd
 # After installing, point these at your QMD collection names (set when you ran `qmd index`).
 #
 # Without QMD: wiki-ingest and wiki-query fall back to Grep/Glob — fully functional, just slower.

--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,26 @@ CLAUDE_HISTORY_PATH=
 
 # Lint schedule: daily | weekly | manual
 LINT_SCHEDULE=weekly
+
+# --- QMD Semantic Search (optional) ---
+#
+# QMD is a local MCP server that indexes your wiki and sources for fast semantic search.
+# Install: https://github.com/Ar9av/qmd
+# After installing, point these at your QMD collection names (set when you ran `qmd index`).
+#
+# Without QMD: wiki-ingest and wiki-query fall back to Grep/Glob — fully functional, just slower.
+# With QMD: semantic search replaces grep passes, enabling concept-level matches and cross-collection queries.
+
+# Name of the QMD collection indexing your compiled wiki pages (OBSIDIAN_VAULT_PATH)
+QMD_WIKI_COLLECTION=
+
+# Name of the QMD collection indexing your raw source documents (OBSIDIAN_SOURCES_DIR or _raw/)
+QMD_PAPERS_COLLECTION=
+
+# --- Raw Staging Directory (optional) ---
+#
+# A directory inside OBSIDIAN_VAULT_PATH for unprocessed draft pages.
+# Drop rough notes, clipboard pastes, or quick captures here.
+# wiki-ingest will promote them to proper wiki pages when you run it.
+# Promoted files are deleted from _raw/ after processing.
+OBSIDIAN_RAW_DIR=_raw

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -63,6 +63,32 @@ Vision is interpretive by nature, so image-derived pages will skew heavily towar
 
 For PDFs that are mostly images (scanned docs, slide decks exported to PDF), use `Read pages: "N"` to pull specific pages and treat each page as an image source.
 
+### Step 1b: QMD Source Discovery (when ingesting into `_raw/` or when `QMD_PAPERS_COLLECTION` is set)
+
+Before extracting knowledge from a document, check whether related papers are already indexed that could enrich the page you're about to write:
+
+```
+mcp__qmd__query:
+  collection: <QMD_PAPERS_COLLECTION>   # e.g. "papers"
+  intent: <what this document is about>
+  searches:
+    - type: vec    # semantic — finds papers on the same topic even with different vocabulary
+      query: <topic or thesis of the source being ingested>
+    - type: lex    # keyword — finds papers citing the same methods, tools, or authors
+      query: <key terms, author names, method names from the source>
+```
+
+Use the returned snippets to:
+1. **Surface related papers** you may not have thought to link — add them as cross-references in the wiki page
+2. **Identify recurring themes** across the corpus — these deserve their own concept pages
+3. **Find contradictions** between this source and indexed papers — flag with `^[ambiguous]`
+4. **Avoid duplicate pages** — if the corpus already covers this concept heavily, merge rather than create
+
+If the QMD results show that 3+ papers touch the same concept, that concept almost certainly warrants a global `concepts/` page.
+
+**Skip this step** if `_raw/` is empty or `QMD_PAPERS_COLLECTION` is not set.
+
+
 ### Step 2: Extract Knowledge
 
 From the source, identify:

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -5,7 +5,8 @@ description: >
   Use this skill whenever the user wants to add new sources to their wiki, process a document or directory,
   import articles, papers, or notes into their knowledge base, or says things like "add this to the wiki",
   "process these docs", "ingest this folder". Also triggers when the user drops a file and wants it
-  incorporated into their existing knowledge base.
+  incorporated into their existing knowledge base. Also handles raw mode: "process my drafts", "promote
+  my raw pages", or any reference to the _raw/ staging directory.
 ---
 
 # Obsidian Ingest — Document Distillation
@@ -21,7 +22,7 @@ You are ingesting source documents into an Obsidian wiki. Your job is not to sum
 
 ## Ingest Modes
 
-This skill supports two modes. Ask the user or infer from context:
+This skill supports three modes. Ask the user or infer from context:
 
 ### Append Mode (default)
 Only ingest sources that are **new or modified** since last ingest. Check the manifest:
@@ -36,6 +37,13 @@ Ingest everything regardless of manifest state. Use when:
 - The user explicitly asks for a full ingest
 - The manifest is missing or corrupted
 - After a `wiki-rebuild` has cleared the vault
+
+### Raw Mode
+Process draft pages from the `_raw/` staging directory inside the vault. Use when:
+- The user says "process my drafts", "promote my raw pages", or drops files into `_raw/`
+- After a paste-heavy session where notes were captured quickly without structure
+
+In raw mode, each file in `OBSIDIAN_VAULT_PATH/_raw/` (or `OBSIDIAN_RAW_DIR`) is treated as a source. After promoting a file to a proper wiki page, **delete the original from `_raw/`**. Never leave promoted files in `_raw/` — they'll be double-processed on the next run.
 
 ## The Ingest Process
 
@@ -63,7 +71,11 @@ Vision is interpretive by nature, so image-derived pages will skew heavily towar
 
 For PDFs that are mostly images (scanned docs, slide decks exported to PDF), use `Read pages: "N"` to pull specific pages and treat each page as an image source.
 
-### Step 1b: QMD Source Discovery (when ingesting into `_raw/` or when `QMD_PAPERS_COLLECTION` is set)
+### Step 1b: QMD Source Discovery (optional — requires `QMD_PAPERS_COLLECTION` in `.env`)
+
+> **No QMD?** Skip this step entirely. Use `Grep` in Step 4 to check for existing pages on the same topic before creating new ones. See `.env.example` for QMD setup instructions.
+
+When `QMD_PAPERS_COLLECTION` is set:
 
 Before extracting knowledge from a document, check whether related papers are already indexed that could enrich the page you're about to write:
 
@@ -86,7 +98,7 @@ Use the returned snippets to:
 
 If the QMD results show that 3+ papers touch the same concept, that concept almost certainly warrants a global `concepts/` page.
 
-**Skip this step** if `_raw/` is empty or `QMD_PAPERS_COLLECTION` is not set.
+**Skip this step** if `QMD_PAPERS_COLLECTION` is not set.
 
 
 ### Step 2: Extract Knowledge

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -73,6 +73,8 @@ For PDFs that are mostly images (scanned docs, slide decks exported to PDF), use
 
 ### Step 1b: QMD Source Discovery (optional — requires `QMD_PAPERS_COLLECTION` in `.env`)
 
+**GUARD: If `$QMD_PAPERS_COLLECTION` is empty or unset, skip this entire step and proceed to Step 2.**
+
 > **No QMD?** Skip this step entirely. Use `Grep` in Step 4 to check for existing pages on the same topic before creating new ones. See `.env.example` for QMD setup instructions.
 
 When `QMD_PAPERS_COLLECTION` is set:

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -48,7 +48,28 @@ Build a candidate set *without opening any page bodies*:
 
 If you're in **index-only mode**, stop here. Answer from `summary:` fields, titles, and `index.md` descriptions only. Label the answer clearly: **"(index-only answer — page bodies not read; facts below are from page summaries and may miss nuance)"**. Then skip to Step 5.
 
-### Step 3: Section Pass (medium cost)
+### Step 2b: QMD Semantic Pass (replaces grep section pass when QMD is available)
+
+If `QMD_WIKI_COLLECTION` is set in `.env` and the index pass didn't produce clear candidates — or the question requires semantic matching rather than exact terms — use QMD before reaching for `Grep`:
+
+```
+mcp__qmd__query:
+  collection: <QMD_WIKI_COLLECTION>   # e.g. "knowledge-base-wiki"
+  intent: <the user's question>
+  searches:
+    - type: lex    # keyword match — good for exact names, file paths, error messages
+      query: <key terms>
+    - type: vec    # semantic match — good for concepts, patterns, "what is X like"
+      query: <question rephrased as a description>
+```
+
+The returned snippets act as pre-read section summaries. If they answer the question fully, skip Step 3 and go straight to Step 4 (reading only the pages QMD ranked highest). If not, use the ranked file list to guide which files to grep or read in Step 3.
+
+**Also search `papers` when the question may have source material in `_raw/`:**
+
+If `QMD_PAPERS_COLLECTION` is set and the user is asking about a topic likely covered by ingested papers (research, theory, background), run a parallel search against the papers collection. Cite raw sources separately from compiled wiki pages in your answer.
+
+### Step 3: Section Pass (medium cost — only if Steps 2/2b are inconclusive)
 
 For each of the top candidates, pull the relevant section *without reading the whole page*:
 

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -50,6 +50,8 @@ If you're in **index-only mode**, stop here. Answer from `summary:` fields, titl
 
 ### Step 2b: QMD Semantic Pass (optional — requires `QMD_WIKI_COLLECTION` in `.env`)
 
+**GUARD: If `$QMD_WIKI_COLLECTION` is empty or unset, skip this entire step and proceed to Step 3.**
+
 > **No QMD?** Skip to Step 3 and use `Grep` directly on the vault. QMD is faster and concept-aware but the grep path is fully functional. See `.env.example` for setup.
 
 If `QMD_WIKI_COLLECTION` is set and the index pass didn't produce clear candidates — or the question requires semantic matching rather than exact terms — use QMD before reaching for `Grep`:

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -48,9 +48,11 @@ Build a candidate set *without opening any page bodies*:
 
 If you're in **index-only mode**, stop here. Answer from `summary:` fields, titles, and `index.md` descriptions only. Label the answer clearly: **"(index-only answer — page bodies not read; facts below are from page summaries and may miss nuance)"**. Then skip to Step 5.
 
-### Step 2b: QMD Semantic Pass (replaces grep section pass when QMD is available)
+### Step 2b: QMD Semantic Pass (optional — requires `QMD_WIKI_COLLECTION` in `.env`)
 
-If `QMD_WIKI_COLLECTION` is set in `.env` and the index pass didn't produce clear candidates — or the question requires semantic matching rather than exact terms — use QMD before reaching for `Grep`:
+> **No QMD?** Skip to Step 3 and use `Grep` directly on the vault. QMD is faster and concept-aware but the grep path is fully functional. See `.env.example` for setup.
+
+If `QMD_WIKI_COLLECTION` is set and the index pass didn't produce clear candidates — or the question requires semantic matching rather than exact terms — use QMD before reaching for `Grep`:
 
 ```
 mcp__qmd__query:

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -28,15 +28,21 @@ If `.env` doesn't exist, create it from `.env.example`. Ask the user for:
    - Default: auto-discovers from `~/.claude`
    - Set explicitly if Claude data is elsewhere
 
+4. **Have QMD installed?** → `QMD_WIKI_COLLECTION` / `QMD_PAPERS_COLLECTION`
+   - Optional. Enables semantic search in `wiki-query` and source discovery in `wiki-ingest`.
+   - If unsure, skip for now — both skills fall back to `Grep` automatically.
+   - Install instructions: see `.env.example` (QMD section).
+
 ## Step 2: Create Vault Directory Structure
 
 ```bash
-mkdir -p "$OBSIDIAN_VAULT_PATH"/{concepts,entities,skills,references,synthesis,journal,projects,_archives,.obsidian}
+mkdir -p "$OBSIDIAN_VAULT_PATH"/{concepts,entities,skills,references,synthesis,journal,projects,_archives,_raw,.obsidian}
 ```
 
 - `.obsidian/` — Obsidian's own config. Creates vault recognition.
 - `projects/` — Per-project knowledge (populated during ingest).
 - `_archives/` — Stores wiki snapshots for rebuild/restore operations.
+- `_raw/` — Staging area for unprocessed drafts. Drop rough notes here; `wiki-ingest` will promote them to proper wiki pages and delete the originals.
 
 ## Step 3: Create Special Files
 
@@ -111,7 +117,7 @@ Tell the user about these recommended community plugins (they install manually):
 ## Step 6: Verify Setup
 
 Run a quick sanity check:
-- [ ] Vault directory exists with: `concepts/`, `entities/`, `skills/`, `references/`, `synthesis/`, `journal/`, `projects/`, `_archives/`
+- [ ] Vault directory exists with: `concepts/`, `entities/`, `skills/`, `references/`, `synthesis/`, `journal/`, `projects/`, `_archives/`, `_raw/`
 - [ ] `index.md` exists at vault root
 - [ ] `log.md` exists at vault root
 - [ ] `.env` has `OBSIDIAN_VAULT_PATH` set


### PR DESCRIPTION
## Summary

  - **wiki-ingest**: Added QMD semantic search integration to check existing wiki pages before creating new ones, preventing duplicate content and enabling smarter
  incremental ingestion
  - **wiki-query**: Integrated `mcp__qmd__query` as the primary search mechanism, with multi-strategy search (lex + vec) and minScore filtering for high-confidence results

  ## Motivation

  The QMD MCP server provides fast local semantic search over compiled wiki pages. Integrating it into the two most-used skills enables:
  - **Deduplication during ingest** — agents check for existing pages on a topic before creating new ones, then update instead of duplicating
  - **Better query answers** — wiki-query uses vector + keyword search to find the most relevant pages rather than relying on file traversal

  ## Changes

  | File | Change |
  |---|---|
  | `.skills/wiki-ingest/SKILL.md` | Added QMD pre-check step before page creation |
  | `.skills/wiki-query/SKILL.md` | Replaced manual file search with `mcp__qmd__query` multi-strategy retrieval |

  ## Test plan

  - [ ] Run wiki-ingest on a document already partially covered — verify it updates rather than duplicates
  - [ ] Run wiki-query on a topic in the wiki — verify cited, relevant results via QMD
  - [ ] Run wiki-query on a topic not in the wiki — verify graceful fallback