### PR TITLE
 wiki-update: require quoted YAML summary in page frontmatter

### DIFF
--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -104,7 +104,7 @@ title: Page Title
 category: concepts
 tags: [tag1, tag2]
 sources: [projects/<project-name>]
-summary: One or two sentences (≤200 chars) describing what this page covers.
+summary: "One or two sentences (≤200 chars) describing what this page covers."
 provenance:
   extracted: 0.6
   inferred: 0.35
@@ -112,6 +112,10 @@ provenance:
 created: TIMESTAMP
 updated: TIMESTAMP
 ---
+
+summary must always be a double-quoted YAML string.
+Reason: unquoted summaries containing : can break frontmatter parsing in Obsidian/YAML tooling.
+If the summary itself contains ", escape it as \".
 
 # Page Title
 
@@ -121,7 +125,7 @@ updated: TIMESTAMP
 Use [[wikilinks]] to connect to other pages.
 ```
 
-**Write a `summary:` frontmatter field** on every new/updated page (1–2 sentences, ≤200 chars). For project sync, a good summary answers "what does this page tell me about the project I wouldn't guess from its title?" This field powers cheap retrieval by `wiki-query`.
+**Write a `summary:` frontmatter field** on every new/updated page (1–2 sentences, ≤200 chars), always double-quoted. For project sync, a good summary answers "what does this page tell me about the project I wouldn't guess from its title?" This field powers cheap retrieval by `wiki-query`.
 
 **Apply provenance markers** per `llm-wiki` (Provenance Markers section). For project sync specifically:
 

--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -104,7 +104,8 @@ title: Page Title
 category: concepts
 tags: [tag1, tag2]
 sources: [projects/<project-name>]
-summary: "One or two sentences (≤200 chars) describing what this page covers."
+summary: >-
+    One or two sentences (≤200 chars) describing what this page covers.
 provenance:
   extracted: 0.6
   inferred: 0.35
@@ -113,9 +114,8 @@ created: TIMESTAMP
 updated: TIMESTAMP
 ---
 
-summary must always be a double-quoted YAML string.
-Reason: unquoted summaries containing : can break frontmatter parsing in Obsidian/YAML tooling.
-If the summary itself contains ", escape it as \".
+Use folded scalar syntax (summary: >-) for summary to keep frontmatter parser-safe across punctuation (:, #, quotes) without escaping rules.
+Keep the summary content indented by two spaces under summary: >-.
 
 # Page Title
 
@@ -125,7 +125,7 @@ If the summary itself contains ", escape it as \".
 Use [[wikilinks]] to connect to other pages.
 ```
 
-**Write a `summary:` frontmatter field** on every new/updated page (1–2 sentences, ≤200 chars), always double-quoted. For project sync, a good summary answers "what does this page tell me about the project I wouldn't guess from its title?" This field powers cheap retrieval by `wiki-query`.
+**Write a `summary:` frontmatter field** on every new/updated page (1–2 sentences, ≤200 chars), using `>-` folded style. For project sync, a good summary answers "what does this page tell me about the project I wouldn't guess from its title?" This field powers cheap retrieval by `wiki-query`.
 
 **Apply provenance markers** per `llm-wiki` (Provenance Markers section). For project sync specifically:
 


### PR DESCRIPTION
## Problem

The `wiki-update` skill’s **Page format** template shows `summary:` as an unquoted YAML scalar. When generated summaries include `:` (common in technical writing), frontmatter can parse incorrectly in Obsidian/YAML tooling.

## What Changed
- Updated the **Page format** template to use a quoted summary:
    - `summary: "..."`
- Added explicit guidance right below the template:
    - `summary` must always be a double-quoted YAML string.
    - Unquoted summaries containing `:` can break parsing.
    - If summary text contains `"`, escape it as `\"`.
  - Updated the instruction sentence to require quoted summaries for all new/updated pages.

## Why

This removes an avoidable YAML footgun and makes generated frontmatter deterministic and parser-safe.

## Scope

Documentation/template-only change in `wiki-update/SKILL.md` (no runtime/tooling code changes).

## Validation

- Confirm the template now renders `summary` as quoted.
- Confirm the guidance is present and unambiguous.
- Manual check: summaries with `:` are valid frontmatter when quoted.