### PR TITLE
Fix tag formatting in SKILL.md

### DIFF
--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -117,12 +117,15 @@ A content-oriented catalog organized by category. Each entry has a one-line summ
 # Wiki Index
 
 ## Concepts
-- [[transformer-architecture]] — The dominant architecture for sequence modeling (#ml #architecture)
-- [[attention-mechanism]] — Core building block of transformers (#ml #fundamentals)
+- [[transformer-architecture]] — The dominant architecture for sequence modeling ( #ml #architecture)
+- [[attention-mechanism]] — Core building block of transformers ( #ml #fundamentals)
 
 ## Entities
-- [[andrej-karpathy]] — AI researcher, educator, former Tesla AI director (#person #ml)
+- [[andrej-karpathy]] — AI researcher, educator, former Tesla AI director ( #person #ml)
 ```
+**Format rule**: Add a space after the opening `(` and tags.
+❌ Don't: `description (#tag)` — breaks tag parsing
+✅ Do: `description ( #tag)` — proper spacing and tag parsing
 
 ### `log.md`
 Chronological append-only record tracking every operation. Each entry is parseable:


### PR DESCRIPTION
Added space after the opening parenthesis in tags for better parsing.