### PR TITLE
docs: skills CLI install + AGENTS.md rewrite for cross-project agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,39 +1,87 @@
 # Obsidian Wiki — Agent Context
 
-This project is a **skill-based framework** for building and maintaining an Obsidian knowledge base. There are no scripts or dependencies — everything is markdown instructions that you (the agent) execute directly.
+A **skill-based framework** for building and maintaining an Obsidian knowledge base. No scripts or dependencies — everything is markdown instructions that you execute directly.
 
-## Quick Orientation
+## Configuration
 
-1. Read `.env` for `OBSIDIAN_VAULT_PATH` — this is where the wiki lives.
-2. Read `.manifest.json` at the vault root to see what's already been ingested.
-3. Skills are in `.skills/` (symlinked to `.claude/skills/`, `.agents/skills/` (workspace), `~/.gemini/antigravity/skills/`, `~/.codex/skills/`, and `~/.agents/skills/` (the path OpenClaw and other AGENTS.md-aware agents discover from) for global access). Each subfolder has a `SKILL.md`.
+Read config in this order (first found wins):
 
-## When to Use Skills
+1. **`~/.obsidian-wiki/config`** — global config, works from any project directory
+2. **`.env`** in the obsidian-wiki repo — local fallback
 
-| User says something like… | Read this skill |
+Both files set `OBSIDIAN_VAULT_PATH` (where the wiki lives). The global config also sets `OBSIDIAN_WIKI_REPO` (where this repo is cloned).
+
+## Vault Structure
+
+```
+$OBSIDIAN_VAULT_PATH/
+├── index.md                # Master index — every page listed, always kept current
+├── log.md                  # Chronological activity log (ingests, updates, lints)
+├── .manifest.json          # Tracks every ingested source: path, timestamps, pages produced
+├── _meta/
+│   └── taxonomy.md         # Controlled tag vocabulary
+├── _insights.md            # Graph analysis output (hubs, bridges, dead ends)
+├── _raw/                   # Staging area — drop rough notes here, next ingest promotes them
+├── concepts/               # Abstract ideas, patterns, mental models
+├── entities/               # Concrete things — people, tools, libraries, companies
+├── skills/                 # How-to knowledge, techniques, procedures
+├── references/             # Factual lookups — specs, APIs, configs
+├── synthesis/              # Cross-cutting analysis connecting multiple concepts
+├── journal/                # Time-bound entries — daily logs, session notes
+└── projects/
+    └── <project-name>.md   # One page per project synced via wiki-update
+```
+
+Every wiki page has required frontmatter: `title`, `category`, `tags`, `sources`, `created`, `updated`. Pages connect via `[[wikilinks]]`.
+
+## Skill Routing
+
+Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right skill:
+
+| User says something like… | Skill |
 |---|---|
-| "set up my wiki" / "initialize" | `.skills/wiki-setup/SKILL.md` |
-| "ingest" / "add this to the wiki" / "process these docs" | `.skills/wiki-ingest/SKILL.md` |
-| "import my Claude history" / "mine my conversations" | `.skills/claude-history-ingest/SKILL.md` |
-| "process this export" / "ingest this data" / logs, transcripts | `.skills/data-ingest/SKILL.md` |
-| "what's the status" / "what's been ingested" / "show the delta" | `.skills/wiki-status/SKILL.md` |
-| "wiki insights" / "what's central" / "show me the hubs" / "wiki structure" | `.skills/wiki-status/SKILL.md` (insights mode) |
-| "what do I know about X" / "find info on Y" / any question | `.skills/wiki-query/SKILL.md` |
-| "audit" / "lint" / "find broken links" / "wiki health" | `.skills/wiki-lint/SKILL.md` |
-| "rebuild" / "start over" / "archive" / "restore" | `.skills/wiki-rebuild/SKILL.md` |
-| "link my pages" / "cross-reference" / "connect my wiki" | `.skills/cross-linker/SKILL.md` |
-| "fix my tags" / "normalize tags" / "tag audit" | `.skills/tag-taxonomy/SKILL.md` |
-| "update wiki" / "sync to wiki" / "save this to my wiki" | `.skills/wiki-update/SKILL.md` |
-| "create a new skill" | `.skills/skill-creator/SKILL.md` |
-| "export wiki" / "export graph" / "graphml" / "neo4j" / "visualize wiki" | `.skills/wiki-export/SKILL.md` |
+| "set up my wiki" / "initialize" | `wiki-setup` |
+| "ingest" / "add this to the wiki" / "process these docs" | `wiki-ingest` |
+| "import my Claude history" / "mine my conversations" | `claude-history-ingest` |
+| "process this export" / "ingest this data" / logs, transcripts | `data-ingest` |
+| "what's the status" / "what's been ingested" / "show the delta" | `wiki-status` |
+| "wiki insights" / "hubs" / "wiki structure" | `wiki-status` (insights mode) |
+| "what do I know about X" / "find info on Y" / any question | `wiki-query` |
+| "audit" / "lint" / "find broken links" / "wiki health" | `wiki-lint` |
+| "rebuild" / "start over" / "archive" / "restore" | `wiki-rebuild` |
+| "link my pages" / "cross-reference" / "connect my wiki" | `cross-linker` |
+| "fix my tags" / "normalize tags" / "tag audit" | `tag-taxonomy` |
+| "update wiki" / "sync to wiki" / "save this to my wiki" | `wiki-update` |
+| "export wiki" / "export graph" / "graphml" / "neo4j" | `wiki-export` |
+| "create a new skill" | `skill-creator` |
 
-## Key Rules
+## Cross-Project Usage
 
-- **Compile, don't retrieve.** The wiki is pre-compiled knowledge. Update existing pages, don't just append.
-- **Always update `.manifest.json`** after ingesting — it tracks what's been processed.
-- **Always update `index.md` and `log.md`** after any operation.
-- **Use `[[wikilinks]]`** to connect related pages. This is an Obsidian vault.
-- **Frontmatter is required** on every wiki page: title, category, tags, sources, created, updated.
+The main use case: you're working in some other project and want to sync knowledge into your wiki or query it. Two global skills handle this — `wiki-update` and `wiki-query`. They work from any directory.
+
+### wiki-update (write to wiki)
+
+1. Read `~/.obsidian-wiki/config` to get `OBSIDIAN_VAULT_PATH`
+2. Scan the current project: README, source structure, git log, package metadata
+3. Distill what's worth remembering (architecture decisions, patterns, trade-offs — not code listings)
+4. Write to `$VAULT/projects/<project-name>.md`, cross-linking to concept/entity pages as needed
+5. Update `.manifest.json`, `index.md`, and `log.md`
+
+On repeat runs, it checks `last_commit_synced` in `.manifest.json` and only processes the delta via `git log <last_commit>..HEAD`.
+
+### wiki-query (read from wiki)
+
+1. Read `~/.obsidian-wiki/config` to get `OBSIDIAN_VAULT_PATH`
+2. Scan titles, tags, and `summary:` frontmatter fields first (cheap pass)
+3. Only open page bodies when the index pass can't answer
+4. Return a synthesized answer with `[[wikilink]]` citations
+
+## Core Principles
+
+- **Compile, don't retrieve.** The wiki is pre-compiled knowledge. Update existing pages — don't append or duplicate.
+- **Track everything.** Update `.manifest.json` after ingesting, `index.md` and `log.md` after any operation.
+- **Connect with `[[wikilinks]]`.** Every page should link to related pages. This is what makes it a knowledge graph, not a folder of files.
+- **Frontmatter is required.** Every wiki page needs: `title`, `category`, `tags`, `sources`, `created`, `updated`.
 
 ## Architecture Reference
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,18 @@ We took that and built a framework around it. The whole thing is a set of markdo
 
 ## Quick Start
 
+### Install via Skills CLI (recommended)
+
+```bash
+npx skills add Ar9av/obsidian-wiki
+```
+
+This installs all wiki skills into your current agent (Claude Code, Cursor, Codex, etc.). Then open your agent and say **"set up my wiki"**.
+
+Browse the full skill list at [skills.sh/ar9av/obsidian-wiki](https://skills.sh/ar9av/obsidian-wiki).
+
+### Install via git clone
+
 ```bash
 git clone https://github.com/Ar9av/obsidian-wiki.git
 cd obsidian-wiki
@@ -251,12 +263,7 @@ Both projects use the same [Agent Skills spec](https://agentskills.io/specificat
 **Install:**
 
 ```bash
-# Via npx (if skills CLI is available)
-npx skills add git@github.com:kepano/obsidian-skills.git
-
-# Or manually — copy into your skills directory
-git clone https://github.com/kepano/obsidian-skills.git /tmp/obsidian-skills
-cp -r /tmp/obsidian-skills/skills/* .skills/
+npx skills add kepano/obsidian-skills
 ```
 
 After installing, your agent will automatically pick up the new skills alongside the existing wiki skills.


### PR DESCRIPTION
## Summary

- **README**: Add `npx skills add Ar9av/obsidian-wiki` as the recommended install method in Quick Start, with a link to the [skills.sh listing](https://skills.sh/ar9av/obsidian-wiki). Git clone remains as a secondary option. Simplify kepano companion install to `npx skills add kepano/obsidian-skills`.
- **AGENTS.md**: Full rewrite so agents arriving from other projects can understand the entire system in one read — no need to open 2-3 skill files just to know what folders exist.

## What changed in AGENTS.md

1. **Vault Structure** — inline directory tree with every folder and special file described
2. **Cross-Project Usage** — documents the `wiki-update` / `wiki-query` workflow end-to-end (read `~/.obsidian-wiki/config`, scan project, distill to `$VAULT/projects/<name>.md`, delta tracking via `last_commit_synced`)
3. **Configuration** — `~/.obsidian-wiki/config` is now the primary config source, `.env` is fallback (agents running from other projects don't have `.env` in scope)
4. **Skill routing table** — simplified to just skill names (agents know to look in `.skills/<name>/SKILL.md`)
5. **Core Principles** — merged from the old "Key Rules" section, tighter and scannable

## Why

The repo is already indexed on [skills.sh](https://skills.sh/ar9av/obsidian-wiki) (52 installs, 14 skills). Users should be able to install with one command rather than cloning. And agents landing on `AGENTS.md` from another project directory had no way to understand the vault layout or the cross-project workflow without reading multiple skill files.

## Test plan

- [ ] Verify `npx skills add Ar9av/obsidian-wiki --list` still discovers all 14 skills
- [ ] Verify `npx skills add kepano/obsidian-skills --list` works
- [ ] Confirm skills.sh link resolves: https://skills.sh/ar9av/obsidian-wiki