### PR TITLE
Add Codex history ingest + unified /wiki-history-ingest routing and pipeline doc alignment

### DIFF
--- a/.cursor/rules/obsidian-wiki.mdc
+++ b/.cursor/rules/obsidian-wiki.mdc
@@ -20,7 +20,9 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 |---|---|
 | "set up my wiki" / "initialize" | `.skills/wiki-setup/SKILL.md` |
 | "ingest" / "add this to the wiki" | `.skills/wiki-ingest/SKILL.md` |
+| "/wiki-history-ingest claude" / "/wiki-history-ingest codex" | `.skills/wiki-history-ingest/SKILL.md` |
 | "import my Claude history" | `.skills/claude-history-ingest/SKILL.md` |
+| "import my Codex history" | `.skills/codex-history-ingest/SKILL.md` |
 | "process this export" / "ingest this data" | `.skills/data-ingest/SKILL.md` |
 | "what's the status" / "show the delta" | `.skills/wiki-status/SKILL.md` |
 | "what do I know about X" / any question | `.skills/wiki-query/SKILL.md` |

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ OBSIDIAN_MAX_PAGES_PER_INGEST=15
 # Claude conversation history path (auto-discovered from ~/.claude if empty)
 CLAUDE_HISTORY_PATH=
 
+# Codex history path (defaults to ~/.codex if empty)
+CODEX_HISTORY_PATH=
+
 # Lint schedule: daily | weekly | manual
 LINT_SCHEDULE=weekly
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,7 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 - **Purpose:** Build and maintain an Obsidian wiki using the LLM Wiki pattern (Andrej Karpathy).
 - **Tech Stack:** Markdown only. No code, no dependencies. The AI agent IS the runtime.
 - **Key Config:** `.env` contains `OBSIDIAN_VAULT_PATH` pointing to the vault location.
-- **Skills:** `.skills/` contains 12 skill folders, each with a `SKILL.md` defining a workflow.
+- **Skills:** `.skills/` contains skill folders, each with a `SKILL.md` defining a workflow.
 
 ## Key Concepts
 
@@ -23,7 +23,9 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 |---|---|---|
 | Setup | `.skills/wiki-setup/` | Initialize vault structure |
 | Ingest | `.skills/wiki-ingest/` | Distill documents into wiki pages |
+| History Router | `.skills/wiki-history-ingest/` | Route `/wiki-history-ingest <claude|codex>` to the right history skill |
 | Claude History | `.skills/claude-history-ingest/` | Mine `~/.claude` conversations |
+| Codex History | `.skills/codex-history-ingest/` | Mine `~/.codex` sessions and rollout logs |
 | Data Ingest | `.skills/data-ingest/` | Process any text data |
 | Status | `.skills/wiki-status/` | Audit ingestion state and delta |
 | Query | `.skills/wiki-query/` | Answer questions from wiki |

--- a/.skills/claude-history-ingest/SKILL.md
+++ b/.skills/claude-history-ingest/SKILL.md
@@ -12,6 +12,8 @@ description: >
 
 You are extracting knowledge from the user's past Claude Code conversations and distilling it into the Obsidian wiki. Conversations are rich but messy — your job is to find the signal and compile it.
 
+This skill can be invoked directly or via the `wiki-history-ingest` router (`/wiki-history-ingest claude`).
+
 ## Before You Start
 
 1. Read `.env` to get `OBSIDIAN_VAULT_PATH` and `CLAUDE_HISTORY_PATH` (defaults to `~/.claude`)

--- a/.skills/codex-history-ingest/SKILL.md
+++ b/.skills/codex-history-ingest/SKILL.md
@@ -1,0 +1,199 @@
+---
+name: codex-history-ingest
+description: >
+  Ingest Codex CLI conversation history into the Obsidian wiki. Use this skill when the user wants to mine
+  their past Codex sessions for knowledge, import their ~/.codex folder, extract insights from previous coding
+  sessions, or says things like "process my Codex history", "add my Codex conversations to the wiki", or
+  "what have I discussed in Codex before". Also triggers when the user mentions .codex sessions, rollout files,
+  session_index.jsonl, or Codex transcript logs.
+---
+
+# Codex History Ingest — Conversation Mining
+
+You are extracting knowledge from the user's past Codex sessions and distilling it into the Obsidian wiki. Session logs are rich but noisy: focus on durable knowledge, not operational telemetry.
+
+## Before You Start
+
+1. Read `.env` to get `OBSIDIAN_VAULT_PATH` and `CODEX_HISTORY_PATH` (default to `~/.codex` if unset)
+2. Read `.manifest.json` at the vault root to check what has already been ingested
+3. Read `index.md` at the vault root to understand what the wiki already contains
+
+## Ingest Modes
+
+### Append Mode (default)
+
+Check `.manifest.json` for each source file. Only process:
+
+- Files not in the manifest (new session rollouts, new index files)
+- Files whose modification time is newer than `ingested_at` in the manifest
+
+Use this mode for regular syncs.
+
+### Full Mode
+
+Process everything regardless of manifest. Use after `wiki-rebuild` or if the user explicitly asks for a full re-ingest.
+
+## Codex Data Layout
+
+Codex stores local artifacts under `~/.codex/`.
+
+```
+~/.codex/
+├── sessions/                          # Session rollout logs by date
+│   └── YYYY/MM/DD/
+│       └── rollout-<timestamp>-<id>.jsonl
+├── archived_sessions/                 # Archived rollout logs
+├── session_index.jsonl                # Lightweight index of thread id/name/updated_at
+├── history.jsonl                      # Local transcript history (if persistence enabled)
+├── config.toml                        # User config (contains history settings)
+└── state_*.sqlite / logs_*.sqlite     # Runtime DBs (usually skip)
+```
+
+### Key data sources ranked by value
+
+1. `session_index.jsonl` — best inventory source for IDs, titles, and freshness
+2. `sessions/**/rollout-*.jsonl` — rich structured transcript events
+3. `history.jsonl` — useful fallback/timeline aid if enabled
+
+Avoid ingesting SQLite internals unless the user explicitly asks.
+
+## Step 1: Survey and Compute Delta
+
+Scan `CODEX_HISTORY_PATH` and compare against `.manifest.json`:
+
+- `~/.codex/session_index.jsonl`
+- `~/.codex/sessions/**/rollout-*.jsonl`
+- `~/.codex/archived_sessions/**` (optional; only if user asks for archived history)
+- `~/.codex/history.jsonl` (optional fallback)
+
+Classify each file:
+
+- **New** — not in manifest
+- **Modified** — in manifest but file is newer than `ingested_at`
+- **Unchanged** — already ingested and unchanged
+
+Report a concise delta summary before deep parsing.
+
+## Step 2: Parse Session Index First
+
+`session_index.jsonl` typically has entries like:
+
+```json
+{"id":"...","thread_name":"...","updated_at":"..."}
+```
+
+Use it to:
+
+- Build a canonical session inventory
+- Prioritize recent/high-signal sessions
+- Map rollout IDs to human-readable thread names
+
+## Step 3: Parse Rollout JSONL Safely
+
+Each `rollout-*.jsonl` line is an event envelope with:
+
+```json
+{
+  "timestamp": "...",
+  "type": "session_meta|turn_context|event_msg|response_item",
+  "payload": { ... }
+}
+```
+
+### Extraction rules
+
+- Prioritize user intent and assistant-visible outputs
+- Favor `response_item` records with user/assistant message content
+- Use `event_msg` selectively for meaningful milestones; ignore pure telemetry
+- Treat `session_meta` as metadata (cwd, model, ids), not user knowledge
+
+### Skip/noise filters
+
+- Token accounting events
+- Tool plumbing with no semantic content
+- Raw command output unless it contains reusable decisions/patterns
+- Repeated plan snapshots unless they add novel decisions
+
+### Critical privacy filter
+
+Rollout logs can include injected instructions, tool payloads, and sensitive text. Do not ingest verbatim system/developer prompts or secrets.
+
+- Remove API keys, tokens, passwords, credentials
+- Redact private identifiers unless relevant and approved
+- Summarize instead of quoting raw transcripts
+
+## Step 4: Cluster by Topic
+
+Do not create one wiki page per session.
+
+- Group by stable topics across many sessions
+- Split mixed sessions into separate themes
+- Merge recurring concepts across dates/projects
+- Use `cwd` from metadata to infer project scope
+
+## Step 5: Distill into Wiki Pages
+
+Route extracted knowledge using existing wiki conventions:
+
+- Project-specific architecture/process -> `projects/<name>/...`
+- General concepts -> `concepts/`
+- Recurring techniques/debug playbooks -> `skills/`
+- Tools/services -> `entities/`
+- Cross-session patterns -> `synthesis/`
+
+For each impacted project, create/update `projects/<name>/<name>.md` (project name as filename, never `_project.md`).
+
+### Writing rules
+
+- Distill knowledge, not chronology
+- Avoid "on date X we discussed..." unless date context is essential
+- Add `summary:` frontmatter on each new/updated page (1-2 sentences, <= 200 chars)
+- Add provenance markers:
+  - `^[extracted]` when directly grounded in explicit session content
+  - `^[inferred]` when synthesizing patterns across events/sessions
+  - `^[ambiguous]` when sessions conflict
+- Add/update `provenance:` frontmatter mix for each changed page
+
+## Step 6: Update Manifest, Log, and Index
+
+### Update `.manifest.json`
+
+For each processed source file:
+
+- `ingested_at`, `size_bytes`, `modified_at`
+- `source_type`: `codex_rollout` | `codex_index` | `codex_history`
+- `project`: inferred project name (when applicable)
+- `pages_created`, `pages_updated`
+
+Add/update a top-level project/session summary block:
+
+```json
+{
+  "project-name": {
+    "source_path": "~/.codex/sessions/...",
+    "last_ingested": "TIMESTAMP",
+    "sessions_ingested": 12,
+    "sessions_total": 40,
+    "index_updated_at": "TIMESTAMP"
+  }
+}
+```
+
+### Update special files
+
+Update `index.md` and `log.md`:
+
+```
+- [TIMESTAMP] CODEX_HISTORY_INGEST sessions=N pages_updated=X pages_created=Y mode=append|full
+```
+
+## Privacy and Compliance
+
+- Distill and synthesize; avoid raw transcript dumps
+- Default to redaction for anything that looks sensitive
+- Ask the user before storing personal/sensitive details
+- Keep references to other people minimal and purpose-bound
+
+## Reference
+
+See `references/codex-data-format.md` for field-level parsing notes and extraction guidance.

--- a/.skills/codex-history-ingest/SKILL.md
+++ b/.skills/codex-history-ingest/SKILL.md
@@ -12,6 +12,8 @@ description: >
 
 You are extracting knowledge from the user's past Codex sessions and distilling it into the Obsidian wiki. Session logs are rich but noisy: focus on durable knowledge, not operational telemetry.
 
+This skill can be invoked directly or via the `wiki-history-ingest` router (`/wiki-history-ingest codex`).
+
 ## Before You Start
 
 1. Read `.env` to get `OBSIDIAN_VAULT_PATH` and `CODEX_HISTORY_PATH` (default to `~/.codex` if unset)

--- a/.skills/codex-history-ingest/references/codex-data-format.md
+++ b/.skills/codex-history-ingest/references/codex-data-format.md
@@ -1,0 +1,82 @@
+# Codex Data Format — Detailed Reference
+
+This reference describes practical, observed structures for Codex local history ingestion.
+
+## Root Layout
+
+`~/.codex/` usually contains:
+
+- `sessions/YYYY/MM/DD/rollout-*.jsonl` — primary structured session logs
+- `archived_sessions/` — archived rollouts
+- `session_index.jsonl` — session id/name/update index
+- `history.jsonl` — transcript history (depends on config)
+- `config.toml` — history persistence controls
+
+## Session Index
+
+`~/.codex/session_index.jsonl` entries are one JSON object per line, commonly:
+
+```json
+{"id":"<thread-id>","thread_name":"<title>","updated_at":"<timestamp>"}
+```
+
+Use this as the inventory backbone for append/full mode deltas.
+
+## Rollout JSONL
+
+`rollout-*.jsonl` files are event streams with envelope fields:
+
+```json
+{
+  "timestamp": "2026-04-12T09:40:02.337Z",
+  "type": "session_meta|turn_context|event_msg|response_item",
+  "payload": { "...": "..." }
+}
+```
+
+Common `type` values:
+
+- `session_meta` — run metadata (id, cwd, model/provider, etc.)
+- `turn_context` — turn-scoped context envelope
+- `event_msg` — runtime events (task lifecycle, token/accounting, tool-call markers)
+- `response_item` — model response items (messages, tool calls, reasoning blocks)
+
+### Typical payload subtypes
+
+Observed examples include:
+
+- `event_msg.payload.type`: `task_started`, `user_message`, `agent_message`, `mcp_tool_call_end`, `exec_command_end`, `token_count`
+- `response_item.payload.type`: `message`, `function_call`, `function_call_output`, `reasoning`
+
+## Extraction Strategy
+
+### Keep
+
+- User intent from user-message records
+- Assistant conclusions/decisions from assistant message records
+- High-signal tool outputs that encode reusable knowledge
+
+### Skip
+
+- Pure telemetry (`token_count`, low-level plumbing events)
+- Internal reasoning traces unless user explicitly asks to retain them
+- Verbose execution dumps with no durable insight
+
+## Privacy Notes
+
+Rollouts can contain sensitive data:
+
+- Injected instruction layers
+- Tool inputs/outputs
+- Potential secrets in command output
+
+Always redact secrets and summarize instead of copying raw transcript content.
+
+## Config Interaction
+
+`~/.codex/config.toml` keys that affect ingestion completeness:
+
+- `history.persistence = "save-all" | "none"`
+- `history.max_bytes = <int>` (truncation/compaction cap)
+
+`codex exec --ephemeral` runs may not persist rollout files.

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -286,6 +286,7 @@ For details on specific operations, see the companion skills:
 - **wiki-rebuild** — Archive current wiki, rebuild from scratch, or restore from archive
 - **wiki-ingest** — Distill source documents into wiki pages
 - **claude-history-ingest** — Ingest Claude conversation history
+- **codex-history-ingest** — Ingest Codex CLI session history
 - **data-ingest** — Ingest any raw text data
 - **wiki-query** — Answer questions against the wiki
 - **wiki-lint** — Audit and maintain wiki health

--- a/.skills/wiki-history-ingest/SKILL.md
+++ b/.skills/wiki-history-ingest/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: wiki-history-ingest
+description: >
+  Unified wiki-history-ingest entrypoint for conversation/session sources. Use this when the user says
+  "/wiki-history-ingest claude" or "/wiki-history-ingest codex", or asks to ingest agent history without
+  naming the underlying skill. This router dispatches to the specialized history skill.
+---
+
+# Unified History Ingest Router
+
+This is a thin router for **history sources only**. It does not replace `wiki-ingest` for documents.
+
+## Subcommands
+
+If the user invokes `/wiki-history-ingest <target>` (or equivalent text command), dispatch directly:
+
+| Subcommand | Route To |
+|---|---|
+| `claude` | `claude-history-ingest` |
+| `codex` | `codex-history-ingest` |
+| `auto` | infer from context using rules below |
+
+## Routing Rules
+
+1. If the user explicitly says `claude` or `codex`, route directly.
+2. If the user provides a path/source:
+   - `~/.claude` or Claude memory/session JSONL artifacts -> `claude-history-ingest`
+   - `~/.codex` or rollout/session index artifacts -> `codex-history-ingest`
+3. If ambiguous, ask one short clarification:
+   - "Should I ingest `claude` history or `codex` history?"
+
+## Execution Contract
+
+- After routing, execute the destination skill's workflow exactly.
+- Do not duplicate destination logic in this file.
+- Leave manifest/index/log update semantics to the destination skill.
+
+## UX Convention
+
+- Use `wiki-ingest` for **documents/content sources**
+- Use `wiki-history-ingest` for **agent history sources**
+
+Examples:
+
+- `/wiki-history-ingest claude`
+- `/wiki-history-ingest codex`
+- `$wiki-history-ingest claude` (agents that use `$skill` invocation)

--- a/.skills/wiki-rebuild/SKILL.md
+++ b/.skills/wiki-rebuild/SKILL.md
@@ -99,8 +99,9 @@ Tell the user the vault is cleared and ready for a full re-ingest. They can now 
 
 1. `wiki-status` — to see all sources as "new"
 2. `claude-history-ingest` — to reprocess Claude history
-3. `wiki-ingest` — to reprocess documents
-4. `data-ingest` — to reprocess any other data
+3. `codex-history-ingest` — to reprocess Codex session history
+4. `wiki-ingest` — to reprocess documents
+5. `data-ingest` — to reprocess any other data
 
 Each of these will rebuild the manifest as they go.
 

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -129,4 +129,5 @@ Report the results and tell the user they can now:
 2. Run `wiki-status` to see what's available to ingest
 3. Run `wiki-ingest` to add their first sources
 4. Run `claude-history-ingest` to mine their Claude conversations
-5. Run `wiki-status` again anytime to check the delta
+5. Run `codex-history-ingest` to mine their Codex sessions (if they use Codex)
+6. Run `wiki-status` again anytime to check the delta

--- a/.skills/wiki-status/SKILL.md
+++ b/.skills/wiki-status/SKILL.md
@@ -292,5 +292,5 @@ After writing the file, append to `log.md`:
 
 - If the manifest doesn't exist, report everything as "new" and recommend a full ingest
 - This skill only reads and reports — it doesn't modify anything (except writing `_insights.md` in insights mode, which is regenerable)
-- The actual ingest work is done by the ingest skills (`wiki-ingest`, `claude-history-ingest`, `data-ingest`)
+- The actual ingest work is done by the ingest skills (`wiki-ingest`, `claude-history-ingest`, `codex-history-ingest`, `data-ingest`)
 - Those skills are responsible for updating the manifest after they finish

--- a/.skills/wiki-status/SKILL.md
+++ b/.skills/wiki-status/SKILL.md
@@ -16,7 +16,7 @@ You are computing the current state of the wiki: what's been ingested, what's ne
 
 ## Before You Start
 
-1. Read `.env` to get `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `CLAUDE_HISTORY_PATH`
+1. Read `.env` to get `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `CLAUDE_HISTORY_PATH`, `CODEX_HISTORY_PATH`
 2. Read `.manifest.json` at the vault root — this is the ingest tracking ledger
 
 ## The Manifest
@@ -84,6 +84,15 @@ Glob: ~/.claude/projects/*/memory/*.md → memory files
 Record: path, size, modification time, parent project
 ```
 
+### Codex History (from `CODEX_HISTORY_PATH`)
+```
+Glob: ~/.codex/session_index.jsonl            → session inventory index
+Glob: ~/.codex/sessions/**/rollout-*.jsonl    → session rollout transcripts
+Glob: ~/.codex/history.jsonl                  → optional local history log
+Glob: ~/.codex/archived_sessions/**/rollout-*.jsonl → archived rollouts (if user wants archive coverage)
+Record: path, size, modification time, inferred project from cwd when available
+```
+
 ### Any other sources the user has pointed at previously
 Check the manifest for source paths outside the standard directories.
 
@@ -106,6 +115,11 @@ For Claude history specifically, also compute:
 - New conversations within existing projects
 - Updated memory files
 
+For Codex history specifically, also compute:
+- New rollout files under `sessions/**`
+- Updated `session_index.jsonl` entries (session title/freshness changes)
+- Archived rollout delta only when archive coverage is requested
+
 ## Step 3: Report the Status
 
 Present a clear summary:
@@ -126,6 +140,7 @@ Present a clear summary:
 |---|---|---|
 | ~/Documents/research/new-paper.pdf | document | 2.1 MB |
 | ~/.claude/projects/-Users-.../session-xyz.jsonl | claude_conversation | 340 KB |
+| ~/.codex/sessions/2026/04/12/rollout-...jsonl | codex_rollout | 220 KB |
 | ... | | |
 
 ### Modified sources (need re-ingesting): 3

--- a/.windsurf/rules/obsidian-wiki.md
+++ b/.windsurf/rules/obsidian-wiki.md
@@ -19,7 +19,9 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 |---|---|
 | "set up my wiki" / "initialize" | `.skills/wiki-setup/SKILL.md` |
 | "ingest" / "add this to the wiki" | `.skills/wiki-ingest/SKILL.md` |
+| "/wiki-history-ingest claude" / "/wiki-history-ingest codex" | `.skills/wiki-history-ingest/SKILL.md` |
 | "import my Claude history" | `.skills/claude-history-ingest/SKILL.md` |
+| "import my Codex history" | `.skills/codex-history-ingest/SKILL.md` |
 | "process this export" / "ingest this data" | `.skills/data-ingest/SKILL.md` |
 | "what's the status" / "show the delta" | `.skills/wiki-status/SKILL.md` |
 | "what do I know about X" / any question | `.skills/wiki-query/SKILL.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | "set up my wiki" / "initialize" | `wiki-setup` |
 | "ingest" / "add this to the wiki" / "process these docs" | `wiki-ingest` |
 | "import my Claude history" / "mine my conversations" | `claude-history-ingest` |
+| "import my Codex history" / "mine my Codex sessions" | `codex-history-ingest` |
 | "process this export" / "ingest this data" / logs, transcripts | `data-ingest` |
 | "what's the status" / "what's been ingested" / "show the delta" | `wiki-status` |
 | "wiki insights" / "hubs" / "wiki structure" | `wiki-status` (insights mode) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,7 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | User says something like… | Skill |
 |---|---|
 | "set up my wiki" / "initialize" | `wiki-setup` |
+| "/wiki-history-ingest claude" / "/wiki-history-ingest codex" / "$wiki-history-ingest claude|codex" | `wiki-history-ingest` |
 | "ingest" / "add this to the wiki" / "process these docs" | `wiki-ingest` |
 | "import my Claude history" / "mine my conversations" | `claude-history-ingest` |
 | "import my Codex history" / "mine my Codex sessions" | `codex-history-ingest` |

--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Everything lives in `.skills/`. Each skill is a markdown file the agent reads wh
 | ----------------------- | ------------------------------------------------- | ------------------------ |
 | `wiki-setup`            | Initialize vault structure                        | `/wiki-setup`            |
 | `wiki-ingest`           | Distill documents into wiki pages                 | `/wiki-ingest`           |
+| `wiki-history-ingest`   | Unified history router (`claude` or `codex`)      | `/wiki-history-ingest <claude|codex>` |
 | `claude-history-ingest` | Mine your `~/.claude` conversations and memories  | `/claude-history-ingest` |
 | `codex-history-ingest`  | Mine your `~/.codex` sessions and rollout logs    | `/codex-history-ingest`  |
 | `data-ingest`           | Ingest any text — chat exports, logs, transcripts | `/data-ingest`           |
@@ -276,6 +277,7 @@ obsidian-wiki/
 ├── .skills/                          # ← Canonical skill definitions (source of truth)
 │   ├── wiki-setup/SKILL.md
 │   ├── wiki-ingest/SKILL.md
+│   ├── wiki-history-ingest/SKILL.md
 │   ├── claude-history-ingest/SKILL.md
 │   ├── codex-history-ingest/SKILL.md
 │   ├── data-ingest/SKILL.md

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ A `.manifest.json` tracks every source that's been ingested — path, timestamps
 
 - **Archive and rebuild.** When the wiki drifts too far from your sources, you can archive the whole thing (timestamped snapshot, nothing lost) and rebuild from scratch. Or restore any previous archive.
 
-- **Multi-agent ingest.** Documents, PDFs, Claude Code history (`~/.claude`), Codex sessions (`~/.codex/`), Windsurf data (`~/.windsurf`), ChatGPT exports, Slack logs, meeting transcripts, raw text. There's a specific skill for Claude history that understands the JSONL format and memory files, and a catch-all skill that figures out whatever format you throw at it.
+- **Multi-agent ingest.** Documents, PDFs, Claude Code history (`~/.claude`), Codex sessions (`~/.codex/`), Windsurf data (`~/.windsurf`), ChatGPT exports, Slack logs, meeting transcripts, raw text. There are dedicated skills for both Claude history and Codex history, plus a catch-all ingest skill for arbitrary text exports.
 
 - **Audit and lint.** Find orphaned pages, broken wikilinks, stale content, contradictions, missing frontmatter. See a dashboard of what's been ingested vs what's pending.
 
@@ -232,6 +232,7 @@ Everything lives in `.skills/`. Each skill is a markdown file the agent reads wh
 | `wiki-setup`            | Initialize vault structure                        | `/wiki-setup`            |
 | `wiki-ingest`           | Distill documents into wiki pages                 | `/wiki-ingest`           |
 | `claude-history-ingest` | Mine your `~/.claude` conversations and memories  | `/claude-history-ingest` |
+| `codex-history-ingest`  | Mine your `~/.codex` sessions and rollout logs    | `/codex-history-ingest`  |
 | `data-ingest`           | Ingest any text — chat exports, logs, transcripts | `/data-ingest`           |
 | `wiki-status`           | Show what's ingested, what's pending, the delta   | `/wiki-status`           |
 | `wiki-rebuild`          | Archive, rebuild from scratch, or restore         | `/wiki-rebuild`          |
@@ -276,6 +277,7 @@ obsidian-wiki/
 │   ├── wiki-setup/SKILL.md
 │   ├── wiki-ingest/SKILL.md
 │   ├── claude-history-ingest/SKILL.md
+│   ├── codex-history-ingest/SKILL.md
 │   ├── data-ingest/SKILL.md
 │   ├── wiki-status/SKILL.md
 │   ├── wiki-rebuild/SKILL.md

--- a/SETUP.md
+++ b/SETUP.md
@@ -27,6 +27,7 @@ Open this project in your coding agent and tell it what you want:
 | "Set up my wiki" | `wiki-setup` |
 | "Ingest my documents from ~/research" | `wiki-ingest` |
 | "Import my Claude history" | `claude-history-ingest` |
+| "Import my Codex history" | `codex-history-ingest` |
 | "Process this ChatGPT export" | `data-ingest` |
 | "What's the status of my wiki?" | `wiki-status` |
 | "What do I know about X?" | `wiki-query` |
@@ -47,6 +48,7 @@ Anything text-based:
 |---|---|---|
 | Markdown, PDFs, text files | `wiki-ingest` | Any document directory |
 | Claude Code history | `claude-history-ingest` | `~/.claude/` — conversations, memories, sessions |
+| Codex CLI history | `codex-history-ingest` | `~/.codex/` — sessions, rollouts, history index |
 | ChatGPT exports | `data-ingest` | `conversations.json` from ChatGPT export |
 | Slack / Discord logs | `data-ingest` | Channel export JSON files |
 | Meeting transcripts | `data-ingest` | Any text transcript |
@@ -111,6 +113,7 @@ Knowledge that's project-specific goes under `projects/<name>/`. Knowledge that'
 | `OBSIDIAN_CATEGORIES` | Wiki page categories | `concepts,entities,skills,references,synthesis,journal` |
 | `OBSIDIAN_MAX_PAGES_PER_INGEST` | Max pages updated per ingest | `15` |
 | `CLAUDE_HISTORY_PATH` | Where to find Claude data | *auto-discovers from `~/.claude`* |
+| `CODEX_HISTORY_PATH` | Where to find Codex data | *defaults to `~/.codex`* |
 | `LINT_SCHEDULE` | Wiki health check frequency | `weekly` |
 
 ## Skills Reference
@@ -122,6 +125,7 @@ Knowledge that's project-specific goes under `projects/<name>/`. Knowledge that'
 | `wiki-ingest` | Distill source documents into wiki pages (append or full mode) |
 | `data-ingest` | Ingest any raw text — chat exports, logs, transcripts, anything |
 | `claude-history-ingest` | Mine `~/.claude` conversations and memories into wiki pages |
+| `codex-history-ingest` | Mine `~/.codex` sessions and rollout logs into wiki pages |
 | `wiki-status` | Audit: what's ingested, what's pending, delta, recommend action |
 | `wiki-rebuild` | Archive current wiki, rebuild from scratch, or restore from archive |
 | `wiki-query` | Answer questions from the compiled wiki with citations |

--- a/SETUP.md
+++ b/SETUP.md
@@ -26,6 +26,7 @@ Open this project in your coding agent and tell it what you want:
 |---|---|
 | "Set up my wiki" | `wiki-setup` |
 | "Ingest my documents from ~/research" | `wiki-ingest` |
+| "/wiki-history-ingest claude" or "/wiki-history-ingest codex" | `wiki-history-ingest` |
 | "Import my Claude history" | `claude-history-ingest` |
 | "Import my Codex history" | `codex-history-ingest` |
 | "Process this ChatGPT export" | `data-ingest` |
@@ -123,6 +124,7 @@ Knowledge that's project-specific goes under `projects/<name>/`. Knowledge that'
 | `llm-wiki` | Core pattern — 3-layer architecture, page templates, project org |
 | `wiki-setup` | Initialize vault structure, create index/log, configure Obsidian |
 | `wiki-ingest` | Distill source documents into wiki pages (append or full mode) |
+| `wiki-history-ingest` | Unified history ingest router (`claude` or `codex`) |
 | `data-ingest` | Ingest any raw text — chat exports, logs, transcripts, anything |
 | `claude-history-ingest` | Mine `~/.claude` conversations and memories into wiki pages |
 | `codex-history-ingest` | Mine `~/.codex` sessions and rollout logs into wiki pages |


### PR DESCRIPTION
## Summary
- add new `codex-history-ingest` skill to ingest Codex CLI session history into the Obsidian wiki
- add Codex data-format reference (`rollout` JSONL envelopes, source discovery, privacy filters)
- add unified `wiki-history-ingest` router skill (`/wiki-history-ingest <claude|codex>`)
- keep `claude-history-ingest` and `codex-history-ingest` as provider-specific executors, with router invocation guidance
- update routing/docs to include full Codex + router coverage across:
  - `AGENTS.md`, `README.md`, `SETUP.md`
  - Cursor, Windsurf, and Copilot bootstrap docs
- add missing `CODEX_HISTORY_PATH` to `.env.example`
- extend `wiki-status` guidance to include Codex source scanning and delta reporting

## What Was Validated
- bounded dry-run (last 7 days): inventory + topic-cluster preview, no writes
- bounded ingest (last 7 days): end-to-end updates of manifest/index/log + synthesis page
- bounded ingest (last 30 days): scaling validation before full backfill
- bounded creation-focused pass (last 30 days): verified distillation/creation behavior with new pages in `concepts/`, `entities/`, `skills/`, and `references/`

## Repo Changes In This PR
- `AGENTS.md`
- `README.md`
- `SETUP.md`
- `.env.example`
- `.skills/wiki-history-ingest/SKILL.md`
- `.skills/claude-history-ingest/SKILL.md`
- `.skills/codex-history-ingest/SKILL.md`
- `.skills/codex-history-ingest/references/codex-data-format.md`
- `.skills/wiki-status/SKILL.md`
- `.skills/llm-wiki/SKILL.md`
- `.skills/wiki-setup/SKILL.md`
- `.skills/wiki-rebuild/SKILL.md`
- `.cursor/rules/obsidian-wiki.mdc`
- `.windsurf/rules/obsidian-wiki.md`
- `.github/copilot-instructions.md`

## Notes
- vault-level runtime test outputs are outside this repo and are not part of this PR
- changes are markdown-only in this repository