### PR TITLE
feat: video/audio ingest, smarter dedup, diacritic search, directed exports

### DIFF
--- a/.skills/wiki-export/SKILL.md
+++ b/.skills/wiki-export/SKILL.md
@@ -17,6 +17,12 @@ You are exporting the wiki's wikilink graph to structured formats so it can be u
 1. Read `.env` to get `OBSIDIAN_VAULT_PATH`
 2. Confirm the vault has pages to export — if fewer than 5 pages exist, warn the user and stop
 
+## Directed vs Undirected Mode
+
+Wikilinks have direction — "A links to B" is not the same as "B links to A". By default, exports are **directed** (`directed: true`), which gives semantically accurate results in Neo4j, Gephi, and graph analysis tools.
+
+Pass `directed=false` (or the user says "undirected", "ignore link direction") to produce an undirected graph instead — useful for community detection and clustering algorithms that require undirected input.
+
 ## Step 1: Build the Node and Edge Lists
 
 Glob all `.md` files in the vault (excluding `_archives/`, `_raw/`, `.obsidian/`, `index.md`, `log.md`, `_insights.md`).
@@ -61,7 +67,7 @@ NetworkX node_link format — standard for graph tools and scripts:
 
 ```json
 {
-  "directed": false,
+  "directed": true,
   "multigraph": false,
   "graph": {
     "exported_at": "<ISO timestamp>",
@@ -105,7 +111,7 @@ GraphML XML format — loadable in Gephi, yEd, and Cytoscape:
   <key id="community" for="node" attr.name="community" attr.type="int"/>
   <key id="relation" for="edge" attr.name="relation" attr.type="string"/>
   <key id="confidence" for="edge" attr.name="confidence" attr.type="string"/>
-  <graph id="wiki" edgedefault="undirected">
+  <graph id="wiki" edgedefault="directed">
     <node id="concepts/transformers">
       <data key="label">Transformer Architecture</data>
       <data key="category">concepts</data>
@@ -251,3 +257,4 @@ Wiki export complete → wiki-export/
 - **Broken wikilinks are skipped** — only edges to pages that exist in the vault are exported
 - **The `wiki-export/` directory should be gitignored** if the vault is version-controlled — these are derived artifacts
 - **`graph.json` is the primary format** — the others are derived from it. If a future tool supports graph queries natively, point it at `graph.json`
+- **Directed by default** — exports preserve wikilink direction (A→B). Pass `directed=false` for undirected output when needed by clustering tools. The HTML visualization always renders arrows regardless of this setting.

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -30,6 +30,7 @@ Only ingest sources that are **new or modified** since last ingest. Check the ma
 - If a source path is not in `.manifest.json` → it's new, ingest it
 - If a source path is in `.manifest.json`:
   - Compute the file's SHA-256 hash: `sha256sum <file>` (or `shasum -a 256 <file>` on macOS)
+  - **For `.md` source files:** hash the **body only** — strip the YAML frontmatter block (everything between the opening `---` and closing `---`) before hashing. Metadata-only edits (updating a tag, bumping `updated:`) won't invalidate the cache and trigger a needless re-ingest.
   - If the hash matches `content_hash` in the manifest → **skip it**, even if the modification time differs (file was touched but content is identical — git checkout, copy, NFS timestamp drift)
   - If the hash differs → it's genuinely modified, re-ingest it
 - If a source path is in `.manifest.json` and has no `content_hash` (older entry) → fall back to mtime comparison as before
@@ -59,6 +60,8 @@ Read the document(s) the user wants to ingest. In append mode, skip files the ma
 - PDF (`.pdf`) — use the Read tool with page ranges
 - Web clippings — markdown files from Obsidian Web Clipper
 - **Images** (`.png`, `.jpg`, `.jpeg`, `.webp`, `.gif`) — *requires a vision-capable model*. Use the Read tool, which renders the image into your context. Treat screenshots, whiteboard photos, diagrams, and slide captures as first-class sources. If your model doesn't support vision, skip image sources and tell the user which files were skipped so they can re-run with a vision-capable model.
+- **Video/audio** (`.mp4`, `.mp3`, `.wav`, `.mov`, `.webm`, `.m4a`, `.ogg`, `.mkv`, `.avi`, `.m4v`) — transcribe to text first (see "Video/audio branch" below), then treat the transcript as a text source.
+- **YouTube / web video URLs** — if the user passes a URL (e.g. `https://youtube.com/...`), download audio-only via `yt-dlp` and transcribe. Cache the transcript by URL hash so re-runs skip already-transcribed URLs.
 
 Note the source path — you'll need it for provenance tracking.
 
@@ -74,6 +77,22 @@ When the source is an image, your extraction job is interpretive — you're read
 Vision is interpretive by nature, so image-derived pages will skew heavily toward `^[inferred]`. That's expected — the provenance markers exist precisely to surface this. Don't pretend an image's "meaning" was extracted when you really inferred it.
 
 For PDFs that are mostly images (scanned docs, slide decks exported to PDF), use `Read pages: "N"` to pull specific pages and treat each page as an image source.
+
+### Video/audio branch
+
+When the source is a video or audio file (or a YouTube/web URL):
+
+1. **Check the transcript cache first.** Look for `_transcripts/<filename>.txt` (or `_transcripts/<url-hash>.txt` for URLs) inside the vault. If it exists, read it directly and skip transcription.
+2. **Transcribe.** Use whichever transcription tool is available in priority order:
+   - `faster-whisper` CLI if installed: `faster-whisper <file> --output_dir _transcripts/`
+   - `whisper` CLI: `whisper <file> --output_dir _transcripts/ --output_format txt`
+   - For YouTube URLs: `yt-dlp -x --audio-format mp3 -o "_transcripts/%(id)s.%(ext)s" <url>` then transcribe the downloaded file
+   - If no transcription tool is available, **skip the file** and tell the user which files were skipped and what to install.
+3. **Save the transcript** to `_transcripts/<filename>.txt` (or `_transcripts/<url-hash>.txt`) inside the vault for future cache reuse.
+4. **Treat the transcript as a text source** from this point forward — extract concepts, entities, and claims the same way you would from a `.txt` file.
+5. **Tag transcript-derived content** as `^[inferred]` for any claim that relies on interpretation of spoken language (incomplete sentences, filler words, unclear antecedents). Verbatim quotes from the transcript are `extracted`.
+
+Domain hint: if the vault already has god-node pages (heavily-linked hub concepts), include their labels as a comma-separated hint when invoking Whisper — this improves accuracy on technical vocabulary.
 
 ### Step 1b: QMD Source Discovery (optional — requires `QMD_PAPERS_COLLECTION` in `.env`)
 
@@ -178,7 +197,7 @@ After writing pages, check that wikilinks work in both directions. If page A lin
   "size_bytes": FILE_SIZE,
   "modified_at": FILE_MTIME,
   "content_hash": "sha256:<64-char-hex>",
-  "source_type": "document",  // or "image" for png/jpg/webp/gif and image-only PDFs
+  "source_type": "document",  // or "image" for png/jpg/webp/gif and image-only PDFs; "video" for mp4/mov/mkv etc; "audio" for mp3/wav/m4a etc; "url" for YouTube/web URLs
   "project": "project-name-or-null",
   "pages_created": ["list/of/pages.md"],
   "pages_updated": ["list/of/pages.md"]

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -46,6 +46,8 @@ Build a candidate set *without opening any page bodies*:
   3. Summary field contains the query term
   4. `index.md` entry contains the query term
 
+**Diacritic normalization:** Before comparing the query against titles, aliases, and summaries, normalize both sides: decompose accented characters to base + combining marks (Unicode NFKD), then strip the combining marks. This ensures a search for "Muller" matches "Müller", "resume" matches "résumé", etc. Apply this to string comparisons only — raw `Grep` patterns are left unmodified (regex partial matching already handles many cases).
+
 If you're in **index-only mode**, stop here. Answer from `summary:` fields, titles, and `index.md` descriptions only. Label the answer clearly: **"(index-only answer — page bodies not read; facts below are from page summaries and may miss nuance)"**. Then skip to Step 5.
 
 ### Step 2b: QMD Semantic Pass (optional — requires `QMD_WIKI_COLLECTION` in `.env`)

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Use Copilot Chat in VS Code and say "set up my wiki".
 
 Every ingest runs through four stages:
 
-**1. Ingest** — The agent reads your source material directly. It handles whatever you throw at it: markdown files, PDFs (with page ranges), JSONL conversation exports, plain text logs, chat exports, meeting transcripts, and images (screenshots, whiteboard photos, diagrams — vision-capable model required). No preprocessing step, no pipeline to run. The agent reads the file the same way it reads code.
+**1. Ingest** — The agent reads your source material directly. It handles whatever you throw at it: markdown files, PDFs (with page ranges), JSONL conversation exports, plain text logs, chat exports, meeting transcripts, images (screenshots, whiteboard photos, diagrams — vision-capable model required), and video/audio files (lectures, podcasts, meeting recordings — transcribed before ingestion). Pass a YouTube URL and it downloads and transcribes automatically. No preprocessing step, no pipeline to run. The agent reads the file the same way it reads code.
 
 **2. Extract** — From the raw source, the agent pulls out concepts, entities, claims, relationships, and open questions. A conversation about debugging a React hook yields a "stale closure" pattern. A research paper yields the key idea and its caveats. A work log yields decisions and their rationale. Noise gets dropped, signal gets kept. Each page also gets a 1–2 sentence `summary:` in its frontmatter at write time — later queries use this to preview pages without opening them.
 
@@ -150,7 +150,7 @@ A `.manifest.json` tracks every source that's been ingested — path, timestamps
 
 ## What we added on top of Karpathy's pattern
 
-- **Delta tracking.** A manifest tracks every source file that's been ingested: path, timestamps, which wiki pages it produced. When you come back later, it computes the delta and only processes what's new or changed. You're not re-ingesting your entire document library every time.
+- **Delta tracking.** A manifest tracks every source file that's been ingested: path, timestamps, content hash, which wiki pages it produced. When you come back later, it computes the delta and only processes what's new or changed. For `.md` sources, the hash covers only the body — metadata edits (tags, timestamps) don't count as changes. You're not re-ingesting your entire document library every time.
 
 - **Project-based organization.** Knowledge gets filed under projects when it's project-specific, globally when it's not. Both are cross-referenced with wikilinks. If you're working on 10 different codebases, each one gets its own space in the vault.
 
@@ -166,11 +166,11 @@ A `.manifest.json` tracks every source that's been ingested — path, timestamps
 
 - **Provenance tracking.** Every claim on a wiki page is tagged: extracted (default), `^[inferred]` (LLM synthesis), or `^[ambiguous]` (sources disagree). A `provenance:` block in the frontmatter summarizes the mix per page, and `wiki-lint` flags pages that drift into mostly speculation. You can always tell what your wiki actually knows from what it guessed.
 
-- **Multimodal sources.** Screenshots, whiteboard photos, slide captures, and diagrams ingest the same way as text — the agent transcribes any visible text verbatim and tags interpreted content as inferred. Requires a vision-capable model.
+- **Multimodal sources.** Screenshots, whiteboard photos, slide captures, and diagrams ingest the same way as text — the agent transcribes any visible text verbatim and tags interpreted content as inferred. Requires a vision-capable model. Video and audio files (`.mp4`, `.mp3`, `.wav`, `.m4a`, and more) are transcribed first via faster-whisper or Whisper, then ingested as text. YouTube and web video URLs are also supported — pass the URL directly and the agent downloads audio-only via `yt-dlp` and runs the same pipeline. Transcripts are cached in `_transcripts/` so re-runs are instant.
 
 - **Wiki insights.** Beyond delta tracking, `wiki-status` can analyze the shape of your vault itself: top hubs, bridge pages (nodes whose removal would partition the graph), tag cluster cohesion scores, scored surprising connections, a graph delta since last run, and suggested questions the wiki structure is uniquely positioned to answer. Output goes to `_insights.md`.
 
-- **Graph export.** `wiki-export` turns the vault's wikilink graph into `graph.json` (queryable), `graph.graphml` (Gephi/yEd), `cypher.txt` (Neo4j), and a self-contained `graph.html` interactive browser visualization — no server required.
+- **Graph export.** `wiki-export` turns the vault's wikilink graph into `graph.json` (queryable), `graph.graphml` (Gephi/yEd), `cypher.txt` (Neo4j), and a self-contained `graph.html` interactive browser visualization — no server required. Exports are directed by default (A→B preserves wikilink direction), with an undirected mode available for clustering tools that require it.
 
 - **Tiered retrieval.** `wiki-query` reads titles, tags, and page summaries first and only opens page bodies when the cheap pass can't answer. Say "quick answer" or "just scan" to force index-only mode. Keeps query cost roughly flat as your vault grows from 20 pages to 2000.
 


### PR DESCRIPTION
## Summary

- **Video/audio ingest** — `wiki-ingest` now accepts `.mp4`, `.mp3`, `.wav`, `.m4a`, `.mov`, `.webm`, `.ogg`, `.mkv`, `.avi`, `.m4v` and YouTube/web URLs. Files are transcribed via faster-whisper or Whisper (with `yt-dlp` for URLs), transcripts cached in `_transcripts/` so re-runs skip already-transcribed files. Spoken content follows the same extract → resolve → write pipeline as any other source.

- **Frontmatter-aware deduplication** — `wiki-ingest` append mode now hashes `.md` source files over body only (YAML frontmatter stripped before SHA-256). Metadata-only edits — updating a tag, bumping `updated:` — no longer invalidate the cache and trigger a full re-ingest.

- **Diacritic-insensitive search** — `wiki-query` Step 2 normalizes both the query and candidate titles/summaries with Unicode NFKD before string comparison. Searching "Muller" now matches "Müller", "resume" matches "résumé", etc.

- **Directed graph exports** — `wiki-export` now defaults to `directed: true` in `graph.json` and `edgedefault="directed"` in GraphML, correctly reflecting wikilink semantics (A→B ≠ B→A). An undirected mode is available via `directed=false` for tools that require it. The HTML visualization was already rendering arrows; the underlying format now matches.

## Files changed

| File | Change |
|---|---|
| `.skills/wiki-ingest/SKILL.md` | Video/audio branch, URL ingestion, frontmatter-aware hash |
| `.skills/wiki-query/SKILL.md` | NFKD normalization in Step 2 index pass |
| `.skills/wiki-export/SKILL.md` | Directed mode section, directed defaults in JSON/GraphML |
| `README.md` | Updated ingest list, multimodal bullet, delta tracking, graph export bullet |

## Test plan

- [ ] Ingest a `.mp3` or `.mp4` file — verify transcript appears in `_transcripts/` and wiki page is created
- [ ] Ingest a YouTube URL — verify `yt-dlp` download + transcription flow is described correctly
- [ ] Edit only the `tags:` line of an `.md` source file and re-ingest — verify manifest skips it
- [ ] Query for an accented name (e.g. "Muller") and verify it matches a page titled "Müller"
- [ ] Run `wiki-export` and verify `graph.json` has `"directed": true` and GraphML has `edgedefault="directed"`