### PR TITLE
fix(setup): handle Git-on-Windows pseudo-symlinks so install_skills doesn't abort

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -48,6 +48,10 @@ install_skills() {
     elif [ -d "$link_path" ]; then
       echo "⚠️   $link_path is a real directory, skipping symlink"
       continue
+    elif [ -f "$link_path" ]; then
+      # Git on Windows without core.symlinks=true writes committed symlinks
+      # as regular files containing the target path. Replace with a real symlink.
+      rm "$link_path"
     fi
     ln -s "${skill%/}" "$link_path"
   done
@@ -140,6 +144,8 @@ for skill_name in "wiki-update" "wiki-query"; do
   elif [ -d "$link_path" ]; then
     echo "⚠️   $link_path is a real directory, skipping symlink"
     continue
+  elif [ -f "$link_path" ]; then
+    rm "$link_path"
   fi
   ln -s "$SKILLS_DIR/$skill_name" "$link_path"
 done


### PR DESCRIPTION
## Summary

`bash setup.sh` aborts partway through on Windows clones, leaving most agents wired to dead text files instead of real skill directories. Only the entries that happened to run before the abort end up properly linked. This patch makes `install_skills` (and the `~/.claude/skills/` fallback block) tolerate the failure mode.

## Root cause

The repo commits symlinks under `.claude/skills/`, `.cursor/skills/`, `.windsurf/skills/`, `.agents/skills/`, and `.kiro/skills/`. When cloned on Windows without `core.symlinks=true` (which is the default on most Windows installs), Git materializes those symlinks as **regular text files whose contents are the link target path** — e.g. `.claude/skills/wiki-query` becomes a 46-byte file containing the literal string `/Users/ar9av/obsidian-wiki/.skills/wiki-query/`.

`install_skills` only branched on:

```bash
if [ -L "$link_path" ]; then
  rm "$link_path"
elif [ -d "$link_path" ]; then
  echo "⚠️   ... is a real directory, skipping symlink"
  continue
fi
ln -s "${skill%/}" "$link_path"
```

The pseudo-symlink is neither a symlink nor a directory, so execution fell through to `ln -s`, which failed with `File exists`. With `set -e` at the top of the script, the first failure aborted the entire run. Result on a fresh Windows clone:

- Skills linked: only the 0–N alphabetically-earliest skills before the first pre-existing pseudo-symlink (often zero)
- Agents reporting only 2–3 working slash commands instead of all 24
- No error surface that points at the real cause — the user sees "File exists" and a stack of unlinked dirs

## Fix

Add an `elif [ -f "$link_path" ]` branch in both spots that removes the regular file before the `ln -s` call. POSIX-only; no behavior change on macOS/Linux because pseudo-symlinks don't occur there.

```bash
elif [ -f "$link_path" ]; then
  # Git on Windows without core.symlinks=true writes committed symlinks
  # as regular files containing the target path. Replace with a real symlink.
  rm "$link_path"
fi
```

## Reproduction

On a Windows machine with default Git config:

```bash
git clone https://github.com/Ar9av/obsidian-wiki.git
cd obsidian-wiki
bash setup.sh   # aborts with "ln: failed to create symbolic link ... File exists"
ls -la .claude/skills/   # mostly regular files containing Mac paths
```

After this PR, re-running `setup.sh` cleans up the pseudo-symlinks and produces real symbolic links (assuming `MSYS=winsymlinks:native` or Windows Developer Mode — same prerequisite as before).

## Out of scope

- `.hermes.md → AGENTS.md` symlink also fails on Windows without privileges, but it's a single non-skill bootstrap symlink and the failure mode there is a real OS-level `Operation not permitted`, not a Git-checkout artifact. Worth a separate issue/PR.
- Long-term, recommending `git config core.symlinks true` (and/or shipping a `.gitattributes` symlink declaration) in the README would prevent the pseudo-symlinks from being created in the first place.

## Test plan

- [x] On a Windows clone where `setup.sh` previously aborted, run patched script and confirm all 24 skills are now real symlinks under each agent dir
- [x] Confirm staged diff is exactly two minimal `elif` blocks (6 added lines, 0 removed)
- [ ] Sanity-check on macOS that the new branch is unreachable (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)