### PR TITLE
Load vault AGENTS.md universally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ Read config in this order (first found wins):
 
 Both files set `OBSIDIAN_VAULT_PATH` (where the wiki lives). The global config also sets `OBSIDIAN_WIKI_REPO` (where this repo is cloned).
 
+**After reading config, always read `$OBSIDIAN_VAULT_PATH/AGENTS.md` if it exists.** It contains owner-specific conventions (domain vocabulary, ingest preferences, writing style, project scoping) that override framework defaults for all skills. Apply it for the duration of the session.
+
 ## Vault Structure
 
 ```


### PR DESCRIPTION
## Summary

- Adds a single universal rule in `AGENTS.md` telling agents to read `\$OBSIDIAN_VAULT_PATH/AGENTS.md` after loading config.
- Owner-specific conventions in the vault (domain vocabulary, ingest preferences, writing style, project scoping) are picked up automatically by **every** skill without per-skill changes.
- Two-line documentation change, no code or skill behaviour modified beyond the convention.

## Why

Right now each skill that wants to honour vault-level conventions has to remember to read the vault's instruction file itself, which is easy to forget and inconsistent across skills. Putting the rule once at the top-level `AGENTS.md` (loaded as part of the agent's project context every session) covers all current and future skills uniformly.

Using `AGENTS.md` as the canonical name in the vault mirrors this repo's own pattern (`AGENTS.md` canonical, `CLAUDE.md` symlinked to it). Users can still symlink `CLAUDE.md` → `AGENTS.md` in their vault if their tooling looks for `CLAUDE.md`. Same file works across Claude Code, Codex, Cursor, etc.

## Test plan

- [x] Place an `AGENTS.md` in `\$OBSIDIAN_VAULT_PATH` with a custom convention (e.g. "tag every page with `team/foo`").
- [x] Run any wiki skill (e.g. `wiki-ingest`, `wiki-update`) and confirm the convention is applied.
- [ ] Confirm skills still work normally when the vault `AGENTS.md` is absent.

(Replaces #21 — branch renamed from `fix/universal-vault-claudemd` to better reflect the canonical filename.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)