### PR TITLE
Add gstack-learnings-sync and gstack-learnings-watch skills

### DIFF
--- a/.skills/gstack-learnings-sync/SKILL.md
+++ b/.skills/gstack-learnings-sync/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: gstack-learnings-sync
+description: >
+  Sync new gstack learnings into the Obsidian wiki. Reads ~/.gstack/projects/*/learnings.jsonl,
+  finds entries added since the last sync, and appends them to matching wiki project pages
+  (or creates new pages for unknown projects). Use when the user says "sync gstack learnings",
+  "update wiki from gstack", "pull in new learnings", "what did gstack learn recently",
+  or after any gstack review session that produced new learnings. Also invoke automatically
+  if the vault has a .gstack-sync-pending marker file.
+---
+
+# gstack Learnings Sync
+
+Syncs new entries from gstack's `learnings.jsonl` files into your Obsidian wiki. Each entry
+was written by a gstack review skill and captures a concrete pitfall, pattern, or
+architectural insight from real project work.
+
+## Before You Start
+
+1. Read `~/.obsidian-wiki/config` → get `OBSIDIAN_VAULT_PATH`
+2. Read `$VAULT/.manifest.json` → find `gstack_learnings_last_sync` (ISO timestamp, may be absent on first run)
+3. Read `$VAULT/index.md` → know which project pages exist
+
+## Step 1: Collect New Learnings
+
+For each directory under `~/.gstack/projects/`:
+
+```bash
+find ~/.gstack/projects -name "learnings.jsonl" | sort
+```
+
+Read each `learnings.jsonl` file. Each line is a JSON object:
+
+```json
+{
+  "skill": "plan-eng-review",
+  "type": "pitfall",
+  "key": "<short-stable-id>",
+  "insight": "...",
+  "confidence": 10,
+  "source": "observed",
+  "files": ["path/to/file.ext"],
+  "ts": "<ISO timestamp>"
+}
+```
+
+Keep only entries where `ts` is newer than `gstack_learnings_last_sync`. On first run, process all entries.
+
+## Step 2: Group by Project
+
+Group new entries by their parent directory name (the gstack project slug):
+
+```
+~/.gstack/projects/<slug>/learnings.jsonl  →  slug: <slug>
+```
+
+## Step 3: Map gstack Slug → Wiki Project Page
+
+gstack slugs are derived from directory names and don't always match wiki project names exactly.
+Use this matching order (stop at first match):
+
+1. **Exact slug match** — look for `projects/<slug>/<slug>.md` in the vault
+2. **Prefix-stripped match** — strip common org/team prefixes the user has configured (e.g. `<org>-`, `<team>-`) and retry
+3. **Normalized match** — lowercase the slug and replace `_` with `-`, retry
+4. **Fuzzy match** — compare slug words against existing project page filenames and titles
+5. **No match** — create a new project page (Step 4b)
+
+Examples (illustrative — real slugs depend on the user's gstack project layout):
+- `<org>-foo-service` → `projects/foo-service/foo-service.md` (prefix stripped)
+- `My_Project` → `projects/my-project/my-project.md` (normalized)
+- `unknown-project` → no match → create `projects/unknown-project/unknown-project.md`
+
+## Step 4a: Update Existing Project Pages
+
+For each project with new learnings and an existing wiki page:
+
+1. Read the page
+2. Find the `## gstack Learnings` section (it may already exist from a previous sync)
+3. If the section exists: append new entries inside it, under a `### <YYYY-MM-DD>` sub-heading grouping entries from the same day
+4. If the section doesn't exist: add it before `## Related Pages` (or at the end if that section is absent)
+
+Format each learning as:
+
+```markdown
+- **[type] `key`:** insight text.^[source]
+  Files: `path/to/file.py` (only include if files array is non-empty)
+```
+
+Where:
+- `type` is one of: `pitfall` | `pattern` | `architecture` | `operational` | `preference`
+- `source` annotation maps to: `observed` → `[extracted]`, `inferred` → `[inferred]`, `cross-model` → `[cross-model]`, `user-stated` → `[user-stated]`
+- Omit the files line if `files` is empty or absent
+
+Update the page's `updated` frontmatter to today's date and add the learnings source to `sources`.
+
+## Step 4b: Create New Project Pages
+
+If no matching wiki page exists, create `$VAULT/projects/<normalized-slug>/<normalized-slug>.md`:
+
+```markdown
+---
+title: >-
+  <Human-readable project name from slug>
+category: project
+tags: [<infer from learning types and key terms>]
+sources: [~/.gstack/projects/<slug>/learnings.jsonl]
+summary: >-
+  <1-2 sentence summary inferred from the learnings>
+provenance:
+  extracted: 0.8
+  inferred: 0.2
+  ambiguous: 0.0
+created: <today>
+updated: <today>
+---
+
+# <Project Name>
+
+<One paragraph inferred from the learnings — what this project appears to be about.>
+
+## gstack Learnings
+
+<entries formatted as in Step 4a>
+
+## Related Pages
+
+<any obvious connections based on the project name and learning content>
+```
+
+## Step 5: Update Tracking
+
+### Update `.manifest.json`
+
+Set `gstack_learnings_last_sync` to the `ts` of the newest entry processed:
+
+```json
+{
+  "gstack_learnings_last_sync": "2026-04-23T20:30:00.000Z"
+}
+```
+
+Also remove `.gstack-sync-pending` from the vault root if it exists:
+```bash
+rm -f "$VAULT/.gstack-sync-pending"
+```
+
+### Update `index.md`
+
+Add any newly created project pages under the appropriate section.
+
+### Update `log.md`
+
+```
+- [TIMESTAMP] GSTACK_SYNC projects=N entries_new=M pages_updated=X pages_created=Y
+```
+
+## Step 6: Report
+
+Tell the user:
+- How many projects were scanned
+- How many new entries were found
+- Which pages were updated vs created
+- The date range of the new entries
+
+If zero new entries: "No new gstack learnings since <last sync date>. Wiki is up to date."
+
+## Tips
+
+- If an entry's `insight` is long, keep the wiki entry concise — the key claim, not a restatement of the whole sentence.
+- If multiple entries share the same `key` (duplicates from retry runs), deduplicate by `key` per project — keep the entry with the highest confidence or most recent `ts`.
+- `trusted: false` on an entry is gstack's internal flag meaning the entry hasn't been reviewed by the user. Include it in the wiki but you can note `(unverified)` if the user prefers — don't filter it out.

--- a/.skills/gstack-learnings-watch/SKILL.md
+++ b/.skills/gstack-learnings-watch/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: gstack-learnings-watch
+description: >
+  Set up automatic background watching of gstack learnings so the wiki stays current without
+  manual syncing (macOS only — uses launchd; Linux/Windows users can adapt the script with
+  cron, systemd, or Task Scheduler). Installs an agent that checks for new learnings.jsonl
+  entries on a schedule and stages them for the next wiki session. Use when the user says
+  "watch gstack learnings", "auto-sync gstack", "set up automatic learning sync", "keep wiki
+  updated automatically", or "I don't want to manually sync". Also use to check watch status,
+  change the schedule, or remove the watcher.
+---
+
+# gstack Learnings Watch
+
+Installs a lightweight macOS launchd agent that periodically checks for new gstack learnings
+and stages them for your next wiki session. When new learnings are found, it writes a trigger
+file to your vault — the next time you open Claude Code in the obsidian-wiki project, the
+`gstack-learnings-sync` skill runs automatically.
+
+No external dependencies. No Claude required to run the watch itself.
+
+## Commands
+
+Match the user's intent:
+
+| User says | Action |
+|---|---|
+| "set up" / "install" / "enable" | → **Install** |
+| "status" / "is it running" | → **Check status** |
+| "change interval" / "every N hours" | → **Update interval** |
+| "stop" / "disable" / "remove" | → **Uninstall** |
+
+---
+
+## Install
+
+### Step 1: Read config
+
+```bash
+cat ~/.obsidian-wiki/config
+```
+
+Get `OBSIDIAN_VAULT_PATH`. If missing, tell the user to run `bash setup.sh` first.
+
+Ask the user (or default to 2 hours if they don't specify):
+> "How often should the watcher check for new learnings? (default: every 2 hours)"
+
+### Step 2: Write the watcher script
+
+Create `~/.obsidian-wiki/gstack-watch.sh`:
+
+```bash
+#!/bin/bash
+# gstack-learnings-watch — checks for new learnings and stages them
+# Installed by obsidian-wiki gstack-learnings-watch skill
+
+set -e
+
+VAULT_PATH="VAULT_PATH_PLACEHOLDER"
+GSTACK_DIR="$HOME/.gstack/projects"
+MANIFEST="$VAULT_PATH/.manifest.json"
+PENDING="$VAULT_PATH/.gstack-sync-pending"
+MARKER="$HOME/.obsidian-wiki/.watch-last-run"
+
+# Get last sync timestamp from manifest (or epoch if absent)
+if command -v python3 &>/dev/null; then
+  LAST_SYNC=$(python3 -c "
+import json, sys
+try:
+  d = json.load(open('$MANIFEST'))
+  print(d.get('gstack_learnings_last_sync', '1970-01-01T00:00:00.000Z'))
+except:
+  print('1970-01-01T00:00:00.000Z')
+" 2>/dev/null || echo "1970-01-01T00:00:00.000Z")
+else
+  LAST_SYNC="1970-01-01T00:00:00.000Z"
+fi
+
+# Check each learnings.jsonl for entries newer than LAST_SYNC
+NEW_ENTRIES=0
+for f in "$GSTACK_DIR"/*/learnings.jsonl; do
+  [ -f "$f" ] || continue
+  COUNT=$(python3 -c "
+import json, sys
+last = '$LAST_SYNC'
+count = 0
+for line in open('$f'):
+  line = line.strip()
+  if not line: continue
+  try:
+    entry = json.loads(line)
+    if entry.get('ts','') > last:
+      count += 1
+  except:
+    pass
+print(count)
+" 2>/dev/null || echo "0")
+  NEW_ENTRIES=$((NEW_ENTRIES + COUNT))
+done
+
+# If new entries exist, write a pending marker
+if [ "$NEW_ENTRIES" -gt 0 ]; then
+  echo "$NEW_ENTRIES new gstack learnings found at $(date -u +%Y-%m-%dT%H:%M:%SZ)" > "$PENDING"
+fi
+
+# Update last-run marker
+date -u +%Y-%m-%dT%H:%M:%SZ > "$MARKER"
+```
+
+Replace `VAULT_PATH_PLACEHOLDER` with the actual vault path from config.
+
+Make it executable:
+```bash
+chmod +x ~/.obsidian-wiki/gstack-watch.sh
+```
+
+### Step 3: Write the launchd plist
+
+Create `~/Library/LaunchAgents/com.obsidian-wiki.gstack-watch.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.obsidian-wiki.gstack-watch</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>WATCH_SCRIPT_PATH</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>INTERVAL_SECONDS</integer>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>StandardOutPath</key>
+  <string>VAULT_PATH/.gstack-watch.log</string>
+  <key>StandardErrorPath</key>
+  <string>VAULT_PATH/.gstack-watch.log</string>
+</dict>
+</plist>
+```
+
+Replace:
+- `WATCH_SCRIPT_PATH` → `~/.obsidian-wiki/gstack-watch.sh` (expanded absolute path)
+- `INTERVAL_SECONDS` → user's chosen interval in seconds (e.g., 7200 for 2 hours)
+- `VAULT_PATH` → actual vault path from config
+
+### Step 4: Load the agent
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.obsidian-wiki.gstack-watch.plist
+```
+
+Verify it's running:
+```bash
+launchctl list | grep gstack-watch
+```
+
+### Step 5: Wire auto-trigger into the vault
+
+Append to `$OBSIDIAN_VAULT_PATH/AGENTS.md` (read it first to check if already present; create the file if it doesn't exist):
+
+```markdown
+
+## Auto-triggers
+
+- If `$OBSIDIAN_VAULT_PATH/.gstack-sync-pending` exists at session start: run the `gstack-learnings-sync` skill immediately before any other operation.
+```
+
+The vault `AGENTS.md` is loaded universally by every skill (see the obsidian-wiki repo's own `AGENTS.md`), so this auto-trigger applies across the whole framework without modifying the cloned repo.
+
+### Step 6: Confirm
+
+Tell the user:
+- Watch installed, runs every N hours
+- Script at `~/.obsidian-wiki/gstack-watch.sh`
+- Log at `$VAULT/.gstack-watch.log`
+- Next time Claude Code opens in the wiki project and new learnings exist, sync runs automatically
+
+---
+
+## Check Status
+
+```bash
+# Is the launchd agent loaded?
+launchctl list | grep gstack-watch
+
+# When did it last run?
+cat ~/.obsidian-wiki/.watch-last-run 2>/dev/null || echo "Never run"
+
+# Are there pending learnings?
+cat "$VAULT/.gstack-sync-pending" 2>/dev/null || echo "No pending learnings"
+
+# Recent log
+tail -20 "$VAULT/.gstack-watch.log" 2>/dev/null || echo "No log yet"
+```
+
+Report the results in plain English.
+
+---
+
+## Update Interval
+
+1. Unload the current agent: `launchctl unload ~/Library/LaunchAgents/com.obsidian-wiki.gstack-watch.plist`
+2. Edit the plist: update `StartInterval` to the new value in seconds
+3. Reload: `launchctl load ~/Library/LaunchAgents/com.obsidian-wiki.gstack-watch.plist`
+4. Confirm the new schedule
+
+---
+
+## Uninstall
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.obsidian-wiki.gstack-watch.plist
+rm ~/Library/LaunchAgents/com.obsidian-wiki.gstack-watch.plist
+rm -f ~/.obsidian-wiki/gstack-watch.sh
+rm -f ~/.obsidian-wiki/.watch-last-run
+```
+
+Tell the user the watcher is removed. The `gstack-learnings-sync` skill still works on demand.
+
+---
+
+## Notes
+
+- The watcher script only writes a marker file — it does NOT run Claude or modify the wiki directly. Actual wiki updates happen inside Claude Code via `gstack-learnings-sync`.
+- On battery power, launchd may defer the run. This is expected — the watcher catches up on next trigger.
+- If `python3` is not in PATH for the launchd environment, the script falls back to treating all entries as new (safe but slightly wasteful — it will always mark pending until the full sync runs).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,8 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | "save this" / "/wiki-capture" / "capture this" / "file this conversation" | `wiki-capture` |
 | "/wiki-research [topic]" / "research X" / "find everything about Y" | `wiki-research` |
 | "create a dashboard" / "vault dashboard" / "show all X as a table" / "dynamic view" | `wiki-dashboard` |
+| "sync gstack learnings" / "pull in new learnings" / "update wiki from gstack" | `gstack-learnings-sync` |
+| "watch gstack learnings" / "auto-sync gstack" / "keep wiki updated automatically" | `gstack-learnings-watch` |
 | "create a new skill" | `skill-creator` |
 
 ## Cross-Project Usage


### PR DESCRIPTION
## Summary

Adds two new skills that bridge [gstack](https://github.com/) review learnings into the Obsidian wiki:

- **`gstack-learnings-sync`** — reads `~/.gstack/projects/*/learnings.jsonl`, finds entries newer than the last sync, and appends them to matching wiki project pages (or creates new pages for unknown projects). Tracks state via `gstack_learnings_last_sync` in `.manifest.json`.
- **`gstack-learnings-watch`** — installs a lightweight macOS launchd agent that periodically scans for new learnings and stages them for the next wiki session via a `.gstack-sync-pending` marker. Includes install / status / update-interval / uninstall flows.

Also adds two routing entries to `AGENTS.md`.

## Why

For users who run gstack alongside obsidian-wiki, the review skills (`/plan-eng-review`, `/plan-ceo-review`, etc.) emit structured `learnings.jsonl` entries with concrete pitfalls/patterns/architecture insights. Without a bridge, those insights stay siloed in `~/.gstack` and never reach the wiki, where they'd otherwise enrich the per-project knowledge graph. These skills close that loop.

## Notes for reviewers

- Both skills are self-contained — no new dependencies beyond what gstack and obsidian-wiki already need.
- `gstack-learnings-watch` is **macOS-only** (uses `launchd`); the description calls this out and points Linux/Windows users at cron / systemd / Task Scheduler as adaptations.
- `gstack-learnings-watch` Step 5 writes its auto-trigger rule to `\$OBSIDIAN_VAULT_PATH/AGENTS.md` (the vault's instruction file), **not** the cloned repo's `AGENTS.md`. This depends on the universal-vault-AGENTS.md loader from #22 — if that PR doesn't land, this step still works but only when the user happens to read the vault's `AGENTS.md` themselves.
- I genericized all examples and removed all references to my own gstack projects/skills before opening this PR. Slug-mapping examples are illustrative placeholders, not real project names.
- No platform-symlinks (`.claude/skills/`, `.cursor/skills/`, etc.) are included — happy to add them in whatever convention you use; let me know.

## Test plan

- [ ] Place a `learnings.jsonl` in `~/.gstack/projects/<some-slug>/` with a couple of entries.
- [ ] Run the `gstack-learnings-sync` skill — confirm entries appear on the matching project page (or that a new page is created if the slug doesn't match).
- [ ] Run a second time — confirm only new entries are picked up (incremental via `gstack_learnings_last_sync`).
- [ ] Install the watcher with a short interval (e.g. 60s for testing), drop a new entry, and confirm `.gstack-sync-pending` appears in the vault.
- [ ] Uninstall the watcher — confirm launchd job and files are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)