### PR TITLE
feat: confidence + lifecycle frontmatter schema (closes #28)

### DIFF
--- a/.skills/claude-history-ingest/SKILL.md
+++ b/.skills/claude-history-ingest/SKILL.md
@@ -276,6 +276,14 @@ For each project with content, create or update the project overview page at `pr
 
 **Write a `summary:` frontmatter field** on every new/updated page — 1–2 sentences, ≤200 chars, answering "what is this page about?" for a reader who hasn't opened it. `wiki-query`'s cheap retrieval path reads this field to avoid opening page bodies.
 
+**Add confidence and lifecycle fields** to every new page's frontmatter:
+```yaml
+base_confidence: 0.42
+lifecycle: draft
+lifecycle_changed: <ISO date today>
+```
+On update, leave `lifecycle` and `lifecycle_changed` unchanged — only a human editor transitions lifecycle state.
+
 **Mark provenance** per the convention in `llm-wiki` (Provenance Markers section):
 
 - **Memory files** are mostly extracted — the user wrote them by hand and they're already distilled. Treat memory-derived claims as extracted unless you're stitching together claims from multiple memory files.

--- a/.skills/codex-history-ingest/SKILL.md
+++ b/.skills/codex-history-ingest/SKILL.md
@@ -150,6 +150,13 @@ For each impacted project, create/update `projects/<name>/<name>.md` (project na
 - Distill knowledge, not chronology
 - Avoid "on date X we discussed..." unless date context is essential
 - Add `summary:` frontmatter on each new/updated page (1-2 sentences, <= 200 chars)
+- Add confidence and lifecycle fields to every new page:
+  ```yaml
+  base_confidence: 0.42
+  lifecycle: draft
+  lifecycle_changed: <ISO date today>
+  ```
+  Leave `lifecycle` unchanged on update.
 - Add provenance markers:
   - `^[extracted]` when directly grounded in explicit session content
   - `^[inferred]` when synthesizing patterns across events/sessions

--- a/.skills/copilot-history-ingest/SKILL.md
+++ b/.skills/copilot-history-ingest/SKILL.md
@@ -271,6 +271,14 @@ For each project with content, create or update the project overview page at `pr
 
 **Write a `summary:` frontmatter field** on every new/updated page — 1–2 sentences, ≤200 chars, answering "what is this page about?" for a reader who hasn't opened it. `wiki-query`'s cheap retrieval path reads this field to avoid opening page bodies.
 
+**Add confidence and lifecycle fields** to every new page's frontmatter:
+```yaml
+base_confidence: 0.42
+lifecycle: draft
+lifecycle_changed: <ISO date today>
+```
+Leave `lifecycle` unchanged on update.
+
 **Mark provenance** per the convention in `llm-wiki` (Provenance Markers section):
 
 - **Checkpoints and index.md** are pre-distilled by the system — treat checkpoint-derived claims as extracted (the system wrote them from observed actions).

--- a/.skills/data-ingest/SKILL.md
+++ b/.skills/data-ingest/SKILL.md
@@ -121,6 +121,13 @@ Follow the `wiki-ingest` skill's process for creating/updating pages:
 - Attribute claims to their source
 - **Write a `summary:` frontmatter field** on every new page (1–2 sentences, ≤200 characters) answering "what is this page about?" — this is what downstream skills read to avoid opening the page body.
 - **Apply provenance markers** per the convention in `llm-wiki`. Conversation, log, and chat data tend to be high-inference — you're often reading between the turns to extract a coherent claim. Be liberal with `^[inferred]` for synthesized patterns and with `^[ambiguous]` when speakers contradict each other or you're unsure who's right. Write a `provenance:` frontmatter block on each new/updated page.
+- **Add confidence and lifecycle fields** to every new page:
+  ```yaml
+  base_confidence: 0.37
+  lifecycle: draft
+  lifecycle_changed: <ISO date today>
+  ```
+  The caller may pass an explicit quality override (e.g. `quality: documentation`) — if so, recompute: `base_confidence = round(0.17 + 0.5 × quality_score, 2)` using the quality table in `llm-wiki/SKILL.md`. Default is `unknown` (0.4) → 0.37.
 
 ## Step 5: Update Manifest and Special Files
 

--- a/.skills/hermes-history-ingest/SKILL.md
+++ b/.skills/hermes-history-ingest/SKILL.md
@@ -140,6 +140,13 @@ For each impacted project, create/update `projects/<name>/<name>.md`.
 - Distill knowledge, not chronology
 - Avoid "on date X we discussed..." unless date context is essential
 - Add `summary:` frontmatter on each new/updated page (1–2 sentences, ≤ 200 chars)
+- Add confidence and lifecycle fields to every new page:
+  ```yaml
+  base_confidence: 0.42
+  lifecycle: draft
+  lifecycle_changed: <ISO date today>
+  ```
+  Leave `lifecycle` unchanged on update.
 - Add provenance markers:
   - `^[extracted]` when directly grounded in explicit memory/session content
   - `^[inferred]` when synthesizing patterns across multiple memories

--- a/.skills/ingest-url/SKILL.md
+++ b/.skills/ingest-url/SKILL.md
@@ -170,6 +170,9 @@ provenance:
   extracted: 0.X
   inferred: 0.X
   ambiguous: 0.X
+base_confidence: <computed — see below>
+lifecycle: draft
+lifecycle_changed: "<ISO date today>"
 ---
 ```
 
@@ -192,8 +195,26 @@ provenance:
   extracted: 0.X
   inferred: 0.X
   ambiguous: 0.X
+base_confidence: <computed — see below>
+lifecycle: draft
+lifecycle_changed: "<ISO date today>"
 ---
 ```
+
+**Computing `base_confidence` for a URL source:**
+
+Classify the URL's quality bucket using the host:
+- `arxiv.org`, `doi.org`, conference sites → `paper` (1.0)
+- `*.gov`, official vendor docs (e.g. `docs.python.org`, `developer.mozilla.org`) → `official` (0.9)
+- Well-maintained third-party docs (e.g. `docs.docker.com`) → `documentation` (0.85)
+- GitHub READMEs (`github.com`) → `repository` (0.75)
+- Personal blogs, Medium, Substack, dev.to → `blog` (0.55)
+- Stack Overflow, Hacker News, Reddit → `forum` (0.4)
+- Anything else → `unknown` (0.4)
+
+With 1 distinct source: `base_confidence = round(0.17 + 0.5 × quality_score, 2)`
+
+Examples: `paper` → 0.67, `official` → 0.62, `documentation` → 0.60, `repository` → 0.55, `blog` → 0.45, `forum/unknown` → 0.37.
 
 Then write the body (same for both modes):
 

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -165,6 +165,9 @@ provenance:
   extracted: 0.72
   inferred: 0.25
   ambiguous: 0.03
+base_confidence: 0.65
+lifecycle: draft
+lifecycle_changed: 2024-03-15
 created: 2024-03-15T10:30:00Z
 updated: 2024-03-15T10:30:00Z
 ---
@@ -223,6 +226,85 @@ provenance:
 ```
 
 These are best-effort numbers written by the ingest skill at create/update time. `wiki-lint` recomputes them and flags drift. The block is optional — pages without it are treated as fully extracted by convention.
+
+## Confidence and Lifecycle
+
+Every page carries two orthogonal trust signals plus an optional supersession link.
+
+### Required fields
+
+```yaml
+base_confidence: 0.65          # [0.0, 1.0] — time-independent quality estimate. Stored once, recomputed on content change.
+lifecycle: draft               # draft | reviewed | verified | disputed | archived
+lifecycle_changed: 2024-03-15  # ISO date of last state transition
+# lifecycle_reason: "..."      # optional free-text — why the state changed; surfaced by wiki-query
+# superseded_by: "[[new-page]]" # wikilink; only when lifecycle=archived
+```
+
+`lifecycle_reason` and `superseded_by` are optional. Never fabricate them.
+
+### Confidence formula
+
+```
+base_confidence = source_count_score * 0.5 + source_quality_score * 0.5
+
+source_count_score   = min(distinct_source_ids / 3, 1.0)
+source_quality_score = avg(quality score per distinct source_id)
+```
+
+**Source-quality scores** (use the highest-matching bucket):
+
+| Bucket | Score | Examples |
+|---|---|---|
+| `paper` | 1.0 | arXiv, conference proceedings |
+| `official` | 0.9 | `*.gov`, vendor docs |
+| `documentation` | 0.85 | well-maintained third-party docs |
+| `book` | 0.8 | books, technical references |
+| `repository` | 0.75 | GitHub READMEs, codebases |
+| `blog` | 0.55 | personal blogs |
+| `session_transcript` | 0.5 | conversation history |
+| `forum` | 0.4 | Stack Overflow, HN, Reddit |
+| `unknown` | 0.4 | catch-all |
+| `llm_generated` | 0.3 | LLM self-reflections |
+
+**A `source_id`** is a stable per-source identifier — prevents counting three copies of the same blog as three distinct sources:
+
+| Source type | source_id rule |
+|---|---|
+| Academic paper | DOI > arXiv ID > `<author>-<year>-<slug>` |
+| GitHub repo | `github.com/<owner>/<repo>` |
+| Documentation site | `<canonical-host>/<product>` |
+| Blog post | `<host>/<author>` |
+| Session transcript | `<agent>/<session-id>` |
+| Other | `<canonical-url>` |
+
+**Per-skill defaults** (ingest skills compute this automatically):
+
+| Skill | base_confidence | lifecycle |
+|---|---|---|
+| `ingest-url` | `0.17 + 0.5 × classify(url)` | `draft` |
+| `wiki-ingest` (single doc) | per-source classifier | `draft` |
+| `wiki-ingest` (multi-doc) | `min(N/3,1)×0.5 + avg_q×0.5` | `draft` |
+| `wiki-research` | varies, often 0.85+ | `draft` |
+| `wiki-capture` | 0.42 | `draft` |
+| `*-history-ingest` | 0.42 | `draft` |
+| `wiki-update` | 0.59 | `draft` |
+| `wiki-synthesize` | `min(input_pages.base_confidence)` | `draft` |
+| `data-ingest` | 0.37 | `draft` |
+
+### Lifecycle state machine
+
+Five states. **`stale` is not a state** — it is a computed overlay: `is_stale = (today − updated) > 90 days`.
+
+| State | Entered by | Notes |
+|---|---|---|
+| `draft` | Any ingest skill on first write | Default for all new pages |
+| `reviewed` | Human edit only | |
+| `verified` | Human edit only | Time alone never demotes verified pages |
+| `disputed` | Manual edit only | Overrides every state except `archived` in display |
+| `archived` | Manual edit, or ingest skill setting `superseded_by` | Terminal |
+
+Only ingest skills set `draft`. All other transitions require a human editor. Update `lifecycle_changed` whenever the state changes.
 
 ## Retrieval Primitives
 

--- a/.skills/openclaw-history-ingest/SKILL.md
+++ b/.skills/openclaw-history-ingest/SKILL.md
@@ -157,6 +157,13 @@ For each impacted project, create/update `projects/<name>/<name>.md`.
 - Distill knowledge, not chronology
 - Avoid "on date X we discussed..." unless date context is essential
 - Add `summary:` frontmatter on each new/updated page (1–2 sentences, ≤ 200 chars)
+- Add confidence and lifecycle fields to every new page:
+  ```yaml
+  base_confidence: 0.42
+  lifecycle: draft
+  lifecycle_changed: <ISO date today>
+  ```
+  Leave `lifecycle` unchanged on update.
 - Add provenance markers:
   - `^[extracted]` when directly grounded in explicit session/memory content
   - `^[inferred]` when synthesizing patterns across multiple sessions

--- a/.skills/wiki-capture/SKILL.md
+++ b/.skills/wiki-capture/SKILL.md
@@ -94,6 +94,9 @@ provenance:
   extracted: 0.X
   inferred: 0.X
   ambiguous: 0.X
+base_confidence: 0.42
+lifecycle: draft
+lifecycle_changed: <ISO date today>
 ---
 ```
 

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -175,6 +175,21 @@ For each page in your plan:
 
 **Write a `summary:` frontmatter field** on every new page (1–2 sentences, ≤200 characters) answering "what is this page about?" for a reader who hasn't opened it. When updating an existing page whose meaning has shifted, rewrite the summary to match the new content. This field is what `wiki-query`'s cheap retrieval path reads — a missing or stale summary forces expensive full-page reads.
 
+**Add confidence and lifecycle fields** to every new page's frontmatter:
+
+```yaml
+base_confidence: <computed>   # [0.0, 1.0] — see llm-wiki/SKILL.md Confidence formula
+lifecycle: draft
+lifecycle_changed: "<ISO date today>"
+```
+
+Compute `base_confidence` using the formula from `llm-wiki/SKILL.md` (Confidence and Lifecycle section):
+- Count distinct source_ids for this page
+- Classify each source's quality bucket
+- `base_confidence = min(N/3, 1.0) × 0.5 + avg_quality × 0.5`
+
+When **updating** an existing page, recompute `base_confidence` only if sources changed materially (source added or removed). Do not rewrite it on every update — this avoids git churn. Leave `lifecycle` unchanged on update; only the human editor promotes lifecycle state.
+
 **Apply a `visibility/` tag** if the content clearly warrants one (optional):
 - `visibility/internal` — architecture internals, system credentials patterns, team-only context
 - `visibility/pii` — content that references personal data, user records, or sensitive identifiers

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -165,6 +165,80 @@ Find pages in `misc/` that have accumulated enough project affinity to be promot
 - Run the `cross-linker` skill first if affinity scores look stale (e.g., `affinity: {}` on a page with many wikilinks)
 - To promote: move the page to `projects/<project-name>/references/` (or another appropriate category), update its `category` frontmatter, remove `promotion_status`, and grep the vault for backlinks to update them
 
+### 12. Confidence and Lifecycle Schema
+
+Enforces the confidence + lifecycle frontmatter schema (see `llm-wiki/SKILL.md`, Confidence and Lifecycle section).
+
+Two modes:
+- **`--check`** (default, read-only) — reports errors and warnings
+- **`--fix`** — may rewrite `base_confidence` only when drift is detected (Rule 12e); never rewrites `lifecycle`
+
+#### Rule 12a — `lifecycle` enum validation
+
+**How to check:** Grep frontmatter for `^lifecycle:` across all pages. Flag any value not in `{draft, reviewed, verified, disputed, archived}`.
+
+**How to fix:** n/a (only a human should set lifecycle state)
+
+#### Rule 12b — `base_confidence` range
+
+**How to check:** Grep frontmatter for `^base_confidence:` across all pages. Flag any value outside `[0.0, 1.0]` or any page missing the field entirely.
+
+**How to fix:** n/a (wrong value means the skill computed it wrong — surface for manual correction)
+
+#### Rule 12c — Stale page report (computed overlay)
+
+Staleness is never stored — it is computed at read time: `is_stale = (today − updated) > 90 days`.
+
+**How to check:** For each page, read `updated:` from frontmatter and compute `is_stale`. If stale, also check `lifecycle:`. Report:
+- Stale pages with `lifecycle: verified` with a louder annotation (these are the most dangerous — high-trust pages that may be wrong)
+- All other stale pages as a standard warning
+
+**How to fix:** `--fix` does **not** rewrite `lifecycle`. Staleness clears automatically when a re-ingest bumps `updated`.
+
+#### Rule 12d — Supersession integrity
+
+**How to check:** For each page with `superseded_by: "[[target]]"`:
+- Verify the target page exists
+- Verify the target page is not itself `archived` (no circular or chained supersession)
+- Verify there are no cycles (A supersedes B which supersedes A)
+- Warn if `lifecycle != archived` while `superseded_by` is set (inconsistent state)
+
+**How to fix:** n/a — flag for human resolution
+
+#### Rule 12e — Confidence drift
+
+**How to check:** For pages that have both `base_confidence:` and `sources:` in frontmatter, recompute `base_confidence` using the formula in `llm-wiki/SKILL.md`. If the stored value differs from the recomputed value by more than 0.05, flag it as drift.
+
+**How to fix (`--fix` only):** Rewrite the `base_confidence` field to the recomputed value. This is the **only rule** that mutates frontmatter automatically.
+
+#### Migration timeline
+
+| Phase | When | Behavior on missing fields |
+|---|---|---|
+| Phase 1: Soft launch | Initial PR | Warning only — missing `base_confidence` or `lifecycle` on any page |
+| Phase 2: New pages enforced | +2 weeks | Error for newly created pages missing the fields; existing pages still warn even if `updated` is bumped during routine maintenance |
+| Phase 3: Full enforcement | +6 weeks, gated on a backfill script shipping in a separate PR | Error for all pages |
+
+#### Output additions
+
+Add to the Wiki Health Report:
+
+```markdown
+### Confidence/Lifecycle Issues (N found)
+- `concepts/foo.md` — missing `lifecycle` field (warning: Phase 1)
+- `entities/bar.md` — `lifecycle: stalestate` is not a valid enum value
+- `concepts/scaling.md` — `base_confidence: 1.4` is out of range [0.0, 1.0]
+- `synthesis/old-analysis.md` — STALE (last updated 2025-10-01, 182 days ago) lifecycle=verified ⚠️ HIGH PRIORITY
+- `concepts/outdated.md` — STALE (last updated 2025-11-15, 137 days ago) lifecycle=draft
+- `entities/tool-v1.md` — `superseded_by: [[entities/tool-v2]]` but lifecycle=draft (expected archived)
+- `concepts/drift-example.md` — base_confidence drift: stored=0.80, recomputed=0.59 (delta=0.21)
+```
+
+Append to the `LINT` log entry:
+```
+- [TIMESTAMP] LINT ... lifecycle_issues=N
+```
+
 ### 11. Synthesis Gaps
 
 Identify high-value synthesis opportunities the wiki is missing — concept pairs that co-occur across many pages but have no `synthesis/` page connecting them.

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -115,6 +115,25 @@ Compose your answer from wiki content:
 - If the wiki doesn't cover something, say so explicitly
 - Suggest which sources might fill the gap
 
+**Page trust annotations:** For every page cited in your answer, check its `lifecycle` frontmatter and compute `is_stale = (today − updated) > 90 days`. Annotate risky pages inline so the user knows which citations to verify:
+
+| Condition | Annotation |
+|---|---|
+| `lifecycle: archived` | `(ARCHIVED: superseded by [[target]])` — use the successor instead |
+| `lifecycle: disputed` | `(DISPUTED, marked <lifecycle_changed>: <lifecycle_reason or "reason unspecified">)` |
+| `is_stale` + `lifecycle: verified` | `(VERIFIED but stale: last updated <updated>)` — reader should re-verify before relying |
+| `is_stale` (other lifecycle) | `(stale: last updated <updated>)` |
+
+Examples in a synthesized answer:
+```
+[[concept-page]] (stale: last updated 2026-01-15) — Original claim was X.
+[[verified-page]] (VERIFIED but stale: last updated 2025-09-10) — Reader should reverify before relying.
+[[disputed-page]] (DISPUTED, marked 2026-04-30: contradicted by [[new-source]]) — Earlier said Y, now uncertain.
+[[old-page]] (ARCHIVED: superseded by [[new-page]]) — Use the successor.
+```
+
+Pages with no lifecycle field (legacy pages predating the schema) are treated the same as `draft` — annotate if stale, skip otherwise. Never fabricate a `lifecycle_reason`; if the field is absent, omit the reason from the annotation.
+
 ### Step 6: Log the Query
 
 Append to `log.md`:

--- a/.skills/wiki-research/SKILL.md
+++ b/.skills/wiki-research/SKILL.md
@@ -97,6 +97,9 @@ provenance:
   extracted: 0.X
   inferred: 0.X
   ambiguous: 0.X
+base_confidence: <0.17 + 0.5 × classify(url) for a single source>
+lifecycle: draft
+lifecycle_changed: <ISO date today>
 ---
 ```
 
@@ -133,6 +136,9 @@ provenance:
   extracted: 0.X
   inferred: 0.X
   ambiguous: 0.X
+base_confidence: <min(N_unique_sources/3,1.0)×0.5 + avg_source_quality×0.5>
+lifecycle: draft
+lifecycle_changed: <ISO date today>
 ---
 
 # Research: <Topic>

--- a/.skills/wiki-synthesize/SKILL.md
+++ b/.skills/wiki-synthesize/SKILL.md
@@ -81,6 +81,9 @@ provenance:
   extracted: 0.2
   inferred: 0.7
   ambiguous: 0.1
+base_confidence: <min(base_confidence of all input pages)>
+lifecycle: draft
+lifecycle_changed: TIMESTAMP_DATE
 ---
 
 # <Concept A> × <Concept B>

--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -114,6 +114,9 @@ provenance:
   extracted: 0.6
   inferred: 0.35
   ambiguous: 0.05
+base_confidence: 0.59
+lifecycle: draft
+lifecycle_changed: TIMESTAMP_DATE
 created: TIMESTAMP
 updated: TIMESTAMP
 ---


### PR DESCRIPTION
## Summary

Implements the RFC proposed in #28 — adding a small, locked-in trust schema to every wiki page before vaults grow too large to retrofit.

- **`base_confidence`** [0.0, 1.0] — time-independent quality estimate (source count × source quality). Stored once, recomputed only on content change. Never decays.
- **`lifecycle`** — `draft | reviewed | verified | disputed | archived` state machine. Ingest skills always write `draft`; all other transitions require a human editor.
- **`lifecycle_changed`** — ISO date of last state transition.
- **`lifecycle_reason`** (optional) — free-text reason surfaced by `wiki-query` in dispute/archive annotations.
- **`superseded_by`** (optional) — wikilink, only when `lifecycle=archived`.

Staleness is **not** stored — it is computed at read time: `is_stale = (today − updated) > 90 days`.

## Files changed

| Skill | Change |
|---|---|
| `llm-wiki` | Page template updated; new "Confidence and Lifecycle" section with formula, quality table, source_id rules, per-skill defaults, and state machine |
| `ingest-url` | Frontmatter templates + URL quality classifier table |
| `wiki-ingest` | Guidance on computing `base_confidence` per source |
| `wiki-research` | Fields added to sources/ and synthesis/ frontmatter templates |
| `wiki-capture` | Fixed `base_confidence: 0.42` (session transcript) |
| `claude/codex/hermes/openclaw/copilot-history-ingest` | Fixed `base_confidence: 0.42` (session transcript) |
| `wiki-update` | Fixed `base_confidence: 0.59` (first-party project docs) |
| `wiki-synthesize` | Inherited `base_confidence: min(input_pages)` |
| `data-ingest` | Fixed `base_confidence: 0.37` (unknown quality), caller-overridable |
| `wiki-lint` | 5 new rules (12a–12e): enum validation, range check, stale report, supersession integrity, confidence drift; Phase 1/2/3 migration timeline |
| `wiki-query` | Inline trust annotations for stale/disputed/archived/verified-stale citations |

## Test plan

- [ ] Create a new wiki page via `ingest-url` and verify `base_confidence`, `lifecycle: draft`, and `lifecycle_changed` appear in frontmatter
- [ ] Run `wiki-lint --check` and verify rules 12a–12e appear in the health report
- [ ] Query the wiki with `wiki-query` and verify stale/disputed/archived pages receive inline annotations
- [ ] Manually set `lifecycle: disputed` + `lifecycle_reason` on a page and verify `wiki-query` surfaces the reason in the annotation
- [ ] Verify no existing pages are broken (lint Phase 1 = warnings only)

Closes #28