### PR TITLE
fix: resolve relative manifest paths against OBSIDIAN_VAULT_PATH in daily-update.sh

### DIFF
--- a/scripts/daily-update.sh
+++ b/scripts/daily-update.sh
@@ -66,7 +66,7 @@ except:
 " 2>/dev/null || echo "")
 
   if [[ -n "$last_updated" ]]; then
-    stale_count=$(MANIFEST="$MANIFEST" python3 - <<'PYEOF'
+    stale_count=$(MANIFEST="$MANIFEST" OBSIDIAN_VAULT_PATH="$OBSIDIAN_VAULT_PATH" python3 - <<'PYEOF'
 import json, os, sys
 from datetime import datetime, timezone
 
@@ -85,9 +85,12 @@ except Exception:
     print(0)
     sys.exit()
 
+vault_path = os.environ.get("OBSIDIAN_VAULT_PATH", "")
 stale = 0
 for path, meta in manifest.get("sources", {}).items():
     expanded = os.path.expanduser(path)
+    if not os.path.isabs(expanded) and vault_path:
+        expanded = os.path.join(vault_path, expanded)
     if os.path.exists(expanded):
         mtime = datetime.fromtimestamp(os.path.getmtime(expanded), tz=timezone.utc)
         if mtime > last_updated:


### PR DESCRIPTION
## Summary

- Fixes `daily-update.sh` silently under-counting stale sources when `.manifest.json` contains relative paths and the script runs from outside the vault (e.g. launchd default CWD of `/`)
- Passes `OBSIDIAN_VAULT_PATH` into the Python heredoc's environment and joins it onto any relative path before `os.path.exists()` — absolute and `~/…` paths are unaffected
- Implements Option B from the issue (in-loop resolution), which is more defensive than a top-level `cd` and survives any caller that needs to preserve CWD

## Test plan

- [x] Synthetic test confirmed old code from `/` produced `stale_count=1` (only absolute path counted); new code produced `stale_count=2` (relative paths correctly resolved against vault)
- [x] Script runs identically from `/` and from `$OBSIDIAN_VAULT_PATH`
- [x] Non-existent relative paths still silently skipped (no crash)
- [x] Absolute paths unaffected by change

Closes #35