### PR TITLE
fix: replace absolute symlink paths with relative paths

### DIFF
--- a/.agents/skills/claude-history-ingest
+++ b/.agents/skills/claude-history-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/claude-history-ingest/
+../../.skills/claude-history-ingest

--- a/.agents/skills/cross-linker
+++ b/.agents/skills/cross-linker
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/cross-linker/
+../../.skills/cross-linker

--- a/.agents/skills/data-ingest
+++ b/.agents/skills/data-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/data-ingest/
+../../.skills/data-ingest

--- a/.agents/skills/ingest-url
+++ b/.agents/skills/ingest-url
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/ingest-url
+../../.skills/ingest-url

--- a/.agents/skills/llm-wiki
+++ b/.agents/skills/llm-wiki
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/llm-wiki/
+../../.skills/llm-wiki

--- a/.agents/skills/skill-creator
+++ b/.agents/skills/skill-creator
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/skill-creator/
+../../.skills/skill-creator

--- a/.agents/skills/tag-taxonomy
+++ b/.agents/skills/tag-taxonomy
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/tag-taxonomy/
+../../.skills/tag-taxonomy

--- a/.agents/skills/wiki-capture
+++ b/.agents/skills/wiki-capture
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-capture
+../../.skills/wiki-capture

--- a/.agents/skills/wiki-dashboard
+++ b/.agents/skills/wiki-dashboard
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-dashboard
+../../.skills/wiki-dashboard

--- a/.agents/skills/wiki-export
+++ b/.agents/skills/wiki-export
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-export
+../../.skills/wiki-export

--- a/.agents/skills/wiki-ingest
+++ b/.agents/skills/wiki-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-ingest/
+../../.skills/wiki-ingest

--- a/.agents/skills/wiki-lint
+++ b/.agents/skills/wiki-lint
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-lint/
+../../.skills/wiki-lint

--- a/.agents/skills/wiki-query
+++ b/.agents/skills/wiki-query
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-query/
+../../.skills/wiki-query

--- a/.agents/skills/wiki-rebuild
+++ b/.agents/skills/wiki-rebuild
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-rebuild/
+../../.skills/wiki-rebuild

--- a/.agents/skills/wiki-research
+++ b/.agents/skills/wiki-research
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-research
+../../.skills/wiki-research

--- a/.agents/skills/wiki-setup
+++ b/.agents/skills/wiki-setup
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-setup/
+../../.skills/wiki-setup

--- a/.agents/skills/wiki-status
+++ b/.agents/skills/wiki-status
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-status/
+../../.skills/wiki-status

--- a/.agents/skills/wiki-synthesize
+++ b/.agents/skills/wiki-synthesize
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-synthesize
+../../.skills/wiki-synthesize

--- a/.agents/skills/wiki-update
+++ b/.agents/skills/wiki-update
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-update/
+../../.skills/wiki-update

--- a/.claude/skills/claude-history-ingest
+++ b/.claude/skills/claude-history-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/claude-history-ingest/
+../../.skills/claude-history-ingest

--- a/.claude/skills/cross-linker
+++ b/.claude/skills/cross-linker
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/cross-linker/
+../../.skills/cross-linker

--- a/.claude/skills/data-ingest
+++ b/.claude/skills/data-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/data-ingest/
+../../.skills/data-ingest

--- a/.claude/skills/ingest-url
+++ b/.claude/skills/ingest-url
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/ingest-url
+../../.skills/ingest-url

--- a/.claude/skills/llm-wiki
+++ b/.claude/skills/llm-wiki
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/llm-wiki/
+../../.skills/llm-wiki

--- a/.claude/skills/skill-creator
+++ b/.claude/skills/skill-creator
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/skill-creator/
+../../.skills/skill-creator

--- a/.claude/skills/tag-taxonomy
+++ b/.claude/skills/tag-taxonomy
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/tag-taxonomy/
+../../.skills/tag-taxonomy

--- a/.claude/skills/wiki-capture
+++ b/.claude/skills/wiki-capture
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-capture
+../../.skills/wiki-capture

--- a/.claude/skills/wiki-dashboard
+++ b/.claude/skills/wiki-dashboard
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-dashboard
+../../.skills/wiki-dashboard

--- a/.claude/skills/wiki-export
+++ b/.claude/skills/wiki-export
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-export
+../../.skills/wiki-export

--- a/.claude/skills/wiki-ingest
+++ b/.claude/skills/wiki-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-ingest/
+../../.skills/wiki-ingest

--- a/.claude/skills/wiki-lint
+++ b/.claude/skills/wiki-lint
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-lint/
+../../.skills/wiki-lint

--- a/.claude/skills/wiki-query
+++ b/.claude/skills/wiki-query
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-query/
+../../.skills/wiki-query

--- a/.claude/skills/wiki-rebuild
+++ b/.claude/skills/wiki-rebuild
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-rebuild/
+../../.skills/wiki-rebuild

--- a/.claude/skills/wiki-research
+++ b/.claude/skills/wiki-research
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-research
+../../.skills/wiki-research

--- a/.claude/skills/wiki-setup
+++ b/.claude/skills/wiki-setup
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-setup/
+../../.skills/wiki-setup

--- a/.claude/skills/wiki-status
+++ b/.claude/skills/wiki-status
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-status/
+../../.skills/wiki-status

--- a/.claude/skills/wiki-synthesize
+++ b/.claude/skills/wiki-synthesize
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-synthesize
+../../.skills/wiki-synthesize

--- a/.claude/skills/wiki-update
+++ b/.claude/skills/wiki-update
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-update/
+../../.skills/wiki-update

--- a/.cursor/skills/claude-history-ingest
+++ b/.cursor/skills/claude-history-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/claude-history-ingest/
+../../.skills/claude-history-ingest

--- a/.cursor/skills/cross-linker
+++ b/.cursor/skills/cross-linker
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/cross-linker/
+../../.skills/cross-linker

--- a/.cursor/skills/data-ingest
+++ b/.cursor/skills/data-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/data-ingest/
+../../.skills/data-ingest

--- a/.cursor/skills/ingest-url
+++ b/.cursor/skills/ingest-url
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/ingest-url
+../../.skills/ingest-url

--- a/.cursor/skills/llm-wiki
+++ b/.cursor/skills/llm-wiki
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/llm-wiki/
+../../.skills/llm-wiki

--- a/.cursor/skills/skill-creator
+++ b/.cursor/skills/skill-creator
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/skill-creator/
+../../.skills/skill-creator

--- a/.cursor/skills/tag-taxonomy
+++ b/.cursor/skills/tag-taxonomy
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/tag-taxonomy/
+../../.skills/tag-taxonomy

--- a/.cursor/skills/wiki-capture
+++ b/.cursor/skills/wiki-capture
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-capture
+../../.skills/wiki-capture

--- a/.cursor/skills/wiki-dashboard
+++ b/.cursor/skills/wiki-dashboard
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-dashboard
+../../.skills/wiki-dashboard

--- a/.cursor/skills/wiki-export
+++ b/.cursor/skills/wiki-export
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-export
+../../.skills/wiki-export

--- a/.cursor/skills/wiki-ingest
+++ b/.cursor/skills/wiki-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-ingest/
+../../.skills/wiki-ingest

--- a/.cursor/skills/wiki-lint
+++ b/.cursor/skills/wiki-lint
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-lint/
+../../.skills/wiki-lint

--- a/.cursor/skills/wiki-query
+++ b/.cursor/skills/wiki-query
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-query/
+../../.skills/wiki-query

--- a/.cursor/skills/wiki-rebuild
+++ b/.cursor/skills/wiki-rebuild
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-rebuild/
+../../.skills/wiki-rebuild

--- a/.cursor/skills/wiki-research
+++ b/.cursor/skills/wiki-research
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-research
+../../.skills/wiki-research

--- a/.cursor/skills/wiki-setup
+++ b/.cursor/skills/wiki-setup
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-setup/
+../../.skills/wiki-setup

--- a/.cursor/skills/wiki-status
+++ b/.cursor/skills/wiki-status
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-status/
+../../.skills/wiki-status

--- a/.cursor/skills/wiki-synthesize
+++ b/.cursor/skills/wiki-synthesize
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-synthesize
+../../.skills/wiki-synthesize

--- a/.cursor/skills/wiki-update
+++ b/.cursor/skills/wiki-update
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-update/
+../../.skills/wiki-update

--- a/.kiro/skills/ingest-url
+++ b/.kiro/skills/ingest-url
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/ingest-url
+../../.skills/ingest-url

--- a/.kiro/skills/wiki-capture
+++ b/.kiro/skills/wiki-capture
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-capture
+../../.skills/wiki-capture

--- a/.kiro/skills/wiki-dashboard
+++ b/.kiro/skills/wiki-dashboard
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-dashboard
+../../.skills/wiki-dashboard

--- a/.kiro/skills/wiki-research
+++ b/.kiro/skills/wiki-research
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-research
+../../.skills/wiki-research

--- a/.kiro/skills/wiki-synthesize
+++ b/.kiro/skills/wiki-synthesize
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-synthesize
+../../.skills/wiki-synthesize

--- a/.windsurf/skills/claude-history-ingest
+++ b/.windsurf/skills/claude-history-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/claude-history-ingest/
+../../.skills/claude-history-ingest

--- a/.windsurf/skills/cross-linker
+++ b/.windsurf/skills/cross-linker
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/cross-linker/
+../../.skills/cross-linker

--- a/.windsurf/skills/data-ingest
+++ b/.windsurf/skills/data-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/data-ingest/
+../../.skills/data-ingest

--- a/.windsurf/skills/ingest-url
+++ b/.windsurf/skills/ingest-url
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/ingest-url
+../../.skills/ingest-url

--- a/.windsurf/skills/llm-wiki
+++ b/.windsurf/skills/llm-wiki
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/llm-wiki/
+../../.skills/llm-wiki

--- a/.windsurf/skills/skill-creator
+++ b/.windsurf/skills/skill-creator
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/skill-creator/
+../../.skills/skill-creator

--- a/.windsurf/skills/tag-taxonomy
+++ b/.windsurf/skills/tag-taxonomy
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/tag-taxonomy/
+../../.skills/tag-taxonomy

--- a/.windsurf/skills/wiki-capture
+++ b/.windsurf/skills/wiki-capture
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-capture
+../../.skills/wiki-capture

--- a/.windsurf/skills/wiki-dashboard
+++ b/.windsurf/skills/wiki-dashboard
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-dashboard
+../../.skills/wiki-dashboard

--- a/.windsurf/skills/wiki-export
+++ b/.windsurf/skills/wiki-export
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-export
+../../.skills/wiki-export

--- a/.windsurf/skills/wiki-ingest
+++ b/.windsurf/skills/wiki-ingest
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-ingest/
+../../.skills/wiki-ingest

--- a/.windsurf/skills/wiki-lint
+++ b/.windsurf/skills/wiki-lint
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-lint/
+../../.skills/wiki-lint

--- a/.windsurf/skills/wiki-query
+++ b/.windsurf/skills/wiki-query
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-query/
+../../.skills/wiki-query

--- a/.windsurf/skills/wiki-rebuild
+++ b/.windsurf/skills/wiki-rebuild
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-rebuild/
+../../.skills/wiki-rebuild

--- a/.windsurf/skills/wiki-research
+++ b/.windsurf/skills/wiki-research
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-research
+../../.skills/wiki-research

--- a/.windsurf/skills/wiki-setup
+++ b/.windsurf/skills/wiki-setup
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-setup/
+../../.skills/wiki-setup

--- a/.windsurf/skills/wiki-status
+++ b/.windsurf/skills/wiki-status
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-status/
+../../.skills/wiki-status

--- a/.windsurf/skills/wiki-synthesize
+++ b/.windsurf/skills/wiki-synthesize
@@ -1,1 +1,1 @@
-/Users/ar9av/Documents/projects/obsidian-wiki/.skills/wiki-synthesize
+../../.skills/wiki-synthesize

--- a/.windsurf/skills/wiki-update
+++ b/.windsurf/skills/wiki-update
@@ -1,1 +1,1 @@
-/Users/ar9av/obsidian-wiki/.skills/wiki-update/
+../../.skills/wiki-update


### PR DESCRIPTION
## Summary
- 修复所有 skill mirror 目录（`.agents/`、`.claude/`、`.cursor/`、`.kiro/`、`.windsurf/`）中的符号链接路径，从硬编码的绝对路径 `/Users/ar9av/obsidian-wiki/...` 改为相对路径 `../../.skills/...`，使得这些符号链接在任何机器上都能正常工作。

## Test plan
- [ ] 验证各 mirror 目录下的符号链接能正确解析到 `.skills/` 中的对应 skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)