### PR TITLE
Add QMD CLI transport support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,7 +37,7 @@ OBSIDIAN_LINK_FORMAT=wikilink
 
 # --- QMD Semantic Search (optional) ---
 #
-# QMD is a local MCP server that indexes your wiki and sources for fast semantic search.
+# QMD indexes your wiki and sources for fast semantic search.
 # Install: https://github.com/tobi/qmd
 # After installing, point these at your QMD collection names (set when you ran `qmd index`).
 #
@@ -49,6 +49,20 @@ QMD_WIKI_COLLECTION=
 
 # Name of the QMD collection indexing your raw source documents (OBSIDIAN_SOURCES_DIR or _raw/)
 QMD_PAPERS_COLLECTION=
+
+# QMD integration transport: mcp | cli
+# mcp preserves the original behavior and uses an agent-configured QMD MCP server.
+# cli runs the local qmd command directly; useful for agents without QMD MCP support.
+QMD_TRANSPORT=mcp
+
+# CLI search quality mode: quality | balanced | fast
+# quality: qmd query with reranking (best relevance, slowest on CPU)
+# balanced: qmd query --no-rerank (good hybrid results, faster)
+# fast: qmd vsearch (semantic only) or qmd search when exact terms matter
+QMD_CLI_SEARCH_MODE=quality
+
+# Optional qmd binary override if qmd is not on PATH.
+QMD_CLI=qmd
 
 # --- Raw Staging Directory (optional) ---
 #

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -101,6 +101,15 @@ When `QMD_PAPERS_COLLECTION` is set:
 
 Before extracting knowledge from a document, check whether related papers are already indexed that could enrich the page you're about to write:
 
+Choose the QMD transport from `$QMD_TRANSPORT`:
+
+- `mcp` (default): use the QMD MCP tool configured in the agent.
+- `cli`: run the local qmd CLI. Use `$QMD_CLI` if set; otherwise use `qmd`.
+
+If the selected transport is unavailable (no MCP tool, `qmd` not on PATH, or the command errors), skip QMD and continue with Step 2.
+
+For MCP transport:
+
 ```
 mcp__qmd__query:
   collection: <QMD_PAPERS_COLLECTION>   # e.g. "papers"
@@ -111,6 +120,23 @@ mcp__qmd__query:
     - type: lex    # keyword — finds papers citing the same methods, tools, or authors
       query: <key terms, author names, method names from the source>
 ```
+
+For CLI transport, pick the command from `$QMD_CLI_SEARCH_MODE`:
+
+- `quality` (default): best relevance; slower on CPU.
+  ```bash
+  ${QMD_CLI:-qmd} query $'vec: <topic or thesis of the source>\nlex: <key terms, author names, method names>' -c "$QMD_PAPERS_COLLECTION" -n 8 --files
+  ```
+- `balanced`: hybrid search without LLM reranking; use when `quality` is too slow.
+  ```bash
+  ${QMD_CLI:-qmd} query $'vec: <topic or thesis of the source>\nlex: <key terms, author names, method names>' -c "$QMD_PAPERS_COLLECTION" -n 8 --no-rerank --files
+  ```
+- `fast`: semantic-only source discovery.
+  ```bash
+  ${QMD_CLI:-qmd} vsearch "<topic or thesis of the source>" -c "$QMD_PAPERS_COLLECTION" -n 8 --files
+  ```
+
+Use `${QMD_CLI:-qmd} get "#docid"` to retrieve a ranked source by docid when CLI output provides one.
 
 Use the returned snippets to:
 1. **Surface related papers** you may not have thought to link — add them as cross-references in the wiki page

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -15,9 +15,10 @@ You are answering questions against a compiled Obsidian wiki, not raw source doc
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`. Works from any project directory.
-2. If `$OBSIDIAN_VAULT_PATH/hot.md` exists, read it first — it gives you instant context on recent activity. If the user's question is about something ingested recently, hot.md may answer it before you even open `index.md`.
-3. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand the wiki's scope and structure
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). Prefer `~/.obsidian-wiki/config` for cross-project queries when present, even if it is a symlink to the vault `.env`. This gives `OBSIDIAN_VAULT_PATH` and any QMD variables. Works from any project directory.
+2. **Load QMD settings from the resolved config** before deciding retrieval strategy. If `QMD_WIKI_COLLECTION` is set, treat QMD as available subject only to transport/tool checks below. If it is empty or unset, say briefly why QMD is being skipped before using grep/page reads.
+3. If `$OBSIDIAN_VAULT_PATH/hot.md` exists, read it first — it gives you instant context on recent activity. If the user's question is about something ingested recently, hot.md may answer it before you even open `index.md`.
+4. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand the wiki's scope and structure
 
 ## Visibility Filter (optional)
 
@@ -64,18 +65,21 @@ Build a candidate set *without opening any page bodies*:
 
 If you're in **index-only mode**, stop here. Answer from `summary:` fields, titles, and `index.md` descriptions only. Label the answer clearly: **"(index-only answer — page bodies not read; facts below are from page summaries and may miss nuance)"**. Then skip to Step 5.
 
-### Step 2b: QMD Semantic Pass (optional — requires `QMD_WIKI_COLLECTION` in `.env`)
+### Step 2b: QMD Semantic Pass (optional — requires `QMD_WIKI_COLLECTION` in resolved config)
 
-**GUARD: If `$QMD_WIKI_COLLECTION` is empty or unset, skip this entire step and proceed to Step 3.**
+**GUARD: If `$QMD_WIKI_COLLECTION` is empty or unset after config resolution, skip this entire step and proceed to Step 3. Mention the missing variable in your working update.**
 
 > **No QMD?** Skip to Step 3 and use `Grep` directly on the vault. QMD is faster and concept-aware but the grep path is fully functional. See `.env.example` for setup.
 
-If `QMD_WIKI_COLLECTION` is set and the index pass didn't produce clear candidates — or the question requires semantic matching rather than exact terms — use QMD before reaching for `Grep`:
+If `QMD_WIKI_COLLECTION` is set, run QMD before reaching for `Grep` unless the question is already fully answered by `hot.md` or `index.md` metadata. QMD is especially preferred when the question is semantic, project-specific, asks for related context, or uses terms that may not appear verbatim in titles/frontmatter.
 
 Choose the QMD transport from `$QMD_TRANSPORT`:
 
 - `mcp` (default): use the QMD MCP tool configured in the agent.
 - `cli`: run the local qmd CLI. Use `$QMD_CLI` if set; otherwise use `qmd`.
+
+For detailed CLI command selection, maintenance, and VM caveats, use the local
+`$qmd-cli` skill when it is installed.
 
 If the selected transport is unavailable (no MCP tool, `qmd` not on PATH, or the command errors), skip QMD and continue with Step 3.
 
@@ -93,6 +97,8 @@ mcp__qmd__query:
 ```
 
 For CLI transport, pick the command from `$QMD_CLI_SEARCH_MODE`:
+
+Keep operator-like or punctuation-heavy tokens such as `no-sudo`, `ansible_become=false`, and `~/.local/bin` in the `lex:` line. Rewrite the `vec:` line as plain natural language without hyphenated `-term` words; QMD treats `-term` as negation, and negation is not supported in `vec`/`hyde` queries.
 
 - `quality` (default): best relevance; slower on CPU.
   ```bash

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -72,6 +72,15 @@ If you're in **index-only mode**, stop here. Answer from `summary:` fields, titl
 
 If `QMD_WIKI_COLLECTION` is set and the index pass didn't produce clear candidates — or the question requires semantic matching rather than exact terms — use QMD before reaching for `Grep`:
 
+Choose the QMD transport from `$QMD_TRANSPORT`:
+
+- `mcp` (default): use the QMD MCP tool configured in the agent.
+- `cli`: run the local qmd CLI. Use `$QMD_CLI` if set; otherwise use `qmd`.
+
+If the selected transport is unavailable (no MCP tool, `qmd` not on PATH, or the command errors), skip QMD and continue with Step 3.
+
+For MCP transport:
+
 ```
 mcp__qmd__query:
   collection: <QMD_WIKI_COLLECTION>   # e.g. "knowledge-base-wiki"
@@ -83,7 +92,24 @@ mcp__qmd__query:
       query: <question rephrased as a description>
 ```
 
-The returned snippets act as pre-read section summaries. If they answer the question fully, skip Step 3 and go straight to Step 4 (reading only the pages QMD ranked highest). If not, use the ranked file list to guide which files to grep or read in Step 3.
+For CLI transport, pick the command from `$QMD_CLI_SEARCH_MODE`:
+
+- `quality` (default): best relevance; slower on CPU.
+  ```bash
+  ${QMD_CLI:-qmd} query $'lex: <key terms>\nvec: <question rephrased as a description>' -c "$QMD_WIKI_COLLECTION" -n 8 --files
+  ```
+- `balanced`: hybrid search without LLM reranking; use when `quality` is too slow.
+  ```bash
+  ${QMD_CLI:-qmd} query $'lex: <key terms>\nvec: <question rephrased as a description>' -c "$QMD_WIKI_COLLECTION" -n 8 --no-rerank --files
+  ```
+- `fast`: semantic-only recall, or `search` instead when exact names, file paths, or error messages matter.
+  ```bash
+  ${QMD_CLI:-qmd} vsearch "<question rephrased as a description>" -c "$QMD_WIKI_COLLECTION" -n 8 --files
+  ```
+
+Use `${QMD_CLI:-qmd} get "#docid"` to retrieve a ranked document by docid when CLI output provides one.
+
+The returned snippets or ranked files act as pre-read section summaries. If they answer the question fully, skip Step 3 and go straight to Step 4 (reading only the pages QMD ranked highest). If not, use the ranked file list to guide which files to grep or read in Step 3.
 
 **Also search `papers` when the question may have source material in `_raw/`:**
 

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -28,8 +28,10 @@ If `.env` doesn't exist, create it from `.env.example`. Ask the user for:
    - Default: auto-discovers from `~/.claude`
    - Set explicitly if Claude data is elsewhere
 
-4. **Have QMD installed?** → `QMD_WIKI_COLLECTION` / `QMD_PAPERS_COLLECTION`
+4. **Have QMD installed?** → `QMD_WIKI_COLLECTION` / `QMD_PAPERS_COLLECTION` / `QMD_TRANSPORT`
    - Optional. Enables semantic search in `wiki-query` and source discovery in `wiki-ingest`.
+   - Default to `QMD_TRANSPORT=mcp` unless the user wants the agent to call the local `qmd` CLI directly.
+   - If using CLI mode, set `QMD_CLI_SEARCH_MODE=quality` by default; suggest `balanced` if reranking is too slow.
    - If unsure, skip for now — both skills fall back to `Grep` automatically.
    - Install instructions: see `.env.example` (QMD section).
 

--- a/README.md
+++ b/README.md
@@ -219,27 +219,31 @@ Modes: `by-tag` (default — top 10 tags), `by-category` (the seven vault folder
 
 - **Tiered retrieval.** `wiki-query` reads titles, tags, and page summaries first and only opens page bodies when the cheap pass can't answer. Say "quick answer" or "just scan" to force index-only mode. Keeps query cost roughly flat as your vault grows from 20 pages to 2000.
 
-- **QMD semantic search (optional).** [QMD](https://github.com/tobi/qmd) is a local MCP server that indexes your wiki and source documents for fast semantic search. When `QMD_WIKI_COLLECTION` is set in `.env`, `wiki-query` runs a lex+vec pass against the collection before falling back to Grep — enabling concept-level matches that exact-string search misses. When `QMD_PAPERS_COLLECTION` is set, `wiki-ingest` queries your indexed sources before writing a new page, surfacing related work, detecting contradictions, and deciding whether to create or merge. Without QMD, both skills fall back to Grep/Glob and remain fully functional.
+- **QMD semantic search (optional).** [QMD](https://github.com/tobi/qmd) indexes your wiki and source documents for semantic search. When `QMD_WIKI_COLLECTION` is set in `.env`, `wiki-query` runs a lex+vec pass against the collection before falling back to Grep — enabling concept-level matches that exact-string search misses. When `QMD_PAPERS_COLLECTION` is set, `wiki-ingest` queries your indexed sources before writing a new page, surfacing related work, detecting contradictions, and deciding whether to create or merge. QMD can be used through MCP or the local CLI. Without QMD, both skills fall back to Grep/Glob and remain fully functional.
 
 - **`_raw/` staging directory.** Drop rough notes, clipboard pastes, or quick captures into `_raw/` inside your vault. The next `wiki-ingest` run promotes them to proper wiki pages and removes the originals. Configured via `OBSIDIAN_RAW_DIR` in `.env` (defaults to `_raw`).
 
 ## Optional: QMD Semantic Search
 
-By default, `wiki-ingest` and `wiki-query` use `Grep`/`Glob` for search — fully functional, no extra setup. If your vault grows large or you want concept-level matches across your sources, you can plug in [QMD](https://github.com/tobi/qmd): a local MCP server that runs lex+vec queries against indexed collections.
+By default, `wiki-ingest` and `wiki-query` use `Grep`/`Glob` for search — fully functional, no extra setup. If your vault grows large or you want concept-level matches across your sources, you can plug in [QMD](https://github.com/tobi/qmd), either through MCP or by letting the agent call the local `qmd` CLI.
 
 **Setup:**
 
-1. Install QMD and add it to your MCP config (see the QMD repo for instructions).
+1. Install QMD. If you want MCP mode, also add it to your MCP config (see the QMD repo for instructions).
 2. Index your wiki and/or source documents:
    ```bash
    qmd index --name wiki /path/to/your/vault
    qmd index --name papers /path/to/your/sources
    ```
-3. Set the collection names in your `.env`:
+3. Set the collection names and transport in your `.env`:
    ```env
-   QMD_WIKI_COLLECTION=wiki      # used by wiki-query
-   QMD_PAPERS_COLLECTION=papers  # used by wiki-ingest (source discovery)
+   QMD_WIKI_COLLECTION=wiki       # used by wiki-query
+   QMD_PAPERS_COLLECTION=papers   # used by wiki-ingest (source discovery)
+   QMD_TRANSPORT=mcp              # mcp | cli
+   QMD_CLI_SEARCH_MODE=quality    # quality | balanced | fast
    ```
+
+`QMD_TRANSPORT=mcp` preserves the original behavior and uses an agent-configured QMD MCP server. `QMD_TRANSPORT=cli` runs the local `qmd` command directly. CLI mode defaults to `quality`, which uses `qmd query` with reranking for the best relevance. If that is too slow on CPU, set `QMD_CLI_SEARCH_MODE=balanced` to use `qmd query --no-rerank`, or `fast` for a lighter semantic pass.
 
 **What changes with QMD enabled:**
 


### PR DESCRIPTION
## Summary
- add `QMD_TRANSPORT`, `QMD_CLI_SEARCH_MODE`, and `QMD_CLI` config options
- document MCP vs CLI QMD usage in `.env.example`, README, and setup guidance
- teach `wiki-ingest` and `wiki-query` how to use the local `qmd` CLI when MCP is unavailable
- make `wiki-query` load QMD settings from the resolved config and prefer QMD before grep when configured
- document keeping operator-like terms in `lex:` and using natural language for `vec:` queries

## Why CLI mode
- lower agent token usage: the agent can call `qmd` directly and consume compact ranked results instead of loading broader wiki content first
- simpler setup for agents without MCP support: no MCP server wiring is required when `qmd` is already installed locally
- fewer runtime dependencies: CLI mode relies on the existing `qmd` binary and configured collections rather than an agent-specific MCP integration

## Test
- ran a local `qmd query` smoke test from outside the vault using `QMD_TRANSPORT=cli`-style settings
- verified the lex+vec query returned ranked wiki files before any page-body grep was needed
- confirmed a hyphenated `vec:` term can be parsed as negation and that rewriting the vector query in plain language succeeds