### PR TITLE
feat: typed relationships in page frontmatter (llm-wiki + cross-linker + wiki-export + wiki-ingest)

### DIFF
--- a/.skills/cross-linker/SKILL.md
+++ b/.skills/cross-linker/SKILL.md
@@ -156,7 +156,7 @@ relationships:
     type: uses
 ```
 
-Use the same link format (`wikilink` or `markdown`) determined by `OBSIDIAN_LINK_FORMAT`.
+Always use wikilink format (`[[path/to/page]]`) for `target` values in the `relationships:` YAML block — regardless of `OBSIDIAN_LINK_FORMAT`. The `OBSIDIAN_LINK_FORMAT` setting controls body content; frontmatter properties always use wikilink syntax so that `wiki-export` can reliably parse them.
 
 Only add entries for links added in this cross-linker run — do not touch typed entries that were already present.
 

--- a/.skills/cross-linker/SKILL.md
+++ b/.skills/cross-linker/SKILL.md
@@ -128,6 +128,38 @@ If the term isn't mentioned naturally in the body but the pages are semantically
 
 If a `## Related` section already exists, append to it. Don't duplicate existing entries.
 
+### 4c: Infer and write relationship type
+
+For every EXTRACTED or INFERRED link added (inline or related section), infer a semantic relationship type from the surrounding sentence context and write it to the page's `relationships:` frontmatter block. Skip AMBIGUOUS links.
+
+**Type inference rules** — scan the sentence containing the mention (or, for related-section links, the page title and shared-tag context):
+
+| Sentence pattern | Inferred type |
+|---|---|
+| "X extends / builds on / generalises Y" | `extends` |
+| "X implements / is an implementation of Y" | `implements` |
+| "X contradicts / opposes / refutes / is at odds with Y" | `contradicts` |
+| "X is derived from / based on / adapted from Y" | `derived_from` |
+| "X uses / relies on / depends on / requires Y" | `uses` |
+| "X replaces / supersedes / deprecates Y" | `replaces` |
+| Shared tags or cross-category inference with no directional cue | `related_to` |
+
+If the surrounding context is ambiguous or the link came from shared-tag matching (no in-body mention), default to `related_to`.
+
+**Writing the block:**
+
+Read the page's YAML frontmatter. If a `relationships:` block already exists, append new entries without duplicating existing targets. If the block is absent, add it after `aliases:` (or after `tags:` when `aliases:` is missing).
+
+```yaml
+relationships:
+  - target: "[[concepts/knowledge-graphs]]"
+    type: uses
+```
+
+Use the same link format (`wikilink` or `markdown`) determined by `OBSIDIAN_LINK_FORMAT`.
+
+Only add entries for links added in this cross-linker run — do not touch typed entries that were already present.
+
 ## Step 5: Score Misc Page Affinity
 
 After the main linking pass, update affinity scores for all pages in `misc/` (pages with `promotion_status: misc` in their frontmatter, or located under the `misc/` directory).
@@ -161,11 +193,11 @@ Present a summary:
 
 ### Links Added: 23 across 12 pages
 
-| Page | Links Added | Confidence | Type |
-|---|---|---|---|
-| `projects/my-project/my-project.md` | 3 | EXTRACTED | 2 inline, 1 related |
-| `entities/jane-doe.md` | 5 | INFERRED | 3 inline, 2 related |
-| ... | | | |
+| Page | Links Added | Confidence | Placement | Relationship Types |
+|---|---|---|---|---|
+| `projects/my-project/my-project.md` | 3 | EXTRACTED | 2 inline, 1 related | uses ×2, related_to ×1 |
+| `entities/jane-doe.md` | 5 | INFERRED | 3 inline, 2 related | extends ×1, uses ×3, related_to ×1 |
+| ... | | | | |
 
 ### Orphan Pages Remaining: 2
 - `references/foo.md` — no incoming or outgoing links found
@@ -189,7 +221,7 @@ To promote: move the page to `projects/<project-name>/references/` and update al
 
 Append to `log.md`:
 ```
-- [TIMESTAMP] CROSS_LINK pages_scanned=N links_added=M pages_modified=P orphans_remaining=Q misc_affinity_updated=R promotion_candidates=S
+- [TIMESTAMP] CROSS_LINK pages_scanned=N links_added=M typed_relations_written=T pages_modified=P orphans_remaining=Q misc_affinity_updated=R promotion_candidates=S
 ```
 
 **`hot.md`** — Read `$OBSIDIAN_VAULT_PATH/hot.md` (create from the template in `wiki-ingest` if missing). Update **Recent Activity** with a one-line summary of what was linked — e.g. "Cross-linked 23 mentions across 12 pages; 2 orphans remain." Keep the last 3 operations. Update `updated` timestamp.

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -159,6 +159,9 @@ title: Page Title
 category: concepts
 tags: [ml, architecture]
 aliases: [alternate name]
+relationships:
+  - target: "[[concepts/related-concept]]"
+    type: extends
 sources: [papers/attention.pdf]
 summary: One or two sentences, ≤200 chars, so a reader (or another skill) can preview this page without opening it.
 provenance:
@@ -226,6 +229,47 @@ provenance:
 ```
 
 These are best-effort numbers written by the ingest skill at create/update time. `wiki-lint` recomputes them and flags drift. The block is optional — pages without it are treated as fully extracted by convention.
+
+## Typed Relationships
+
+Plain `[[wikilinks]]` in page bodies carry no semantic weight — they indicate "related to" but not *how*. The optional `relationships:` frontmatter block adds typed, directional edges to the knowledge graph.
+
+### The `relationships:` block
+
+```yaml
+relationships:
+  - target: "[[Transformer Architecture]]"
+    type: extends
+  - target: "[[LSTM]]"
+    type: contradicts
+  - target: "[[Attention Mechanism]]"
+    type: implements
+```
+
+Each entry has two required fields:
+- `target` — a wikilink (using the same format as `OBSIDIAN_LINK_FORMAT`) to the related page
+- `type` — one of the allowed semantic types below
+
+### Allowed relationship types
+
+| Type | Meaning | Example |
+|---|---|---|
+| `extends` | This page builds on or generalises the target | GPT extends Transformer Architecture |
+| `implements` | This page is a concrete realisation of the target concept | BERT implements Masked Language Modelling |
+| `contradicts` | This page's claims conflict with or refute the target | Evidence A contradicts Evidence B |
+| `derived_from` | This page is based on or adapted from the target | Fine-tuning is derived from Transfer Learning |
+| `uses` | This page depends on or relies on the target | RAG uses Vector Databases |
+| `replaces` | This page supersedes or deprecates the target | GPT-4 replaces GPT-3 |
+| `related_to` | Catch-all: related but no stronger directional type applies | Concept A is related to Concept B |
+
+### Rules
+
+- **Optional field** — omit the block entirely if no typed relationships are known. Untagged wikilinks remain valid and are treated as `related_to` by `wiki-export`.
+- **Don't duplicate** — if `[[foo]]` already appears as an inline wikilink, the `relationships:` entry just enriches it with a type; it is not a second link.
+- **Direction matters** — the page declaring the entry is the *source*; `target` is the destination. Only declare relationships from this page's perspective.
+- **Don't fabricate** — only add a typed entry when the source material makes the relationship direction and type clear. When in doubt, use `related_to` or omit.
+
+Skills that read `relationships:`: `wiki-export` (emits typed edges), `cross-linker` (writes typed entries when inferring links), `wiki-query` (may surface type in answers).
 
 ## Confidence and Lifecycle
 

--- a/.skills/wiki-export/SKILL.md
+++ b/.skills/wiki-export/SKILL.md
@@ -51,7 +51,7 @@ For each page, Grep the body for `\[\[.*?\]\]` to extract all wikilinks:
 - If the linking sentence ends with `^[inferred]` or `^[ambiguous]`, override `confidence` accordingly
 
 **Typed edge enrichment:** After building the wikilink edge list, read each page's `relationships:` frontmatter block. For each `{target, type}` entry:
-- Resolve the target wikilink to a node id (same normalization as above)
+- The `target` YAML value is a quoted wikilink string such as `"[[concepts/lstm]]"`. Strip the surrounding `[[` and `]]` characters, then apply the same normalization (lowercase, spaces→hyphens, strip `.md`) to get the node id.
 - Skip entries whose resolved target is not in the node list (broken link)
 - If an edge for this `(source, target)` pair already exists, override its `relation` field with the typed value (e.g., `"contradicts"`) and set `typed: true`
 - If no edge exists yet for this pair, add one: `{source: page_id, target: target_id, relation: <type>, confidence: "EXTRACTED", typed: true}`

--- a/.skills/wiki-export/SKILL.md
+++ b/.skills/wiki-export/SKILL.md
@@ -50,6 +50,14 @@ For each page, Grep the body for `\[\[.*?\]\]` to extract all wikilinks:
 - Each resolved link becomes an edge: `{source: page_id, target: linked_id, relation: "wikilink", confidence: "EXTRACTED"}`
 - If the linking sentence ends with `^[inferred]` or `^[ambiguous]`, override `confidence` accordingly
 
+**Typed edge enrichment:** After building the wikilink edge list, read each page's `relationships:` frontmatter block. For each `{target, type}` entry:
+- Resolve the target wikilink to a node id (same normalization as above)
+- Skip entries whose resolved target is not in the node list (broken link)
+- If an edge for this `(source, target)` pair already exists, override its `relation` field with the typed value (e.g., `"contradicts"`) and set `typed: true`
+- If no edge exists yet for this pair, add one: `{source: page_id, target: target_id, relation: <type>, confidence: "EXTRACTED", typed: true}`
+
+This means `relation: "wikilink"` is the default for plain untyped links; a `relationships:` entry promotes it to a named semantic type. Edges that originated from both a body wikilink and a `relationships:` entry keep a single record — the typed version wins.
+
 This is your **edge list**.
 
 ## Step 2: Assign Community IDs
@@ -98,6 +106,13 @@ NetworkX node_link format — standard for graph tools and scripts:
       "target": "entities/vaswani",
       "relation": "wikilink",
       "confidence": "EXTRACTED"
+    },
+    {
+      "source": "concepts/transformers",
+      "target": "concepts/lstm",
+      "relation": "contradicts",
+      "confidence": "EXTRACTED",
+      "typed": true
     }
   ]
 }
@@ -117,6 +132,7 @@ GraphML XML format — loadable in Gephi, yEd, and Cytoscape:
   <key id="tags" for="node" attr.name="tags" attr.type="string"/>
   <key id="community" for="node" attr.name="community" attr.type="int"/>
   <key id="relation" for="edge" attr.name="relation" attr.type="string"/>
+  <key id="type" for="edge" attr.name="type" attr.type="string"/>
   <key id="confidence" for="edge" attr.name="confidence" attr.type="string"/>
   <graph id="wiki" edgedefault="undirected">
     <node id="concepts/transformers">
@@ -125,15 +141,22 @@ GraphML XML format — loadable in Gephi, yEd, and Cytoscape:
       <data key="tags">ml, architecture</data>
       <data key="community">0</data>
     </node>
+    <!-- Untyped wikilink — no <data key="type"> element -->
     <edge source="concepts/transformers" target="entities/vaswani">
       <data key="relation">wikilink</data>
+      <data key="confidence">EXTRACTED</data>
+    </edge>
+    <!-- Typed edge from relationships: block -->
+    <edge source="concepts/transformers" target="concepts/lstm">
+      <data key="relation">contradicts</data>
+      <data key="type">contradicts</data>
       <data key="confidence">EXTRACTED</data>
     </edge>
   </graph>
 </graphml>
 ```
 
-Write one `<node>` per page and one `<edge>` per wikilink.
+Write one `<node>` per page and one `<edge>` per link. For typed edges (those where `typed: true` in the edge list), emit both `<data key="relation">` with the semantic type value **and** `<data key="type">` with the same value — this keeps `relation` readable for tools that already consume it while letting type-aware tools filter on the dedicated `type` key. Untyped wikilinks omit the `<data key="type">` element entirely.
 
 ---
 
@@ -148,12 +171,16 @@ Neo4j Cypher `MERGE` statements — paste into Neo4j Browser or run with `cypher
 // Nodes
 MERGE (n:Page {id: "concepts/transformers"}) SET n.label = "Transformer Architecture", n.category = "concepts", n.tags = ["ml","architecture"], n.community = 0;
 MERGE (n:Page {id: "entities/vaswani"}) SET n.label = "Ashish Vaswani", n.category = "entities", n.tags = ["person","ml"], n.community = 0;
+MERGE (n:Page {id: "concepts/lstm"}) SET n.label = "LSTM", n.category = "concepts", n.tags = ["ml","rnn"], n.community = 0;
 
 // Relationships
+// Untyped wikilinks use [:WIKILINK]
 MATCH (a:Page {id: "concepts/transformers"}), (b:Page {id: "entities/vaswani"}) MERGE (a)-[:WIKILINK {relation: "wikilink", confidence: "EXTRACTED"}]->(b);
+// Typed edges use the relationship type as the label (UPPERCASE)
+MATCH (a:Page {id: "concepts/transformers"}), (b:Page {id: "concepts/lstm"}) MERGE (a)-[:CONTRADICTS {relation: "contradicts", confidence: "EXTRACTED"}]->(b);
 ```
 
-Write one `MERGE` node statement per page, then one `MATCH`/`MERGE` relationship statement per edge.
+Write one `MERGE` node statement per page, then one `MATCH`/`MERGE` relationship statement per edge. For typed edges, use the `type` value uppercased as the Cypher relationship label (e.g., `contradicts` → `[:CONTRADICTS]`, `derived_from` → `[:DERIVED_FROM]`). Untyped wikilinks always use `[:WIKILINK]`.
 
 ---
 
@@ -173,10 +200,26 @@ Build the HTML file by:
 
 2. Generating a JSON array of edge objects for vis.js:
 ```js
-{from: "concepts/transformers", to: "entities/vaswani", dashes: false, width: 1, color: {color: "#666", opacity: 0.6}}
+// Untyped wikilink
+{from: "concepts/transformers", to: "entities/vaswani", dashes: false, width: 1, color: {color: "#666", opacity: 0.6}, title: "wikilink"}
+// Typed edge
+{from: "concepts/transformers", to: "concepts/lstm", dashes: false, width: 2, color: {color: "#E15759", opacity: 0.8}, label: "contradicts", font: {size: 9, color: "#ccc"}, title: "contradicts"}
 ```
 - `dashes: true` for INFERRED edges
 - `dashes: [4,8]` for AMBIGUOUS edges
+- **Typed edges** (`typed: true`): set `width: 2`, add a `label` field showing the type, and apply a type-specific color:
+
+| Type | Edge color |
+|---|---|
+| `extends` | `#59A14F` (green) |
+| `implements` | `#4E79A7` (blue) |
+| `contradicts` | `#E15759` (red) |
+| `derived_from` | `#F28E2B` (orange) |
+| `uses` | `#76B7B2` (teal) |
+| `replaces` | `#B07AA1` (purple) |
+| `related_to` | `#BAB0AC` (grey — same as untyped) |
+
+Untyped `wikilink` edges keep the existing `#666` grey color and no label.
 
 3. Writing the full HTML file:
 

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -155,7 +155,7 @@ From the source, identify:
 - **Key concepts** that deserve their own page or belong on an existing one
 - **Entities** (people, tools, projects, organizations) mentioned
 - **Claims** that can be attributed to the source
-- **Relationships** between concepts (what connects to what)
+- **Relationships** between concepts — note the *type* when the source text makes it clear. Use the allowed types from `llm-wiki/SKILL.md` (Typed Relationships section): `extends`, `implements`, `contradicts`, `derived_from`, `uses`, `replaces`, `related_to`. Record: source page, target page, inferred type.
 - **Open questions** the source raises but doesn't answer
 
 **Track provenance per claim as you go.** For each claim you extract, mentally tag it as:
@@ -198,6 +198,16 @@ For each page in your plan:
 - Update the `updated` timestamp in frontmatter
 - Add the new source to the `sources` list
 - Resolve any contradictions between old and new information (note them if unresolvable)
+
+**Populate `relationships:` when context is clear** — if Step 2 identified typed relationships between this page and another, add a `relationships:` block to the frontmatter (defined in `llm-wiki/SKILL.md`, Typed Relationships section). Only add entries where the source text makes the direction and type unambiguous. When in doubt, use `related_to` or omit the block. Example:
+
+```yaml
+relationships:
+  - target: "[[concepts/attention-mechanism]]"
+    type: uses
+  - target: "[[concepts/lstm]]"
+    type: contradicts
+```
 
 **Write a `summary:` frontmatter field** on every new page (1–2 sentences, ≤200 characters) answering "what is this page about?" for a reader who hasn't opened it. When updating an existing page whose meaning has shifted, rewrite the summary to match the new content. This field is what `wiki-query`'s cheap retrieval path reads — a missing or stale summary forces expensive full-page reads.
 
@@ -292,6 +302,7 @@ After ingesting, verify:
 - [ ] Source attribution is present for every new claim
 - [ ] Inferred and ambiguous claims are marked with `^[inferred]` / `^[ambiguous]`; `provenance:` frontmatter block is present on new and updated pages
 - [ ] Every new/updated page has a `summary:` frontmatter field (1–2 sentences, ≤200 chars)
+- [ ] `relationships:` block is present on pages where source text made typed connections clear; all entries use an allowed type from `llm-wiki/SKILL.md`
 
 ## Reference
 

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -239,6 +239,39 @@ Append to the `LINT` log entry:
 - [TIMESTAMP] LINT ... lifecycle_issues=N
 ```
 
+### 13. Typed Relationships Validity
+
+Validate `relationships:` frontmatter blocks. Skip pages that have no `relationships:` block — the field is optional.
+
+**Allowed types:** `extends`, `implements`, `contradicts`, `derived_from`, `uses`, `replaces`, `related_to`
+
+**How to check:**
+- Grep frontmatter for `^relationships:` across all vault pages
+- For each page that has a `relationships:` block, read its frontmatter (not the full page body)
+- For each entry in the block:
+  1. **Type validation** — flag any `type:` value not in the allowed set above
+  2. **Broken target** — strip `[[` and `]]` from the `target:` string, normalize (lowercase, spaces→hyphens, strip `.md`), and check whether a `.md` file at that path exists in the vault. Flag unresolved targets.
+  3. **Self-reference** — flag any entry where the resolved target equals the page's own node id
+
+**How to fix:**
+- Invalid type: correct the value to the nearest allowed type, or use `related_to` when the type is ambiguous
+- Broken target: update or remove the entry; if the target page should exist, create it first
+- Self-reference: remove the entry
+
+**Output additions:**
+
+```markdown
+### Typed Relationship Issues (N found)
+- `concepts/foo.md` — relationships[1]: type "contradication" is not an allowed type (did you mean "contradicts"?)
+- `concepts/bar.md` — relationships[0]: target "[[skills/nonexistent-skill]]" resolves to no page in vault
+- `entities/baz.md` — relationships[2]: self-reference (target resolves to this page's own id)
+```
+
+Append to the `LINT` log entry:
+```
+... relationship_issues=N
+```
+
 ### 11. Synthesis Gaps
 
 Identify high-value synthesis opportunities the wiki is missing — concept pairs that co-occur across many pages but have no `synthesis/` page connecting them.
@@ -308,6 +341,10 @@ Pages in misc/ that have ≥ 3 connections to a single project and are ready to 
 |---|---|---|
 | `misc/web-martinfowler-articles-microservices.md` | `obsidian-wiki` | 4 |
 
+### Typed Relationship Issues (N found)
+- `concepts/foo.md` — relationships[1]: type "contradication" is not an allowed type
+- `concepts/bar.md` — relationships[0]: target "[[skills/nonexistent]]" resolves to no page
+
 ### Synthesis Gaps (N found)
 Concept pairs that co-occur frequently but have no synthesis page:
 
@@ -321,7 +358,7 @@ Concept pairs that co-occur frequently but have no synthesis page:
 
 Append to `log.md`:
 ```
-- [TIMESTAMP] LINT issues_found=N orphans=X broken_links=Y stale=Z contradictions=W prov_issues=P missing_summary=S fragmented_clusters=F visibility_issues=V promotion_candidates=C synthesis_gaps=G
+- [TIMESTAMP] LINT issues_found=N orphans=X broken_links=Y stale=Z contradictions=W prov_issues=P missing_summary=S fragmented_clusters=F visibility_issues=V promotion_candidates=C synthesis_gaps=G relationship_issues=R
 ```
 
 Offer to fix issues automatically or let the user decide which to address.

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -43,7 +43,7 @@ In filtered mode, note the filter in the Step 6 log entry: `mode=filtered`.
 
 Classify the query type:
 - **Factual lookup** — "What is X?" → Find the relevant page(s)
-- **Relationship query** — "How does X relate to Y?" → Find both pages and their cross-references
+- **Relationship query** — "How does X relate to Y?" / "What contradicts X?" → Find both pages, their cross-references, and their `relationships:` frontmatter blocks for typed edges
 - **Synthesis query** — "What's the current thinking on X?" → Find all pages that touch X, synthesize
 - **Gap query** — "What don't I know about X?" → Find what's missing, check open questions sections
 
@@ -135,6 +135,7 @@ Only when Steps 2 and 3 don't answer the question:
 
 - `Read` the top **3** candidates in full.
 - Follow at most one hop of `[[wikilinks]]` from those pages if the answer requires cross-references.
+- **For relationship queries** ("How does X relate to Y?" / "What contradicts X?"): also read the `relationships:` frontmatter block of the candidate pages. Each entry gives a typed, directional edge (`extends`, `implements`, `contradicts`, `derived_from`, `uses`, `replaces`, `related_to`). Surface these explicitly in your answer — "Page A *contradicts* Page B (typed edge)" is more useful than "Page A links to Page B".
 - Check "Open Questions" sections for known gaps.
 - If you're still short, **then** fall back to a broad content grep across the vault. Tell the user you escalated — this is the expensive path and they should know.
 


### PR DESCRIPTION
Closes #43

## Summary

- **`llm-wiki`**: adds an optional `relationships:` frontmatter block to the page template and a new "Typed Relationships" section documenting all seven allowed types (`extends`, `implements`, `contradicts`, `derived_from`, `uses`, `replaces`, `related_to`), their meanings, and usage rules
- **`cross-linker`**: new Step 4c infers the semantic type from surrounding sentence context whenever a link is added (inline or related section), writes typed entries to the page's `relationships:` frontmatter block, surfaces type counts in the cross-link report, and emits a `typed_relations_written=T` counter in the log entry
- **`wiki-export`**: after building the wikilink edge list, enriches edges from `relationships:` blocks — typed edges use the semantic type as `relation` in `graph.json`, add `<data key="type">` in GraphML (backward-compatible: `relation` key still present), use the uppercased type as the Cypher relationship label (e.g. `[:CONTRADICTS]`), and render with type-specific colors + inline labels in the HTML vis
- **`wiki-ingest`**: Step 2 now records relationship types during knowledge extraction; Step 5 populates `relationships:` when source text makes the type unambiguous; quality checklist updated with a typed-relationships check

## Test plan

- [ ] Create a new wiki page using the `wiki-ingest` skill from a source that contains clear directional relationships (e.g., "GPT contradicts the LSTM approach to sequence modelling"). Verify that the resulting page frontmatter includes a `relationships:` block with `type: contradicts`.
- [ ] Run `cross-linker` on a vault that has unlinked mentions. Verify Step 4c fires: new `[[wikilinks]]` are added and corresponding `relationships:` entries appear in frontmatter with inferred types. Check the report table shows "Relationship Types" counts. Check `log.md` has `typed_relations_written=N`.
- [ ] Run `wiki-export` on a vault that has at least one page with a `relationships:` block. Open `graph.json` and confirm edges from the block have a non-`"wikilink"` `relation` field and `"typed": true`. Open `graph.graphml` and verify typed edges have `<data key="type">…</data>`. Open `cypher.txt` and verify typed edges use an uppercased label (e.g., `[:CONTRADICTS]`). Open `graph.html` in a browser and verify typed edges appear in their type-specific color with a label.
- [ ] Verify untyped plain wikilinks are still exported unchanged: `relation: "wikilink"` in JSON, no `<data key="type">` in GraphML, `[:WIKILINK]` in Cypher, grey unlabelled edge in HTML.
- [ ] Verify `relationships:` is optional — existing pages without the block continue to work in all four skills with no regressions.