### PR TITLE
feat(tiering): importance tier field (core/supporting/peripheral) across skills

### DIFF
--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -171,6 +171,7 @@ provenance:
 base_confidence: 0.65
 lifecycle: draft
 lifecycle_changed: 2024-03-15
+tier: supporting
 created: 2024-03-15T10:30:00Z
 updated: 2024-03-15T10:30:00Z
 ---
@@ -350,6 +351,33 @@ Five states. **`stale` is not a state** — it is a computed overlay: `is_stale 
 
 Only ingest skills set `draft`. All other transitions require a human editor. Update `lifecycle_changed` whenever the state changes.
 
+## Importance Tiering
+
+The `tier:` field controls which pages get updated on each ingest pass and their priority in retrieval. As wikis grow, re-reading every page on every ingest wastes tokens — tiering lets ingest and query skills focus effort where it matters most.
+
+### Three tiers
+
+| Tier | Meaning | Ingest behavior | Query priority |
+|---|---|---|---|
+| `core` | Load-bearing pages — many other pages depend on them (high incoming-link count or bridge position). Always worth updating. | Always update if the source is even marginally relevant | Surfaced first in index and full-read passes |
+| `supporting` *(default)* | Standard wiki pages with moderate connectivity | Update when the source has clear new claims for this page | Standard priority |
+| `peripheral` | Low-connectivity pages — rarely linked, narrowly scoped | Skip unless the source is *primarily* about this topic | Last resort; skipped when trimming to context budget |
+
+### Assignment rules
+
+- **New pages:** default to `tier: supporting`
+- **Promote to `core`:** when a page accumulates ≥5 incoming wikilinks **or** is flagged as a bridge by `wiki-status` insights mode
+- **Demote to `peripheral`:** when a page has ≤1 incoming link and hasn't been updated in 90+ days
+- **Human override always wins** — edit `tier:` manually to lock a page at any level
+- Existing pages without `tier:` are treated as `supporting` (backward compatible — no migration needed)
+
+### Who manages tier
+
+- `wiki-ingest` reads `tier:` to decide whether to update a page on the current pass
+- `wiki-query` uses `tier:` to order candidates in the index pass and trim to context budget
+- `wiki-status` insights mode computes graph metrics and **suggests** tier assignments — it never writes them automatically
+- `wiki-lint` flags missing `tier:` on newly created pages (Phase 2 enforcement, same timeline as `base_confidence`)
+
 ## Retrieval Primitives
 
 Reading the vault is the dominant cost of every read-side skill. Use the cheapest primitive that can answer the question and **escalate only when the cheaper one is insufficient**. Any skill that needs content from the vault should follow this table rather than jumping straight to full-page reads.
@@ -461,6 +489,8 @@ The wiki is configured through environment variables (see `.env.example`). The o
 - `OPENCLAW_HOME` — Where to find OpenClaw data
 - `COPILOT_HISTORY_PATH` — Where to find Copilot session data
 - `OBSIDIAN_LINK_FORMAT` — Internal link syntax: `wikilink` (default) or `markdown`
+- `WIKI_TOKEN_WARN_THRESHOLD` — Emit a warning in `wiki-status` when the full-wiki token estimate exceeds this value (default: `100000`). Set to `0` to disable. See `wiki-status` for the token footprint report.
+- `WIKI_STAGED_WRITES` — When `true`, all LLM-written pages go to `_staging/<category>/` for human review before promotion. See `wiki-setup` and `wiki-stage-commit` for details.
 
 No API keys are needed — the agent running these skills already has LLM access built in.
 

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -182,6 +182,16 @@ Before writing anything, plan which pages to update or create. Aim for 10-15 pag
 - If it's new, which category does it belong in?
 - What `[[wikilinks]]` should connect it to existing pages?
 
+**Apply tier-aware filtering to existing pages** (see `llm-wiki/SKILL.md`, Importance Tiering section):
+
+| Tier | Update decision |
+|---|---|
+| `core` | Always update if the source is even marginally relevant to this page |
+| `supporting` *(default)* | Update only when the source has clear new claims for this page |
+| `peripheral` | Skip unless this source is *primarily* about this specific topic |
+
+Pages without a `tier:` field are treated as `supporting`. When in doubt, err toward updating — the tier is a cost-control hint, not a hard lock.
+
 ### Step 5: Write/Update Pages
 
 For each page in your plan:
@@ -217,6 +227,7 @@ relationships:
 base_confidence: <computed>   # [0.0, 1.0] — see llm-wiki/SKILL.md Confidence formula
 lifecycle: draft
 lifecycle_changed: "<ISO date today>"
+tier: supporting              # default for new pages; promote to core when ≥5 incoming links
 ```
 
 Compute `base_confidence` using the formula from `llm-wiki/SKILL.md` (Confidence and Lifecycle section):

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -62,6 +62,7 @@ Build a candidate set *without opening any page bodies*:
   2. Tag match
   3. Summary field contains the query term
   4. `index.md` entry contains the query term
+- **Apply tier ordering within each rank bucket:** when two candidates score equally, prefer `tier: core` over `tier: supporting` over `tier: peripheral`. Read the `tier:` frontmatter field with the same cheap grep as other fields. Pages without a `tier:` field are treated as `supporting`.
 
 If you're in **index-only mode**, stop here. Answer from `summary:` fields, titles, and `index.md` descriptions only. Label the answer clearly: **"(index-only answer — page bodies not read; facts below are from page summaries and may miss nuance)"**. Then skip to Step 5.
 
@@ -133,7 +134,7 @@ For each of the top candidates, pull the relevant section *without reading the w
 
 Only when Steps 2 and 3 don't answer the question:
 
-- `Read` the top **3** candidates in full.
+- `Read` the top **3** candidates in full. When choosing which 3 to read, apply tier ordering: read `core` pages before `supporting`, and skip `peripheral` pages unless they are the only match.
 - Follow at most one hop of `[[wikilinks]]` from those pages if the answer requires cross-references.
 - **For relationship queries** ("How does X relate to Y?" / "What contradicts X?"): also read the `relationships:` frontmatter block of the candidate pages. Each entry gives a typed, directional edge (`extends`, `implements`, `contradicts`, `derived_from`, `uses`, `replaces`, `related_to`). Surface these explicitly in your answer — "Page A *contradicts* Page B (typed edge)" is more useful than "Page A links to Page B".
 - Check "Open Questions" sections for known gaps.

--- a/.skills/wiki-status/SKILL.md
+++ b/.skills/wiki-status/SKILL.md
@@ -292,7 +292,19 @@ You'll reuse this graph across all sections below.
    - Flag: pages that lost incoming links since last run ("link target may have been renamed: A, B")
    - If no previous snapshot exists, skip this section
 
-8. **Suggested questions.** Questions this wiki structure is uniquely positioned to answer — or that reveal gaps:
+8. **Tier assignment suggestions.** After computing hubs and bridges, recommend `tier:` changes. Never write `tier:` to pages — only surface suggestions so the human can decide.
+   - **Promote to `core`:** pages with ≥5 incoming links OR top-5 bridge position that currently have `tier: supporting` or no `tier:` field
+   - **Demote to `peripheral`:** pages with ≤1 incoming link AND not updated in 90+ days that currently have `tier: supporting` or `tier: core`
+   - Show up to 10 suggestions (promotions first, then demotions), formatted as:
+     ```
+     Tier Suggestions:
+     ↑ core    [[concepts/attention-mechanism]] — 14 incoming links, currently tier=supporting
+     ↑ core    [[entities/andrej-karpathy]]     — bridge (3 cluster pairs), currently unset
+     ↓ peripheral [[concepts/old-concept]]       — 0 incoming, 120 days stale
+     ```
+   - If all high-link pages already have `tier: core` and all low-link pages have `tier: peripheral`, emit: "Tier assignments look healthy — no changes suggested."
+
+9. **Suggested questions.** Questions this wiki structure is uniquely positioned to answer — or that reveal gaps:
    - From `^[ambiguous]` claims: "Resolve: What is the exact relationship between `X` and `Y`?"
    - From bridge pages: "Explore: Why does `P` connect `[cluster-A]` to `[cluster-B]`?"
    - From pages with zero incoming links: "Link: `X` has no incoming links — what should reference it?"
@@ -342,6 +354,11 @@ Write the result to `_insights.md` at the vault root. Overwrite freely — it's 
 - Newly connected: [[concepts/bar]], [[entities/baz]]
 - Lost incoming links: [[references/old-paper]] (target may have been renamed)
 
+## Tier Suggestions
+↑ core    [[concepts/attention-mechanism]] — 14 incoming links, currently tier=supporting
+↑ core    [[entities/andrej-karpathy]]     — top bridge (4 cluster pairs), currently unset
+↓ peripheral [[concepts/old-concept]]       — 0 incoming, 132 days stale
+
 ## Questions Worth Asking
 1. Resolve: What is the exact relationship between `scaling-laws` and `moore's-law`? (^[ambiguous] claim)
 2. Explore: Why does `exponential-growth` bridge #ml and #economics?
@@ -353,7 +370,7 @@ Write the result to `_insights.md` at the vault root. Overwrite freely — it's 
 
 After writing the file, append to `log.md`:
 ```
-- [TIMESTAMP] STATUS_INSIGHTS anchors=10 bridges=N cohesion_checked=T surprising=5 questions=7 delta="+N pages +M links"
+- [TIMESTAMP] STATUS_INSIGHTS anchors=10 bridges=N cohesion_checked=T surprising=5 questions=7 delta="+N pages +M links" tier_suggestions=N
 ```
 
 ### When to skip


### PR DESCRIPTION
## Summary

- Adds `tier:` field to the `llm-wiki` page template (default: `supporting`), with full documentation of all three tiers and assignment rules
- `wiki-ingest` Step 4 now applies tier-aware filtering: `core` always updated, `supporting` only when clear new claims exist, `peripheral` skipped unless source is primarily about that topic
- `wiki-query` index pass now orders candidates by `tier:` within each rank bucket; full-read step prefers `core` before `supporting`, skips `peripheral`
- `wiki-status` insights mode adds a new "Tier Suggestions" section (item 8) that recommends promotions/demotions based on graph metrics — never writes automatically
- Also documents `WIKI_TOKEN_WARN_THRESHOLD` and `WIKI_STAGED_WRITES` env vars in `llm-wiki` (used by #46 and #49)
- Backward compatible: pages without `tier:` treated as `supporting`

Closes #45

## Test plan

- [ ] New page template in `llm-wiki` includes `tier: supporting`
- [ ] Existing pages without `tier:` still treated as `supporting` (no migration needed)
- [ ] `wiki-ingest` skips `peripheral` pages when source is not primarily about them
- [ ] `wiki-query` returns `core` pages before `supporting` for same-relevance matches
- [ ] `wiki-status` insights mode emits a "Tier Suggestions" section with promotions/demotions
- [ ] Insights mode never writes `tier:` to any page