### PR TITLE
feat: staged writes mode (WIKI_STAGED_WRITES) with wiki-stage-commit skill

### DIFF
--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -15,10 +15,11 @@ You are ingesting source documents into an Obsidian wiki. Your job is not to sum
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`). Only read the specific variables you need — do not log, echo, or reference any other values from these files.
-2. Read `.manifest.json` at the vault root to check what's already been ingested
-3. Read `index.md` to understand current wiki content
-4. Read `log.md` to understand recent activity
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `OBSIDIAN_LINK_FORMAT` (default: `wikilink`), and `WIKI_STAGED_WRITES`. Only read the specific variables you need — do not log, echo, or reference any other values from these files.
+2. **Check `WIKI_STAGED_WRITES`** — if set to `true`, all new and updated category pages go to `_staging/<category>/` instead of their final location. Tell the user at the start of the ingest: "Staged writes mode is enabled — pages will land in `_staging/` for your review. Run `/wiki-stage-commit` when ready to promote."
+3. Read `.manifest.json` at the vault root to check what's already been ingested
+4. Read `index.md` to understand current wiki content
+5. Read `log.md` to understand recent activity
 
 When writing internal links in Step 5, apply the link format described in `llm-wiki/SKILL.md` (Link Format section) according to the `OBSIDIAN_LINK_FORMAT` value you read.
 
@@ -195,6 +196,34 @@ Pages without a `tier:` field are treated as `supporting`. When in doubt, err to
 ### Step 5: Write/Update Pages
 
 For each page in your plan:
+
+**If `WIKI_STAGED_WRITES=true`, apply the staging rules below before writing anything:**
+
+- **New pages** go to `_staging/<category>/page.md` instead of `<category>/page.md`. The page content is identical to what it would be in the live wiki — only the location differs.
+- **Updates to existing pages** go to `_staging/<category>/page.patch.md`. The patch file format:
+  ```markdown
+  ---
+  title: <same as target page>
+  patch_target: <category>/page.md
+  ingested_at: <ISO timestamp>
+  source: <source path>
+  ---
+  # Proposed Update: <page title>
+
+  ## Additions
+  <new paragraphs/bullets to merge into the page>
+
+  ## Deletions
+  <lines to remove, verbatim from current page>
+
+  ## Updated Fields
+  updated: <new ISO timestamp>
+  sources: [<new source added>]
+  ```
+- `index.md` and `log.md` are always updated immediately (low-risk tracking files). `hot.md` notes that staged writes are pending.
+- When writing staged pages, use the path `_staging/<category>/` — create the directory if it doesn't exist.
+
+**If `WIKI_STAGED_WRITES` is not set or is `false` (default):**
 
 **If creating a new page:**
 - Use the page template from the llm-wiki skill (frontmatter + sections)

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -40,16 +40,23 @@ If `.env` doesn't exist, create it from `.env.example`. Ask the user for:
    - Set to `0` to disable the warning entirely
    - `wiki-status` shows a token footprint table and emits this warning automatically
 
+6. **Enable staged writes?** → `WIKI_STAGED_WRITES`
+   - Default: unset / `false` (pages written directly to their final location)
+   - Set to `true` for team wikis, high-stakes domains, or any vault where the human wants final say on every LLM-written page
+   - When enabled: all new/updated pages land in `_staging/` first; run `/wiki-stage-commit` to review and promote them
+   - `wiki-status` shows a "Staged writes pending" count when files are waiting
+
 ## Step 2: Create Vault Directory Structure
 
 ```bash
-mkdir -p "$OBSIDIAN_VAULT_PATH"/{concepts,entities,skills,references,synthesis,journal,projects,_archives,_raw,.obsidian}
+mkdir -p "$OBSIDIAN_VAULT_PATH"/{concepts,entities,skills,references,synthesis,journal,projects,_archives,_raw,_staging,.obsidian}
 ```
 
 - `.obsidian/` — Obsidian's own config. Creates vault recognition.
 - `projects/` — Per-project knowledge (populated during ingest).
 - `_archives/` — Stores wiki snapshots for rebuild/restore operations.
 - `_raw/` — Staging area for unprocessed drafts. Drop rough notes here; `wiki-ingest` will promote them to proper wiki pages and delete the originals.
+- `_staging/` — Review queue for LLM-written pages when `WIKI_STAGED_WRITES=true`. Pages here are not visible in Obsidian's graph until promoted via `/wiki-stage-commit`.
 
 ## Step 3: Create Special Files
 
@@ -159,6 +166,7 @@ Run a quick sanity check:
 - [ ] `hot.md` exists at vault root
 - [ ] `.env` has `OBSIDIAN_VAULT_PATH` set
 - [ ] `.obsidian/` directory exists
+- [ ] `_staging/` directory exists (required even when `WIKI_STAGED_WRITES` is not set — created on setup for future use)
 - [ ] Source directories (if configured) exist and are readable
 
 Report the results and tell the user they can now:

--- a/.skills/wiki-stage-commit/SKILL.md
+++ b/.skills/wiki-stage-commit/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: wiki-stage-commit
+description: >
+  Review and promote staged wiki pages to their final locations. Use when WIKI_STAGED_WRITES=true
+  and the user says "/wiki-stage-commit", "review staged pages", "commit staged writes",
+  "promote staged pages", "approve staged changes", or "what's waiting in staging".
+  Shows each staged file, lets the user accept or reject it, and moves accepted files to
+  their final wiki locations. Rejected files are moved back to _raw/ for manual editing.
+---
+
+# Wiki Stage Commit — Staged Write Promotion
+
+You are reviewing LLM-written pages that are waiting in `_staging/` for human approval before they land in the live wiki. This skill is only useful when `WIKI_STAGED_WRITES=true` in the vault config.
+
+## Before You Start
+
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md`. This gives `OBSIDIAN_VAULT_PATH` and `WIKI_STAGED_WRITES`.
+2. If `WIKI_STAGED_WRITES` is not set or is `false`, tell the user: "Staged writes mode is not enabled. Set `WIKI_STAGED_WRITES=true` in your `.env` to use this feature." Then stop.
+3. Read the `_staging/` directory inventory.
+
+## Invocation Forms
+
+```
+/wiki-stage-commit               # interactive review: show each file and ask accept/reject
+/wiki-stage-commit --all         # accept all staged files without per-file review
+/wiki-stage-commit --reject-all  # reject all staged files (move to _raw/ for manual editing)
+/wiki-stage-commit --list        # list staged files with summary, no changes
+```
+
+## Step 1: Inventory Staged Files
+
+Glob `$OBSIDIAN_VAULT_PATH/_staging/**/*.md` — these are the pending pages.
+
+Also glob `$OBSIDIAN_VAULT_PATH/_staging/**/*.patch.md` — these are pending *updates* to existing pages (diff-style files showing proposed additions and deletions).
+
+Report the inventory:
+
+```
+Staged files: 4 new pages, 2 updates
+
+New pages:
+  _staging/concepts/attention-mechanism.md        (ingested 2 days ago)
+  _staging/entities/andrej-karpathy.md            (ingested 2 days ago)
+  _staging/skills/fine-tuning-llms.md             (ingested yesterday)
+  _staging/references/attention-is-all-you-need.md (ingested 3 hours ago)
+
+Updates (patch files):
+  _staging/concepts/transformer-architecture.patch.md  (target: concepts/transformer-architecture.md)
+  _staging/skills/prompt-engineering.patch.md          (target: skills/prompt-engineering.md)
+```
+
+If `_staging/` is empty, report: "Nothing staged. All writes have been committed or no staged writes have been produced yet."
+
+## Step 2: Per-File Review (interactive mode)
+
+For each staged file (new pages first, then updates):
+
+### For new pages:
+
+Display a summary:
+
+```
+--- New page: concepts/attention-mechanism.md ---
+Title:    Attention Mechanism
+Tags:     #ml #architecture
+Summary:  Core building block of transformers — computes weighted sum of values based on query-key similarity.
+Tier:     supporting
+Confidence: 0.72
+Sources:  papers/attention.pdf
+
+[Preview first 20 lines of body]
+...
+
+Accept [a], Reject [r], Skip [s], Preview full [p]?
+```
+
+### For patch files:
+
+Display a structured diff:
+
+```
+--- Update: concepts/transformer-architecture.md ---
+Source: _staging/concepts/transformer-architecture.patch.md
+
+Proposed additions (+):
++ Transformers outperform RNNs on tasks requiring long-range dependencies. ^[inferred]
++ New source: papers/survey-2026.pdf
+
+Proposed deletions (-):
+- The attention mechanism was first described in [Bahdanau 2015].  (to be replaced by updated claim)
+
+⚠️  Conflict check: target page was modified 3 days after staging. Review carefully.
+
+Accept [a], Reject [r], Skip [s], Preview full diff [p]?
+```
+
+If `--all` flag is set, skip prompting and accept every file.
+If `--reject-all` flag is set, skip prompting and reject every file.
+If `--list` flag is set, stop after printing the inventory (Step 1).
+
+## Step 3: Apply Decisions
+
+### Accepting a new page
+
+1. Move `_staging/<category>/page.md` → `<category>/page.md` (the final location)
+2. Update `index.md` with the new page entry
+3. Remove the staged file
+
+### Accepting a patch/update
+
+1. Read the current page at the target path
+2. Apply the proposed additions and deletions (merge, don't just overwrite)
+3. Update the `updated` frontmatter timestamp
+4. Update `index.md` if the summary changed
+5. Remove the staged patch file
+
+### Rejecting a file
+
+Move it to `$OBSIDIAN_VAULT_PATH/_raw/` for manual editing:
+- `_staging/concepts/page.md` → `_raw/rejected-concepts-page.md`
+- `_staging/concepts/page.patch.md` → `_raw/rejected-patch-concepts-page.md`
+- Prefix with `rejected-` so the user can identify it
+
+### Conflict detection on patch accept
+
+Before applying a patch, check whether the target page's `updated` frontmatter is newer than the patch file's own `updated` field:
+- If the target was modified AFTER the patch was staged, warn: `⚠️ Conflict: target was updated since this patch was staged. Applying may lose recent changes.`
+- Give the user a chance to abort: `Apply anyway [y], Skip [s], Reject [r]?`
+
+## Step 4: Update Tracking Files
+
+After processing all staged files:
+
+1. **`hot.md`** — update the Recent Activity section: "Committed N staged pages; rejected M."
+2. **`log.md`** — append:
+   ```
+   - [TIMESTAMP] STAGE_COMMIT accepted=N rejected=M skipped=K
+   ```
+
+## Step 5: Report
+
+```
+Stage commit complete.
+
+✅  Accepted (N):
+  concepts/attention-mechanism.md     → now live
+  entities/andrej-karpathy.md         → now live
+  concepts/transformer-architecture.md → updated (patch applied)
+
+❌  Rejected (M):
+  skills/fine-tuning-llms.md          → moved to _raw/rejected-skills-fine-tuning-llms.md
+
+⏭️  Skipped (K):
+  references/attention-is-all-you-need.md → still in _staging/
+
+Staging queue: K files remaining
+```
+
+## Notes
+
+- Staged files use the same page template as live pages — they are ready to land, just awaiting approval
+- Patch files use a human-readable diff format: lines starting with `+` are additions, lines starting with `-` are deletions
+- `index.md` and `log.md` are always updated immediately on ingest (they are low-risk tracking files) — only category pages go through staging
+- The `_staging/` directory is not tracked by Obsidian's graph view — pages only appear in the wiki after promotion

--- a/.skills/wiki-status/SKILL.md
+++ b/.skills/wiki-status/SKILL.md
@@ -140,6 +140,7 @@ Present a clear summary:
 - **Total sources ingested:** 42
 - **Projects tracked:** 6
 - **Last ingest:** 2026-04-06T11:00:00Z
+- **Staged writes pending:** 4 pages · 2 patches (oldest: 3 days ago)  ← only when WIKI_STAGED_WRITES=true
 
 ## Delta (what's changed since last ingest)
 
@@ -208,6 +209,8 @@ Replace the old single-line Recommendation with a ranked **What to Do Next** sec
 
 ### 4a: Gather signals
 
+0. **Staged writes pending** (only when `WIKI_STAGED_WRITES=true`) — Glob `$OBSIDIAN_VAULT_PATH/_staging/**/*.md` and `**/*.patch.md`. Count new pages and patches separately. Report the oldest file's age (mtime). This is always listed first if any staged files exist — it has the highest intent signal (the LLM already did the work; the human just needs to review).
+
 1. **`_raw/` files** — list every file in `$OBSIDIAN_VAULT_PATH/_raw/` that isn't a `.gitkeep`. Count and name them.
 
 2. **Stale core pages** — scan all vault `.md` files. A page is "stale" when its `updated` frontmatter field is ≥90 days before today's date AND it has ≥5 incoming wikilinks (i.e., it's "core" — other pages depend on it). List them by name + last-updated date.
@@ -226,6 +229,7 @@ Score each category and emit a ranked list, **capped at 6 items**. Always rank i
 
 | Priority | Category | Trigger |
 |---|---|---|
+| 0 | Staged writes pending | Any `.md`/`.patch.md` in `_staging/` (only when `WIKI_STAGED_WRITES=true`) |
 | 1 | `_raw/` files waiting | Any files present in `_raw/` |
 | 2 | Stale core pages | Any page: updated ≥90 days ago AND ≥5 incoming links |
 | 3 | Orphan pages | Any pages with zero incoming wikilinks |
@@ -237,6 +241,10 @@ Render as:
 
 ```markdown
 ## What to Do Next
+
+0. 📋  6 staged pages waiting for review (oldest: 3 days ago)
+   → 4 new pages + 2 patches in _staging/
+   run: /wiki-stage-commit
 
 1. 📥  Ingest 3 files waiting in _raw/
    → architecture-notes.md, meeting-2026-05-10.md, paper-draft.pdf
@@ -257,13 +265,13 @@ Render as:
 6. 🩺  Lint not run in 30+ days — run: /wiki-lint
 ```
 
-**Empty state:** If all categories have nothing to report (no `_raw/` files, no orphans, no stale pages, no synthesis opportunities, no new sources, no lint issues), output instead:
+**Empty state:** If all categories have nothing to report (no staged files, no `_raw/` files, no orphans, no stale pages, no synthesis opportunities, no new sources, no lint issues), output instead:
 
 ```markdown
 ## What to Do Next
 
 ✅  Wiki is healthy — nothing urgent.
-    All sources up to date · no orphans · no stale core pages · no _raw/ files pending
+    All sources up to date · no orphans · no stale core pages · no _raw/ files pending · no staged writes
 ```
 
 **Overflow:** If more than 6 items would be shown, add a footer line: `_(N more items available — run /wiki-status --full to see all)_`. The `--full` flag is not yet implemented; this is forward-looking copy that sets expectations.


### PR DESCRIPTION
## Summary

Adds `WIKI_STAGED_WRITES=true` config flag that routes all LLM-written pages to a `_staging/` review queue before they land in the live wiki.

**New skill: `wiki-stage-commit`**
- Interactive per-file review: shows title, tags, summary, tier, confidence for new pages; shows structured diff for patches
- Accepts `--all`, `--reject-all`, `--list` flags
- Conflict detection: warns when target page was modified after the patch was staged
- Rejected files moved to `_raw/rejected-*` for manual editing
- Updates `hot.md`, `log.md` after commit

**`wiki-ingest` changes**
- Checks `WIKI_STAGED_WRITES` before writing; routes new pages to `_staging/<category>/` and updates to `_staging/<category>/<page>.patch.md`
- `index.md` and `log.md` always updated immediately (low-risk tracking files)
- `hot.md` notes staged writes pending

**`wiki-status` changes**
- Overview shows `Staged writes pending: N pages · M patches (oldest: X days ago)`
- "What to Do Next" adds priority-0 staged-writes item (above `_raw/`)

**`wiki-setup` changes**
- Prompts for `WIKI_STAGED_WRITES` in Step 1
- Creates `_staging/` directory alongside `_raw/` in Step 2
- Verifies `_staging/` in Step 6 checklist

**`CLAUDE.md`**: routing added for `wiki-stage-commit`

Closes #49

## Test plan

- [ ] `WIKI_STAGED_WRITES=true` causes `wiki-ingest` to write to `_staging/` instead of final location
- [ ] `index.md` and `log.md` are still updated immediately
- [ ] `hot.md` notes staged writes pending
- [ ] `wiki-status` shows staged writes count in Overview
- [ ] "What to Do Next" shows staged writes as item 0 when files exist
- [ ] `/wiki-stage-commit` shows per-file summary and prompts accept/reject
- [ ] `--all` accepts everything without prompting
- [ ] `--reject-all` moves all to `_raw/rejected-*`
- [ ] `--list` prints inventory with no changes
- [ ] Conflict detection warns when target modified after staging
- [ ] Accepted new pages land at final location; patch files are merged correctly
- [ ] `wiki-setup` creates `_staging/` directory
- [ ] Existing vaults without `WIKI_STAGED_WRITES` behave exactly as before (fully backward compatible)