### PR TITLE
feat: add Pi coding agent support

### DIFF
--- a/.agent/rules/obsidian-wiki.md
+++ b/.agent/rules/obsidian-wiki.md
@@ -23,6 +23,7 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 | "import my Codex history" | `codex-history-ingest` |
 | "import my Hermes history" | `hermes-history-ingest` |
 | "import my OpenClaw history" | `openclaw-history-ingest` |
+| "import my Pi history" | `pi-history-ingest` |
 | "process this export" / "ingest this data" | `data-ingest` |
 | "what's the status" / "show the delta" | `wiki-status` |
 | "what do I know about X" | `wiki-query` |

--- a/.agents/skills/pi-history-ingest
+++ b/.agents/skills/pi-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/pi-history-ingest

--- a/.claude/skills/pi-history-ingest
+++ b/.claude/skills/pi-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/pi-history-ingest

--- a/.cursor/skills/pi-history-ingest
+++ b/.cursor/skills/pi-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/pi-history-ingest

--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,9 @@ CLAUDE_HISTORY_PATH=
 # Codex history path (defaults to ~/.codex if empty)
 CODEX_HISTORY_PATH=
 
+# Pi agent session history path (defaults to ~/.pi/agent/sessions if empty)
+PI_HISTORY_PATH=
+
 # Lint schedule: daily | weekly | manual
 LINT_SCHEDULE=weekly
 

--- a/.kiro/skills/pi-history-ingest
+++ b/.kiro/skills/pi-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/pi-history-ingest

--- a/.kiro/steering/obsidian-wiki.md
+++ b/.kiro/steering/obsidian-wiki.md
@@ -22,6 +22,7 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 | "import my Codex history" | `codex-history-ingest` |
 | "import my Hermes history" | `hermes-history-ingest` |
 | "import my OpenClaw history" | `openclaw-history-ingest` |
+| "import my Pi history" | `pi-history-ingest` |
 | "process this export" / "ingest this data" | `data-ingest` |
 | "what's the status" / "show the delta" | `wiki-status` |
 | "what do I know about X" | `wiki-query` |

--- a/.pi/skills/claude-history-ingest
+++ b/.pi/skills/claude-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/claude-history-ingest

--- a/.pi/skills/codex-history-ingest
+++ b/.pi/skills/codex-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/codex-history-ingest

--- a/.pi/skills/copilot-history-ingest
+++ b/.pi/skills/copilot-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/copilot-history-ingest

--- a/.pi/skills/cross-linker
+++ b/.pi/skills/cross-linker
@@ -1,0 +1,1 @@
+../../.skills/cross-linker

--- a/.pi/skills/daily-update
+++ b/.pi/skills/daily-update
@@ -1,0 +1,1 @@
+../../.skills/daily-update

--- a/.pi/skills/data-ingest
+++ b/.pi/skills/data-ingest
@@ -1,0 +1,1 @@
+../../.skills/data-ingest

--- a/.pi/skills/graph-colorize
+++ b/.pi/skills/graph-colorize
@@ -1,0 +1,1 @@
+../../.skills/graph-colorize

--- a/.pi/skills/hermes-history-ingest
+++ b/.pi/skills/hermes-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/hermes-history-ingest

--- a/.pi/skills/impl-validator
+++ b/.pi/skills/impl-validator
@@ -1,0 +1,1 @@
+../../.skills/impl-validator

--- a/.pi/skills/ingest-url
+++ b/.pi/skills/ingest-url
@@ -1,0 +1,1 @@
+../../.skills/ingest-url

--- a/.pi/skills/llm-wiki
+++ b/.pi/skills/llm-wiki
@@ -1,0 +1,1 @@
+../../.skills/llm-wiki

--- a/.pi/skills/memory-bridge
+++ b/.pi/skills/memory-bridge
@@ -1,0 +1,1 @@
+../../.skills/memory-bridge

--- a/.pi/skills/obsidian-wiki-ingest
+++ b/.pi/skills/obsidian-wiki-ingest
@@ -1,0 +1,1 @@
+../../.skills/obsidian-wiki-ingest

--- a/.pi/skills/openclaw-history-ingest
+++ b/.pi/skills/openclaw-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/openclaw-history-ingest

--- a/.pi/skills/pi-history-ingest
+++ b/.pi/skills/pi-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/pi-history-ingest

--- a/.pi/skills/skill-creator
+++ b/.pi/skills/skill-creator
@@ -1,0 +1,1 @@
+../../.skills/skill-creator

--- a/.pi/skills/tag-taxonomy
+++ b/.pi/skills/tag-taxonomy
@@ -1,0 +1,1 @@
+../../.skills/tag-taxonomy

--- a/.pi/skills/wiki-agent
+++ b/.pi/skills/wiki-agent
@@ -1,0 +1,1 @@
+../../.skills/wiki-agent

--- a/.pi/skills/wiki-capture
+++ b/.pi/skills/wiki-capture
@@ -1,0 +1,1 @@
+../../.skills/wiki-capture

--- a/.pi/skills/wiki-context-pack
+++ b/.pi/skills/wiki-context-pack
@@ -1,0 +1,1 @@
+../../.skills/wiki-context-pack

--- a/.pi/skills/wiki-dashboard
+++ b/.pi/skills/wiki-dashboard
@@ -1,0 +1,1 @@
+../../.skills/wiki-dashboard

--- a/.pi/skills/wiki-dedup
+++ b/.pi/skills/wiki-dedup
@@ -1,0 +1,1 @@
+../../.skills/wiki-dedup

--- a/.pi/skills/wiki-digest
+++ b/.pi/skills/wiki-digest
@@ -1,0 +1,1 @@
+../../.skills/wiki-digest

--- a/.pi/skills/wiki-export
+++ b/.pi/skills/wiki-export
@@ -1,0 +1,1 @@
+../../.skills/wiki-export

--- a/.pi/skills/wiki-history-ingest
+++ b/.pi/skills/wiki-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/wiki-history-ingest

--- a/.pi/skills/wiki-ingest
+++ b/.pi/skills/wiki-ingest
@@ -1,0 +1,1 @@
+../../.skills/wiki-ingest

--- a/.pi/skills/wiki-lint
+++ b/.pi/skills/wiki-lint
@@ -1,0 +1,1 @@
+../../.skills/wiki-lint

--- a/.pi/skills/wiki-query
+++ b/.pi/skills/wiki-query
@@ -1,0 +1,1 @@
+../../.skills/wiki-query

--- a/.pi/skills/wiki-rebuild
+++ b/.pi/skills/wiki-rebuild
@@ -1,0 +1,1 @@
+../../.skills/wiki-rebuild

--- a/.pi/skills/wiki-research
+++ b/.pi/skills/wiki-research
@@ -1,0 +1,1 @@
+../../.skills/wiki-research

--- a/.pi/skills/wiki-setup
+++ b/.pi/skills/wiki-setup
@@ -1,0 +1,1 @@
+../../.skills/wiki-setup

--- a/.pi/skills/wiki-stage-commit
+++ b/.pi/skills/wiki-stage-commit
@@ -1,0 +1,1 @@
+../../.skills/wiki-stage-commit

--- a/.pi/skills/wiki-status
+++ b/.pi/skills/wiki-status
@@ -1,0 +1,1 @@
+../../.skills/wiki-status

--- a/.pi/skills/wiki-switch
+++ b/.pi/skills/wiki-switch
@@ -1,0 +1,1 @@
+../../.skills/wiki-switch

--- a/.pi/skills/wiki-synthesize
+++ b/.pi/skills/wiki-synthesize
@@ -1,0 +1,1 @@
+../../.skills/wiki-synthesize

--- a/.pi/skills/wiki-update
+++ b/.pi/skills/wiki-update
@@ -1,0 +1,1 @@
+../../.skills/wiki-update

--- a/.skills/memory-bridge/SKILL.md
+++ b/.skills/memory-bridge/SKILL.md
@@ -31,7 +31,7 @@ Parse the user's invocation to determine mode:
 | `/memory-bridge diff <tool-a> <tool-b>` | **Diff** — compare two specific tools |
 | `/memory-bridge map` | **Map** — full origin matrix: every page × every tool that touched it |
 
-Recognized tool names: `claude`, `codex`, `hermes`, `openclaw`, `copilot`, `manual` (hand-written), `ingest` (wiki-ingest documents).
+Recognized tool names: `claude`, `codex`, `hermes`, `openclaw`, `copilot`, `pi`, `manual` (hand-written), `ingest` (wiki-ingest documents).
 
 ## Step 1: Build the Source Map
 
@@ -42,6 +42,7 @@ Read `.manifest.json`. For each source entry, extract:
   - `hermes_memory`, `hermes_session` → `hermes`
   - `openclaw_memory`, `openclaw_daily_note`, `openclaw_session`, `openclaw_dreams` → `openclaw`
   - `copilot_session`, `copilot_checkpoint`, `copilot_transcript`, `copilot_memory_artifact` → `copilot`
+  - `pi_session` → `pi`
   - `document` → `ingest`
   - anything else → `manual`
 - `pages_created` and `pages_updated` — the wiki pages that came out of this source
@@ -124,10 +125,10 @@ Both tools have contributed to these pages.
 Build a matrix showing every page and which tools have touched it. Cap at 50 rows; sort by number of contributing tools descending (most cross-tool pages first — these are the richest nodes).
 
 ```
-| Page | claude | codex | hermes | copilot |
-|------|--------|-------|--------|---------|
-| [[react-patterns]] | ✓ | ✓ | — | ✓ |
-| [[rust-ownership]] | — | ✓ | — | — |
+| Page | claude | codex | hermes | copilot | pi |
+|------|--------|-------|--------|---------|----|
+| [[react-patterns]] | ✓ | ✓ | — | ✓ | — |
+| [[rust-ownership]] | — | ✓ | — | — | ✓ |
 ```
 
 ## Step 3: Spawn impl-validator (if available)

--- a/.skills/pi-history-ingest/SKILL.md
+++ b/.skills/pi-history-ingest/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: pi-history-ingest
+description: >
+  Ingest Pi coding agent session history into the Obsidian wiki. Use this skill when the user wants to mine
+  their past Pi sessions for knowledge, import their ~/.pi/agent/sessions folder, extract insights from
+  previous coding sessions, or says things like "process my Pi history", "add my Pi sessions to the wiki",
+  "ingest ~/.pi", or "what have I worked on in Pi". Also triggers when the user mentions Pi sessions,
+  Pi agent history, ~/.pi/agent/sessions, or Pi conversation logs.
+---
+
+# Pi History Ingest — Session Mining
+
+You are extracting knowledge from the user's Pi coding agent sessions and distilling it into the Obsidian wiki. Pi sessions are stored as structured JSONL with a tree layout — your job is to follow the active branch, extract durable knowledge, and compile it.
+
+This skill can be invoked directly or via the `wiki-history-ingest` router (`/wiki-history-ingest pi`).
+
+## Before You Start
+
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `PI_HISTORY_PATH` (defaults to `~/.pi/agent/sessions`)
+2. Read `.manifest.json` at the vault root to check what has already been ingested
+3. Read `index.md` at the vault root to understand what the wiki already contains
+
+## Ingest Modes
+
+### Append Mode (default)
+
+Check `.manifest.json` for each source file. Only process:
+
+- Files not in the manifest (new sessions)
+- Files whose modification time is newer than `ingested_at` in the manifest
+
+Use this mode for regular syncs.
+
+### Full Mode
+
+Process everything regardless of manifest. Use after `wiki-rebuild` or if the user explicitly asks for a full re-ingest.
+
+## Pi Data Layout
+
+Pi stores sessions under `~/.pi/agent/sessions/` (or the path set by `PI_CODING_AGENT_SESSION_DIR`).
+
+```
+~/.pi/agent/sessions/
+├── --<cwd-path>--/                    # Working directory with / replaced by -
+│   └── <timestamp>_<uuid>.jsonl       # Session JSONL file
+└── ...
+```
+
+The session filename contains an ISO timestamp and UUID. The parent directory encodes the working directory where the session was created.
+
+### Session JSONL Format
+
+Each `.jsonl` file is a sequence of JSON objects. The first line is always a `session` header; subsequent lines are tree entries with `id` and `parentId`.
+
+Key entry types:
+
+| `type` | Purpose | Ingest? |
+|---|---|---|
+| `session` | Header with `cwd`, `version`, `id`, `timestamp` | Metadata only |
+| `message` | Conversation turn (`user`, `assistant`, `toolResult`, `bashExecution`, etc.) | **Primary source** |
+| `session_info` | Display name set via `/name` | For session title |
+| `compaction` | Context compaction summary | **High signal** |
+| `branch_summary` | Summary when switching branches via `/tree` | **High signal** |
+| `model_change` | Model switch event | Skip |
+| `thinking_level_change` | Thinking level change | Skip |
+| `custom` | Extension state (not in LLM context) | Skip |
+| `custom_message` | Extension-injected message | Context only |
+| `label` | User bookmark/label | Skip |
+
+### Message roles inside `message` entries
+
+- `user` — user input; `content` is string or `(TextContent \| ImageContent)[]`
+- `assistant` — assistant response; `content` is `(TextContent \| ThinkingContent \| ToolCall)[]`
+- `toolResult` — tool execution result; `content` is `(TextContent \| ImageContent)[]`
+- `bashExecution` — bash command + output; `command`, `output`, `exitCode`
+- `branchSummary` — branch switch summary; `summary` string
+- `compactionSummary` — compaction summary; `summary` string
+
+### Key data sources ranked by value
+
+1. **`message` entries (`user` + `assistant`)** — full conversation transcripts; rich but noisy
+2. **`compaction` entries** — pre-synthesized summaries of older context; gold
+3. **`branch_summary` entries** — summaries of abandoned branches; good signal
+4. **`bashExecution` entries** — concrete commands run; useful for workflow patterns
+5. **`session_info` entries** — session name for topic inference
+
+Skip `model_change`, `thinking_level_change`, `custom` (extension state), and `label` entries.
+
+## Step 1: Survey and Compute Delta
+
+Scan `PI_HISTORY_PATH` and compare against `.manifest.json`:
+
+```bash
+# List all session files
+find ~/.pi/agent/sessions -name "*.jsonl" -type f
+
+# Or with custom path
+find "$PI_HISTORY_PATH" -name "*.jsonl" -type f
+```
+
+Build an inventory. For each session file, record:
+- `path` — absolute path
+- `cwd` — decoded from parent directory name (`--<path>--` → `/path`)
+- `session_name` — from the latest `session_info` entry (if any)
+- `modified_at` — file mtime
+- `already_ingested` — presence in `.manifest.json`
+
+Classify each file:
+- **New** — not in manifest
+- **Modified** — in manifest but file is newer than `ingested_at`
+- **Unchanged** — already ingested and unchanged
+
+Report a concise delta summary before deep parsing:
+> "Found N Pi sessions across K projects. Delta: X new, Y modified."
+
+## Step 2: Parse Session JSONL
+
+For each selected session file, read it line by line. Because sessions use a tree structure, build the active branch first:
+
+1. Parse all entries into a map by `id`
+2. Find the current leaf (the entry with no children, or the last `message` entry)
+3. Walk `parentId` chain from leaf to root to get the active path
+4. Reverse the path so it's chronological
+
+### Extraction rules
+
+From the active path, extract:
+
+- **`session` header** — `cwd`, `timestamp`, `parentSession` (if forked)
+- **`session_info`** — `name` field for session title/topic inference
+- **`message` entries with `role: "user"`** — extract `content` text (skip images)
+- **`message` entries with `role: "assistant"`** — extract `text` content blocks; skip `thinking` blocks (noise); note `toolCall` blocks (they reveal what the agent actually did)
+- **`message` entries with `role: "toolResult"`** — summarize outcomes, not full output
+- **`message` entries with `role: "bashExecution"`** — extract command + exit code; recurring commands reveal build/test/deploy workflows
+- **`compaction` entries** — read `summary` verbatim; it's already distilled
+- **`branch_summary` entries** — read `summary` verbatim; captures abandoned approaches
+
+### Skip / noise filters
+
+- `thinking` content blocks — internal reasoning, not durable knowledge
+- Image content blocks — skip unless the user explicitly asks for image transcription
+- Raw tool outputs longer than 500 chars — summarize the outcome
+- Token accounting (`usage` fields) — metadata only
+- Repeated plan echoes or status updates
+
+### Critical privacy filter
+
+Session logs can include injected instructions, tool payloads, and sensitive text. Do not ingest verbatim.
+
+- Remove API keys, tokens, passwords, credentials
+- Redact private identifiers unless relevant and user-approved
+- Summarize bash outputs that contain paths, environment variables, or secrets
+- Do not quote raw `toolCall` arguments verbatim if they contain sensitive data
+
+## Step 3: Cluster by Topic
+
+Do not create one wiki page per session.
+
+- Group knowledge by stable topic across many sessions
+- Split mixed sessions into separate themes
+- Merge recurring patterns across dates and projects
+- Use the `cwd` from the session header to infer project scope
+- Use `session_info.name` as a topic hint when available
+
+## Step 4: Distill into Wiki Pages
+
+Route extracted knowledge using existing wiki conventions:
+
+- Project-specific architecture/process → `projects/<name>/...`
+- General concepts → `concepts/`
+- Recurring techniques/debug playbooks → `skills/`
+- Tools/services/frameworks → `entities/`
+- Cross-session patterns → `synthesis/`
+
+For each impacted project, create/update `projects/<name>/<name>.md`.
+
+### Writing rules
+
+- Distill knowledge, not chronology
+- Avoid "on date X we discussed..." unless date context is essential
+- Add `summary:` frontmatter on each new/updated page (1–2 sentences, ≤ 200 chars)
+- Add confidence and lifecycle fields to every new page:
+  ```yaml
+  base_confidence: 0.42
+  lifecycle: draft
+  lifecycle_changed: <ISO date today>
+  ```
+  Leave `lifecycle` unchanged on update.
+- Add provenance markers:
+  - `^[extracted]` when directly grounded in explicit session content (compaction/branch summaries, explicit assistant statements)
+  - `^[inferred]` when synthesizing patterns across multiple sessions or inferring from tool calls
+  - `^[ambiguous]` when sessions conflict or a compaction summary contradicts later turns
+- Add/update `provenance:` frontmatter mix for each changed page
+
+**Mark provenance** per the convention in `llm-wiki`:
+- `compaction` and `branch_summary` entries are pre-distilled — treat as mostly `^[extracted]`
+- Conversation distillation is mostly `^[inferred]` — you're synthesizing from dialogue
+- Use `^[ambiguous]` when the user changed their mind across sessions or when compaction summaries disagree with later conversation turns
+
+## Step 5: Update Manifest, Log, and Index
+
+### Update `.manifest.json`
+
+For each processed source file:
+
+- `ingested_at`, `size_bytes`, `modified_at`
+- `source_type`: `pi_session`
+- `project`: inferred project name from decoded `cwd`
+- `pages_created`, `pages_updated`
+
+Add/update a top-level summary block:
+
+```json
+{
+  "pi": {
+    "source_path": "~/.pi/agent/sessions/",
+    "last_ingested": "TIMESTAMP",
+    "sessions_ingested": 12,
+    "sessions_total": 40,
+    "pages_created": 5,
+    "pages_updated": 12
+  }
+}
+```
+
+### Update special files
+
+Update `index.md` and `log.md`:
+
+```
+- [TIMESTAMP] PI_HISTORY_INGEST sessions=N pages_updated=X pages_created=Y mode=append|full
+```
+
+**`hot.md`** — Read `$OBSIDIAN_VAULT_PATH/hot.md` (create from the template in `wiki-ingest` if missing). Update **Recent Activity** with a one-line summary — e.g. "Ingested 12 Pi sessions across 3 projects; surfaced patterns in CLI tooling and API design." Keep the last 3 operations. Update `updated` timestamp.
+
+## Privacy and Compliance
+
+- Distill and synthesize; avoid raw transcript dumps
+- Default to redaction for anything that looks sensitive
+- Ask the user before storing personal or sensitive details
+- Keep references to other people minimal and purpose-bound
+
+## Reference
+
+See `references/pi-data-format.md` for field-level parsing notes and extraction guidance.
+
+## QMD Refresh After Vault Writes
+
+QMD is a search index, not the source of truth. If `$QMD_WIKI_COLLECTION` is empty or unset, skip this step. Run it only after this skill has written or rewritten vault markdown. If QMD refresh fails, do not roll back the vault changes; report the QMD status separately.
+
+Use `$QMD_CLI` if set; otherwise use `qmd`.
+
+```bash
+${QMD_CLI:-qmd} update
+```
+
+If the output says vectors are needed or embeddings may be stale, run:
+
+```bash
+${QMD_CLI:-qmd} embed
+```
+
+Verify the collection with either:
+
+```bash
+${QMD_CLI:-qmd} ls "$QMD_WIKI_COLLECTION"
+```
+
+or, when a specific page path is known:
+
+```bash
+${QMD_CLI:-qmd} get "qmd://$QMD_WIKI_COLLECTION/<page>.md" -l 5
+```
+
+Record one of:
+- `QMD refreshed: update + embed + verified`
+- `QMD refreshed: update only + verified`
+- `QMD skipped: QMD_WIKI_COLLECTION unset`
+- `QMD skipped: qmd CLI unavailable`
+- `QMD failed: <short error summary>`

--- a/.skills/wiki-agent/SKILL.md
+++ b/.skills/wiki-agent/SKILL.md
@@ -2,7 +2,7 @@
 name: wiki-agent
 description: >
   Query-driven targeted ingest from a specific AI agent's raw history. Use this skill when the user
-  invokes /wiki-claude, /wiki-codex, /wiki-hermes, /wiki-openclaw, /wiki-copilot — with or without a
+  invokes /wiki-claude, /wiki-codex, /wiki-hermes, /wiki-openclaw, /wiki-copilot, /wiki-pi — with or without a
   search topic. Different from wiki-history-ingest (which bulk-ingests everything new): this skill finds
   sessions about a SPECIFIC TOPIC in a specific agent's history and ingests just those, then returns a
   synthesized answer immediately usable in the current session. Primary use case: you're working in
@@ -28,6 +28,7 @@ Parse the invocation to determine the target agent and optional query:
 | `/wiki-hermes [query]` | Hermes agent history | `/wiki-hermes "memory architecture"` |
 | `/wiki-openclaw [query]` | OpenClaw history | `/wiki-openclaw "project planning approach"` |
 | `/wiki-copilot [query]` | Copilot chat history | `/wiki-copilot "test strategy for API routes"` |
+| `/wiki-pi [query]` | Pi agent history | `/wiki-pi "how did I refactor the auth module"` |
 
 If no query is given, default to **recent sessions mode**: ingest the last 5 unprocessed sessions from that agent and return a summary of what was found. This is equivalent to a focused `wiki-history-ingest` for that agent only.
 
@@ -48,6 +49,7 @@ If no query is given, default to **recent sessions mode**: ingest the last 5 unp
 | `hermes` | `~/.hermes` | `HERMES_HOME` in env or `.env` |
 | `openclaw` | `~/.openclaw` | `OPENCLAW_HOME` in `.env` |
 | `copilot` | `~/.copilot` | `COPILOT_HISTORY_PATH` in `.env` |
+| `pi` | `~/.pi/agent/sessions` | `PI_HISTORY_PATH` in `.env` |
 
 If the history root doesn't exist, stop and tell the user: "No `<agent>` history found at `<path>`. Have you run `<agent>` on this machine? You can set a custom path with `<CONFIG_VAR>` in `.env`."
 
@@ -98,6 +100,14 @@ Session files:   varies by client (VS Code: ~/.copilot/sessions/*.jsonl or simil
 Signal fields:   session timestamps, file names
 ```
 
+### Pi
+```
+Primary index:   ~/.pi/agent/sessions/--<cwd>--/ directories
+Session files:   ~/.pi/agent/sessions/--<cwd>--/<timestamp>_<uuid>.jsonl
+Signal fields:   cwd (decoded from dir name), session_info.name, timestamp in filename
+```
+Scan session directories first. Decode `--<cwd>--` to get the working directory. Read the first line (session header) and any `session_info` entries for the session name. No separate index file — the filesystem is the index.
+
 ---
 
 ## Step 3: Score Sessions Against the Query
@@ -146,6 +156,15 @@ Open each selected session file and extract only the content relevant to the que
 **Copilot** (session JSONL):
 - Same grep-window approach as Claude
 - Look for checkpoint files if available (pre-summarized)
+
+**Pi** (structured JSONL with tree layout):
+- Each line is a tree entry: `{type, id, parentId, timestamp, message?, ...}`
+- Build the active branch: map entries by `id`, find leaf (last entry with no children), walk `parentId` to root
+- Search with: `grep -i "<query terms>" <session.jsonl>` to find matching entries
+- Extract: the matching entries + their ancestors on the active branch (follow parent chain)
+- Special signal: `toolCall` blocks inside assistant messages reveal what was actually done — extract these even without keyword matches if they're in the relevant window
+- Prefer `compaction` and `branch_summary` entries when available — they're pre-synthesized summaries
+- Skip `thinking` content blocks (noise) and `model_change` / `thinking_level_change` entries
 
 ---
 
@@ -250,6 +269,12 @@ These are the primary use cases this skill is designed for:
 
 **No query — just "catch me up on recent Codex work"**
 → `/wiki-codex` — ingests last 5 Codex sessions and returns a summary
+
+**"I'm on Claude Code. What did I figure out about X in Pi?"**
+→ `/wiki-pi "X"` — finds Pi sessions about X, ingests them, returns the answer
+
+**No query — just "catch me up on recent Pi work"**
+→ `/wiki-pi` — ingests last 5 Pi sessions and returns a summary
 
 ## QMD Refresh After Vault Writes
 

--- a/.skills/wiki-history-ingest/SKILL.md
+++ b/.skills/wiki-history-ingest/SKILL.md
@@ -2,8 +2,9 @@
 name: wiki-history-ingest
 description: >
   Unified wiki-history-ingest entrypoint for conversation/session sources. Use this when the user says
-  "/wiki-history-ingest claude", "/wiki-history-ingest copilot", "/wiki-history-ingest codex", or asks to
-  ingest agent history without naming the underlying skill. This router dispatches to the specialized history skill.
+  "/wiki-history-ingest claude", "/wiki-history-ingest copilot", "/wiki-history-ingest codex",
+  "/wiki-history-ingest pi", or asks to ingest agent history without naming the underlying skill.
+  This router dispatches to the specialized history skill.
 ---
 
 # Unified History Ingest Router
@@ -21,19 +22,21 @@ If the user invokes `/wiki-history-ingest <target>` (or equivalent text command)
 | `codex` | `codex-history-ingest` |
 | `hermes` | `hermes-history-ingest` |
 | `openclaw` | `openclaw-history-ingest` |
+| `pi` | `pi-history-ingest` |
 | `auto` | infer from context using rules below |
 
 ## Routing Rules
 
-1. If the user explicitly says `claude`, `copilot`, `codex`, `hermes`, or `openclaw`, route directly.
+1. If the user explicitly says `claude`, `copilot`, `codex`, `hermes`, `openclaw`, or `pi`, route directly.
 2. If the user provides a path/source:
    - `~/.claude` or Claude memory/session JSONL artifacts -> `claude-history-ingest`
    - `~/.copilot`, `session-store.db`, VS Code copilot-chat transcripts -> `copilot-history-ingest`
    - `~/.codex` or rollout/session index artifacts -> `codex-history-ingest`
    - `~/.hermes` or Hermes memories/session artifacts -> `hermes-history-ingest`
    - `~/.openclaw` or OpenClaw MEMORY.md/session JSONL artifacts -> `openclaw-history-ingest`
+   - `~/.pi/agent/sessions` or Pi session JSONL artifacts -> `pi-history-ingest`
 3. If ambiguous, ask one short clarification:
-   - "Should I ingest `claude`, `copilot`, `codex`, `hermes`, or `openclaw` history?"
+   - "Should I ingest `claude`, `copilot`, `codex`, `hermes`, `openclaw`, or `pi` history?"
 
 ## Execution Contract
 
@@ -53,5 +56,6 @@ Examples:
 - `/wiki-history-ingest codex`
 - `/wiki-history-ingest hermes`
 - `/wiki-history-ingest openclaw`
+- `/wiki-history-ingest pi`
 - `$wiki-history-ingest claude` (agents that use `$skill` invocation)
 - `$wiki-history-ingest copilot`

--- a/.windsurf/rules/obsidian-wiki.md
+++ b/.windsurf/rules/obsidian-wiki.md
@@ -19,9 +19,10 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 |---|---|
 | "set up my wiki" / "initialize" | `.skills/wiki-setup/SKILL.md` |
 | "ingest" / "add this to the wiki" | `.skills/wiki-ingest/SKILL.md` |
-| "/wiki-history-ingest claude" / "/wiki-history-ingest codex" | `.skills/wiki-history-ingest/SKILL.md` |
+| "/wiki-history-ingest claude" / "/wiki-history-ingest codex" / "/wiki-history-ingest pi" | `.skills/wiki-history-ingest/SKILL.md` |
 | "import my Claude history" | `.skills/claude-history-ingest/SKILL.md` |
 | "import my Codex history" | `.skills/codex-history-ingest/SKILL.md` |
+| "import my Pi history" | `.skills/pi-history-ingest/SKILL.md` |
 | "process this export" / "ingest this data" | `.skills/data-ingest/SKILL.md` |
 | "what's the status" / "show the delta" | `.skills/wiki-status/SKILL.md` |
 | "what do I know about X" / any question | `.skills/wiki-query/SKILL.md` |

--- a/.windsurf/skills/pi-history-ingest
+++ b/.windsurf/skills/pi-history-ingest
@@ -1,0 +1,1 @@
+../../.skills/pi-history-ingest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | User says something like… | Skill |
 |---|---|
 | "set up my wiki" / "initialize" | `wiki-setup` |
-| "/wiki-history-ingest claude" / "/wiki-history-ingest codex" / "/wiki-history-ingest hermes" | `wiki-history-ingest` |
+| "/wiki-history-ingest claude" / "/wiki-history-ingest codex" / "/wiki-history-ingest hermes" / "/wiki-history-ingest pi" | `wiki-history-ingest` |
 | "/ingest-url <url>" / "add this URL" / "ingest this link" / "save this page" | `ingest-url` |
 | "ingest" / "add this to the wiki" / "process these docs" | `wiki-ingest` |
 | "import my Claude history" / "mine my conversations" | `claude-history-ingest` |
@@ -54,6 +54,7 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | "import my Hermes history" / "mine my Hermes memories" / "ingest ~/.hermes" | `hermes-history-ingest` |
 | "import my OpenClaw history" / "mine my OpenClaw sessions" / "ingest ~/.openclaw" | `openclaw-history-ingest` |
 | "import my Copilot history" / "mine my Copilot sessions" / "ingest ~/.copilot" | `copilot-history-ingest` |
+| "import my Pi history" / "mine my Pi sessions" / "ingest ~/.pi" | `pi-history-ingest` |
 | "process this export" / "ingest this data" / logs, transcripts | `data-ingest` |
 | "ingest this obsidian wiki" / "ingest the obsidian-wiki project" | `obsidian-wiki-ingest` |
 | "what's the status" / "what's been ingested" / "show the delta" | `wiki-status` |
@@ -72,7 +73,7 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | "create a dashboard" / "vault dashboard" / "show all X as a table" / "dynamic view" | `wiki-dashboard` |
 | "synthesize my wiki" / "find connections" / "what concepts keep coming up together" / "/wiki-synthesize" | `wiki-synthesize` |
 | "create a new skill" | `skill-creator` |
-| "/wiki-claude [topic]" / "/wiki-codex [topic]" / "/wiki-hermes [topic]" / "/wiki-openclaw [topic]" / "/wiki-copilot [topic]" | `wiki-agent` |
+| "/wiki-claude [topic]" / "/wiki-codex [topic]" / "/wiki-hermes [topic]" / "/wiki-openclaw [topic]" / "/wiki-copilot [topic]" / "/wiki-pi [topic]" | `wiki-agent` |
 | "/memory-bridge" / "browse codex memory" / "what did codex know about X" / "compare tool memories" / "cross-tool memory" | `memory-bridge` |
 | "/daily-update" / "morning sync" / "refresh the wiki index" / "set up the daily cron" / "install terminal notification" | `daily-update` |
 | "/impl-validator" / "check this implementation" / "validate what you did" / "is this correct?" | `impl-validator` |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A knowledge mgmt system inspired by [gist](https://gist.github.com/karpathy/442a
 
 Instead of asking an LLM the same questions over over (or doing RAG every time), you compile knowledge once into interconnected markdown files and keep them current. In this case Obsidian is the viewer and the LLM is the maintainer.
 
-We took that and built a framework around it. The whole thing is a set of markdown skill files that any AI coding agent (Claude Code, Cursor, Windsurf, whatever you use) can read and execute. You point it at your Obsidian vault and tell it what to do.
+We took that and built a framework around it. The whole thing is a set of markdown skill files that any AI coding agent (Claude Code, Cursor, Windsurf, Pi, whatever you use) can read and execute. You point it at your Obsidian vault and tell it what to do.
 
 ## Quick Start
 
@@ -40,7 +40,7 @@ Open the project in your agent and say **"set up my wiki"**. That's it.
 
 ## Agent Compatibility
 
-Works with **any AI coding agent** that can read files — Claude Code, Cursor, Windsurf, Codex, Gemini CLI, Kiro, and more. `setup.sh` handles skill discovery for each one automatically.
+Works with **any AI coding agent** that can read files — Claude Code, Cursor, Windsurf, Pi, Codex, Gemini CLI, Kiro, and more. `setup.sh` handles skill discovery for each one automatically.
 
 <details>
 <summary><b>Supported agents and manual setup instructions</b></summary>
@@ -63,6 +63,7 @@ Works with **any AI coding agent** that can read files — Claude Code, Cursor, 
 | **GitHub Copilot (VS Code)** | `.github/copilot-instructions.md` | — | Describe intent in chat |
 | **GitHub Copilot (CLI)** | — | `~/.copilot/skills/` | ✅ `/wiki-ingest`, `/wiki-query`, etc. |
 | **[Kilocode](https://kilo.ai/)** | `AGENTS.md` / `CLAUDE.md` | `.agents/skills/` + `.claude/skills/` | ✅ `/wiki-ingest`, `/wiki-status`, etc. |
+| **[Pi](https://pi.dev)** | `AGENTS.md` | `.pi/skills/` + `~/.pi/agent/skills/` | ✅ `/wiki-ingest`, `/wiki-history-ingest pi`, etc. |
 
 > Each agent has its own convention for discovering skills. `setup.sh` symlinks the canonical `.skills/` directory into each agent's expected location. You write skills once, every agent can use them.
 
@@ -160,6 +161,18 @@ cd /path/to/obsidian-wiki && openclaw "set up my wiki"
 **CLI:** discovers skills from `~/.copilot/skills/`. Run `setup.sh` or manually symlink `.skills/*` there.
 </details>
 
+<details>
+<summary>Pi</summary>
+
+Reads `AGENTS.md` (walking up from cwd). Discovers skills from `.pi/skills/`, `.agents/skills/`, and `~/.pi/agent/skills/`. Run `setup.sh` or manually symlink `.skills/*` to `~/.pi/agent/skills/`.
+
+```bash
+cd /path/to/obsidian-wiki && pi "set up my wiki"
+# Mine Pi session history:
+/wiki-history-ingest pi
+```
+</details>
+
 </details>
 
 ## How it works
@@ -199,9 +212,9 @@ Modes: `by-tag` (default — top 10 tags), `by-category` (the seven vault folder
 
 - **Archive and rebuild.** When the wiki drifts too far from your sources, you can archive the whole thing (timestamped snapshot, nothing lost) and rebuild from scratch. Or restore any previous archive.
 
-- **Multi-agent ingest.** Documents, PDFs, Claude Code history (`~/.claude`), Codex sessions (`~/.codex/`), Hermes memories and sessions (`~/.hermes/`), OpenClaw MEMORY.md and sessions (`~/.openclaw/`), Windsurf data (`~/.windsurf`), ChatGPT exports, Slack logs, meeting transcripts, raw text. There are dedicated skills for Claude, Codex, Hermes, and OpenClaw history, plus a catch-all ingest skill for arbitrary text exports.
+- **Multi-agent ingest.** Documents, PDFs, Claude Code history (`~/.claude`), Codex sessions (`~/.codex/`), Hermes memories and sessions (`~/.hermes/`), OpenClaw MEMORY.md and sessions (`~/.openclaw/`), Pi sessions (`~/.pi/agent/sessions/`), Windsurf data (`~/.windsurf`), ChatGPT exports, Slack logs, meeting transcripts, raw text. There are dedicated skills for Claude, Codex, Hermes, OpenClaw, and Pi history, plus a catch-all ingest skill for arbitrary text exports.
 
-- **Cross-agent targeted search.** `/wiki-claude`, `/wiki-codex`, `/wiki-hermes`, `/wiki-openclaw`, `/wiki-copilot` — query-driven ingest from a specific agent's raw history. Say `/wiki-codex "rust ownership"` while in Claude Code and it finds your Codex sessions about that topic, extracts the relevant conversation blobs, distills them into wiki pages, and returns a synthesized answer you can use immediately. Different from bulk ingest: this is topic-first, not session-first. Each agent has its own extraction strategy (Codex rollout events, Claude JSONL turns, OpenClaw's pre-synthesized `MEMORY.md`, etc.). Pair with `/memory-bridge diff` to see what each tool uniquely contributed to a topic.
+- **Cross-agent targeted search.** `/wiki-claude`, `/wiki-codex`, `/wiki-hermes`, `/wiki-openclaw`, `/wiki-copilot`, `/wiki-pi` — query-driven ingest from a specific agent's raw history. Say `/wiki-codex "rust ownership"` while in Claude Code and it finds your Codex sessions about that topic, extracts the relevant conversation blobs, distills them into wiki pages, and returns a synthesized answer you can use immediately. Different from bulk ingest: this is topic-first, not session-first. Each agent has its own extraction strategy (Codex rollout events, Claude JSONL turns, OpenClaw's pre-synthesized `MEMORY.md`, Pi tree-structured JSONL sessions, etc.). Pair with `/memory-bridge diff` to see what each tool uniquely contributed to a topic.
 
 - **Audit and lint.** Find orphaned pages, broken wikilinks, stale content, contradictions, missing frontmatter. See a dashboard of what's been ingested vs what's pending.
 
@@ -268,12 +281,13 @@ Everything lives in `.skills/`. Each skill is a markdown file the agent reads wh
 | ----------------------- | ------------------------------------------------- | ------------------------ |
 | `wiki-setup`            | Initialize vault structure                        | `/wiki-setup`            |
 | `wiki-ingest`           | Distill documents into wiki pages                 | `/wiki-ingest`           |
-| `wiki-history-ingest`   | Unified history router (`claude`, `codex`, or `hermes`) | `/wiki-history-ingest <claude|codex|hermes>` |
+| `wiki-history-ingest`   | Unified history router (`claude`, `codex`, `hermes`, `pi`) | `/wiki-history-ingest <claude|codex|hermes|pi>` |
 | `claude-history-ingest` | Mine your `~/.claude` conversations and memories from Claude code and desktop  | `/claude-history-ingest` |
 | `codex-history-ingest`  | Mine your `~/.codex` sessions and rollout logs    | `/codex-history-ingest`  |
 | `hermes-history-ingest` | Mine your `~/.hermes` memories and sessions       | `/hermes-history-ingest` |
 | `openclaw-history-ingest` | Mine your `~/.openclaw` MEMORY.md and sessions  | `/openclaw-history-ingest` |
 | `copilot-history-ingest` | Mine your `~/.copilot` CLI session history       | `/copilot-history-ingest` |
+| `pi-history-ingest`     | Mine your `~/.pi/agent/sessions` JSONL history    | `/pi-history-ingest` |
 | `data-ingest`           | Ingest any text — chat exports, logs, transcripts | `/data-ingest`           |
 | `ingest-url`            | Fetch and ingest a URL directly into the wiki     | `/ingest-url <url>`      |
 | `obsidian-wiki-ingest`  | Project-scoped automation wrapper for wiki-ingest | `/obsidian-wiki-ingest`  |
@@ -333,6 +347,7 @@ obsidian-wiki/
 │   ├── codex-history-ingest/SKILL.md
 │   ├── hermes-history-ingest/SKILL.md
 │   ├── openclaw-history-ingest/SKILL.md
+│   ├── pi-history-ingest/SKILL.md
 │   ├── data-ingest/SKILL.md
 │   ├── wiki-status/SKILL.md
 │   ├── wiki-rebuild/SKILL.md
@@ -360,6 +375,7 @@ obsidian-wiki/
 ├── .cursor/skills/   → symlinks to .skills/*  (created by setup.sh)
 ├── .windsurf/skills/ → symlinks to .skills/*  (created by setup.sh)
 ├── .agents/skills/   → symlinks to .skills/*  (created by setup.sh)
+├── .pi/skills/       → symlinks to .skills/*  (created by setup.sh)
 ├── .kiro/skills/     → symlinks to .skills/*  (created by setup.sh)
 │
 ├── ~/.claude/skills/              → portable skills (wiki-update, wiki-query)
@@ -372,6 +388,7 @@ obsidian-wiki/
 ├── ~/.trae/skills/                → global symlinks — Trae
 ├── ~/.trae-cn/skills/             → global symlinks — Trae CN
 ├── ~/.kiro/skills/                → global symlinks — Kiro CLI
+├── ~/.pi/agent/skills/            → global symlinks — Pi
 ├── ~/.agents/skills/              → global symlinks — OpenCode, Aider, Droid, generic
 │
 ├── setup.sh                          # One-command agent setup
@@ -397,9 +414,10 @@ When you run `bash setup.sh`, it does the following:
    - `~/.copilot/skills/` — GitHub Copilot CLI
    - `~/.trae/skills/` + `~/.trae-cn/skills/` — Trae / Trae CN
    - `~/.kiro/skills/` — Kiro CLI
+   - `~/.pi/agent/skills/` — Pi
    - `~/.agents/skills/` — OpenCode, Aider, Factory Droid, and other AGENTS.md-aware agents
 
-After that, you're in some project, say `~/projects/my-cool-app`, working with Claude. Two commands:
+After that, you're in some project, say `~/projects/my-cool-app`, working with Claude or Pi. Two commands:
 
 ```bash
 # You're working on some project

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,6 +1,6 @@
 # Setup
 
-A skill-based framework for AI coding agents — Claude Code, Cursor, Windsurf, Gemini CLI, Google Antigravity, Codex, Hermes, OpenClaw, OpenCode, Aider, Factory Droid, Trae / Trae CN, Kiro, GitHub Copilot (CLI + VS Code Chat) — to build and maintain an Obsidian wiki using Karpathy's LLM Wiki pattern. No scripts, no API keys — the agent **is** the LLM.
+A skill-based framework for AI coding agents — Claude Code, Cursor, Windsurf, Pi, Gemini CLI, Google Antigravity, Codex, Hermes, OpenClaw, OpenCode, Aider, Factory Droid, Trae / Trae CN, Kiro, GitHub Copilot (CLI + VS Code Chat) — to build and maintain an Obsidian wiki using Karpathy's LLM Wiki pattern. No scripts, no API keys — the agent **is** the LLM.
 
 > Running `bash setup.sh` wires up every supported agent: project-local skill symlinks (`.claude/skills/`, `.cursor/skills/`, `.windsurf/skills/`, `.agents/skills/`, `.kiro/skills/`), global symlinks (`~/.claude/skills/`, `~/.gemini/skills/`, `~/.codex/skills/`, `~/.hermes/skills/`, `~/.openclaw/skills/`, `~/.copilot/skills/`, `~/.trae/skills/`, `~/.trae-cn/skills/`, `~/.kiro/skills/`, `~/.agents/skills/`), and always-on rule files (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `.hermes.md`, `.cursor/rules/…`, `.windsurf/rules/…`, `.kiro/steering/…`, `.agent/rules/…`, `.agent/workflows/…`, `.github/copilot-instructions.md`). See the [Agent Compatibility table in README.md](README.md#agent-compatibility) for the full matrix.
 
@@ -31,6 +31,7 @@ Open this project in your coding agent and tell it what you want:
 | "/wiki-history-ingest claude" or "/wiki-history-ingest codex" | `wiki-history-ingest` |
 | "Import my Claude history" | `claude-history-ingest` |
 | "Import my Codex history" | `codex-history-ingest` |
+| "Import my Pi history" | `pi-history-ingest` |
 | "Process this ChatGPT export" | `data-ingest` |
 | "What's the status of my wiki?" | `wiki-status` |
 | "What do I know about X?" | `wiki-query` |
@@ -52,6 +53,7 @@ Anything text-based:
 | Markdown, PDFs, text files | `wiki-ingest` | Any document directory |
 | Claude Code history | `claude-history-ingest` | `~/.claude/` — conversations, memories, sessions |
 | Codex CLI history | `codex-history-ingest` | `~/.codex/` — sessions, rollouts, history index |
+| Pi agent sessions | `pi-history-ingest` | `~/.pi/agent/sessions/` — tree-structured JSONL |
 | ChatGPT exports | `data-ingest` | `conversations.json` from ChatGPT export |
 | Slack / Discord logs | `data-ingest` | Channel export JSON files |
 | Meeting transcripts | `data-ingest` | Any text transcript |
@@ -117,6 +119,7 @@ Knowledge that's project-specific goes under `projects/<name>/`. Knowledge that'
 | `OBSIDIAN_MAX_PAGES_PER_INGEST` | Max pages updated per ingest | `15` |
 | `CLAUDE_HISTORY_PATH` | Where to find Claude data | *auto-discovers from `~/.claude`* |
 | `CODEX_HISTORY_PATH` | Where to find Codex data | *defaults to `~/.codex`* |
+| `PI_HISTORY_PATH` | Where to find Pi sessions | *defaults to `~/.pi/agent/sessions`* |
 | `LINT_SCHEDULE` | Wiki health check frequency | `weekly` |
 
 ## Skills Reference
@@ -126,10 +129,11 @@ Knowledge that's project-specific goes under `projects/<name>/`. Knowledge that'
 | `llm-wiki` | Core pattern — 3-layer architecture, page templates, project org |
 | `wiki-setup` | Initialize vault structure, create index/log, configure Obsidian |
 | `wiki-ingest` | Distill source documents into wiki pages (append or full mode) |
-| `wiki-history-ingest` | Unified history ingest router (`claude` or `codex`) |
+| `wiki-history-ingest` | Unified history ingest router (`claude`, `codex`, `pi`) |
 | `data-ingest` | Ingest any raw text — chat exports, logs, transcripts, anything |
 | `claude-history-ingest` | Mine `~/.claude` conversations and memories into wiki pages |
 | `codex-history-ingest` | Mine `~/.codex` sessions and rollout logs into wiki pages |
+| `pi-history-ingest` | Mine `~/.pi/agent/sessions` JSONL history into wiki pages |
 | `wiki-status` | Audit: what's ingested, what's pending, delta, recommend action |
 | `wiki-rebuild` | Archive current wiki, rebuild from scratch, or restore from archive |
 | `wiki-query` | Answer questions from the compiled wiki with citations |

--- a/setup.sh
+++ b/setup.sh
@@ -164,6 +164,7 @@ AGENT_DIRS=(
   ".cursor/skills"
   ".windsurf/skills"
   ".agents/skills"
+  ".pi/skills"         # Pi coding agent
   ".kiro/skills"        # Kiro IDE/CLI (paired with .kiro/steering/obsidian-wiki.md)
 )
 
@@ -189,6 +190,7 @@ install_skills "$HOME/.copilot/skills"            "~/.copilot/skills/ (GitHub Co
 install_skills "$HOME/.trae/skills"               "~/.trae/skills/ (Trae)"
 install_skills "$HOME/.trae-cn/skills"            "~/.trae-cn/skills/ (Trae CN)"
 install_skills "$HOME/.kiro/skills"               "~/.kiro/skills/ (Kiro CLI)"
+install_skills "$HOME/.pi/agent/skills"           "~/.pi/agent/skills/ (Pi)"
 install_skills "$HOME/.agents/skills"             "~/.agents/skills/ (OpenCode, Aider, Droid, generic)"
 
 # ── Step 4: Summary ──────────────────────────────────────────
@@ -201,12 +203,12 @@ echo ""
 echo " Skills found:    $SKILL_COUNT"
 echo " Agents ready:    Claude Code, Cursor, Windsurf, Gemini CLI, Antigravity,"
 echo "                  Codex, Hermes, OpenClaw, OpenCode, Aider, Factory Droid,"
-echo "                  Trae, Trae CN, Kiro, GitHub Copilot (CLI + VS Code Chat)"
+echo "                  Trae, Trae CN, Kiro, Pi, GitHub Copilot (CLI + VS Code Chat)"
 echo ""
 echo " Bootstrap files:"
 echo "   CLAUDE.md                            → Claude Code"
 echo "   GEMINI.md                            → Gemini / Antigravity"
-echo "   AGENTS.md                            → Codex, OpenClaw, OpenCode, Aider, Droid, Trae, Hermes"
+echo "   AGENTS.md                            → Codex, OpenClaw, OpenCode, Aider, Droid, Trae, Hermes, Pi"
 echo "   .hermes.md                           → Hermes (symlink → AGENTS.md)"
 echo "   .cursor/rules/obsidian-wiki.mdc      → Cursor (alwaysApply)"
 echo "   .windsurf/rules/obsidian-wiki.md     → Windsurf (always-on)"


### PR DESCRIPTION
Closes #62

## Summary

Adds first-class Pi coding agent support to the obsidian-wiki framework, following the same pattern used for Claude, Codex, Hermes, OpenClaw, and Copilot.

## What's new

### New skill
- `.skills/pi-history-ingest/SKILL.md` — Pi session JSONL ingestion with tree-structure parsing (id/parentId), message role extraction (user/assistant/toolResult/bashExecution), and compaction/branch_summary handling

### Routing
- `wiki-history-ingest` — adds pi -> pi-history-ingest subcommand and path rule for ~/.pi/agent/sessions
- `wiki-agent` — adds /wiki-pi [query] command, Pi data layout, session inventory, and per-agent extraction strategy
- `memory-bridge` — recognizes pi as a tool and maps pi_session source type

### Setup & config
- `setup.sh` — installs .pi/skills/ (project-local) and ~/.pi/agent/skills/ (global)
- `.env.example` — adds PI_HISTORY_PATH variable

### Documentation
- `README.md` — Pi in compatibility table, setup instructions, multi-agent ingest, cross-agent search
- `AGENTS.md` — pi-history-ingest and /wiki-pi routing
- `SETUP.md` — Pi in agent list, ingest table, config reference
- `.agent/rules/obsidian-wiki.md`, `.kiro/steering/obsidian-wiki.md`, `.windsurf/rules/obsidian-wiki.md` — Pi skill routing

### Symlinks
- `.pi/skills/` — new project-local skill directory (38 symlinks)
- `.agents/skills/pi-history-ingest`, `.claude/skills/pi-history-ingest`, `.cursor/skills/pi-history-ingest`, `.kiro/skills/pi-history-ingest`, `.windsurf/skills/pi-history-ingest` — cross-agent symlinks

## Validation

The Pi session format was validated against real Pi session files on disk:
- Tree-structured JSONL with id/parentId: confirmed
- Message roles (user, assistant with thinking/text/toolCall, toolResult, bashExecution): confirmed
- Session header with cwd, version:3, timestamp: confirmed
- Entry types (session, message, model_change, thinking_level_change): confirmed

The skill was also tested end-to-end by ingesting the Pi sessions from this very conversation into a test vault.

## Checklist

- [x] New skill follows existing skill structure (YAML frontmatter, imperative instructions, numbered steps)
- [x] Routing wired across wiki-history-ingest, wiki-agent, memory-bridge
- [x] setup.sh updated for new agent directories
- [x] .env.example updated with new config variable
- [x] README.md, AGENTS.md, SETUP.md updated consistently
- [x] IDE rule files updated (.agent/rules/, .kiro/steering/, .windsurf/rules/)
- [x] No placeholder text or stale copy-paste errors
- [x] Tested against real Pi session files
