### PR TITLE
fix(wiki-update): guard against rebase/force-push in delta computation

### DIFF
--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -36,7 +36,12 @@ Derive a clean project name from the directory name.
 Check `.manifest.json` for this project:
 
 - **First time?** Full scan. Everything is new.
-- **Synced before?** Look at `last_commit_synced`. Only consider what changed since then. Use `git log <last_commit>..HEAD --oneline` to see what's new.
+- **Synced before?** Look at `last_commit_synced`. Before computing the delta, verify the stored SHA is still reachable:
+  ```bash
+  git merge-base --is-ancestor <last_commit_synced> HEAD
+  ```
+  - **Exit 0 (ancestor):** Safe. Run `git log <last_commit_synced>..HEAD --oneline` to see what changed.
+  - **Exit 1 (not an ancestor — rebase or force-push occurred):** The stored SHA is no longer in this branch's history. Warn the user: *"Stored commit `<sha>` is no longer reachable — branch may have been rebased or force-pushed. Falling back to full scan."* Then treat as first-time sync: re-scan everything and update `last_commit_synced` to the current HEAD SHA at the end of Step 6.
 
 If nothing meaningful changed since last sync, tell the user and stop.
 


### PR DESCRIPTION
## Summary

- `wiki-update` Step 2 used `git log <last_commit>..HEAD` directly, which silently breaks after a rebase or force-push — the stored `last_commit_synced` SHA may no longer be an ancestor of HEAD, causing the range to yield wrong or empty results (silent under-ingest or crash).
- Added a `git merge-base --is-ancestor <last_commit_synced> HEAD` guard before computing the delta. Exit 1 → warn the user and fall back to a full scan, then rewrite `last_commit_synced` to current HEAD.

## Test plan

- [x] Tested on st3ve (AWS Lightsail): created a scratch repo, verified `--is-ancestor` returns exit 0 for a valid ancestor and exit 1 after simulated rebase/amend — both cases detected correctly.
- [x] Normal (non-rebased) flow unchanged — ancestry check passes, delta proceeds as before.

Closes #64 (addresses the rebase fragility raised in comments; the broader commit-keying proposal in the issue is a separate design question answered in the thread)