### PR TITLE
feat(skill): wiki-quick-chat-capture — zero-friction mid-session finding capture

### DIFF
--- a/.skills/wiki-quick-chat-capture/SKILL.md
+++ b/.skills/wiki-quick-chat-capture/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: wiki-quick-chat-capture
+description: >
+  Fast, zero-friction capture of technical findings from the current conversation to the wiki's
+  _raw/ staging area. Use this skill when the user says "/wiki-quick-chat-capture", "quick capture",
+  "capture this finding", "save this bug fix", "capture this gotcha", "drop this to raw",
+  "quick save to wiki", or wants to capture a non-obvious discovery mid-session without a full
+  wiki-ingest run. Writes one _raw/ file per topic cluster in under 60 seconds — no subagents,
+  no QMD updates, no manifest writes. Run /wiki-ingest or /data-ingest later to promote raw
+  files to proper wiki pages.
+---
+
+# Wiki Quick Chat Capture
+
+Extract reusable technical findings from the current conversation and stage them in `_raw/` for
+later promotion. The goal is zero-friction capture of discoveries that would otherwise be lost
+when the session ends.
+
+## When to Use This Skill
+
+This is the right tool when:
+- The user just hit a non-obvious bug or confirmed a framework gotcha mid-session
+- There's a concrete finding worth keeping but a full `/wiki-ingest` run would be too disruptive
+- The user wants to offload the knowledge now and defer promotion to end-of-day
+
+It is NOT a replacement for `wiki-capture` (which promotes directly to a final wiki page) or
+`wiki-ingest` (which handles full document ingestion with cross-links and manifest tracking).
+
+## Before You Start
+
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up
+   CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
+2. Ensure `$OBSIDIAN_VAULT_PATH/_raw/` exists. If not, create it.
+
+## Step 1: Scan the Conversation for Findings
+
+Read the current conversation and extract **reusable technical findings** — knowledge that would
+be valuable in 3 months with no memory of this chat.
+
+**Worth capturing:**
+- Non-obvious bugs and their root causes
+- Framework or library gotchas (undocumented behavior, edge cases)
+- API behavior that surprised the user
+- Workarounds or fixes that required investigation
+- Environment/toolchain quirks
+- Patterns that emerged from debugging or testing
+
+**Skip:**
+- Greetings, logistics, meta-conversation
+- Exploratory back-and-forth where no conclusion was reached
+- Things already known or obvious from documentation
+- Content the user has already saved elsewhere
+
+If nothing material emerged, tell the user and stop.
+
+## Step 2: Cluster by Topic
+
+Group related findings under a single topic. One cluster → one raw file.
+
+- If a single bug was investigated, that's one cluster
+- If two unrelated API gotchas came up, those are two clusters
+- If a sequence of related fixes all point to the same root cause, that's one cluster
+
+Name each cluster with a brief slug: `swift-actor-reentrancy`, `nextjs-hydration-mismatch`,
+`postgres-advisory-locks`, etc.
+
+## Step 3: Infer Project Context
+
+Check the conversation for clues about the active project: repository names, file paths,
+framework mentions, error messages. Use the most specific project name you can reliably infer.
+If unclear, use `null`.
+
+## Step 4: Write Raw Files
+
+For each cluster, write a file to `$OBSIDIAN_VAULT_PATH/_raw/YYYY-MM-DD-<slug>.md` using
+today's date. Use the format below exactly — it is designed to be compatible with `wiki-ingest`
+and `data-ingest` for seamless promotion.
+
+```yaml
+---
+title: "<descriptive title>"
+category: skills
+tags: [<2-4 domain tags matching the vault taxonomy>]
+summary: "<1-2 sentences, ≤200 chars — what is the finding?>""
+tier: supporting
+related: []
+extends: null
+contradicts: null
+superseded_by: null
+capture_source: claude-session
+project: <project-name or null>
+base_confidence: <0.6-0.9 based on how clearly confirmed the finding was>
+lifecycle: draft
+lifecycle_changed: <ISO date today>
+provenance:
+  extracted: <0.0-1.0 — how much was stated directly in the session>
+  inferred: <0.0-1.0 — how much was synthesized or generalized>
+sources:
+  - "claude-session <ISO date today>"
+---
+```
+
+**Calibrating `base_confidence`:**
+- 0.6 — finding was discussed but not fully confirmed
+- 0.75 — fix was applied and appeared to work in the session
+- 0.9 — finding was confirmed with a reproducible test or clear evidence
+
+**Body structure** — use the finding block format:
+
+```markdown
+# <Title>
+
+## Problem
+<What went wrong or what was surprising — be specific about the symptom>
+
+## Root Cause
+<Why it happened — the underlying mechanism, not just the surface error>
+
+## Fix
+<What resolved it — commands, code patterns, config changes>
+
+## Confirmed By
+<How the fix was validated — test passed, behavior changed, error disappeared>
+
+## Notes
+<Caveats, related edge cases, follow-up questions — omit if none>
+```
+
+If the finding is a "gotcha" rather than a bug/fix, adapt freely:
+- **Gotcha** → use "Behavior" instead of "Problem", "Explanation" instead of "Root Cause",
+  "Workaround / Pattern" instead of "Fix"
+
+Apply provenance markers per the `llm-wiki` convention:
+- No marker — explicitly stated in the conversation
+- `^[inferred]` — synthesized or generalized beyond what was explicitly said
+- `^[ambiguous]` — uncertain or potentially incomplete
+
+## Step 5: Confirm to User
+
+Report what was written, one line per file:
+
+```
+Staged to _raw/:
+  _raw/2026-05-27-swift-actor-reentrancy.md  — "Actor reentrancy causes deadlock in async forEach"
+  _raw/2026-05-27-xcode-derived-data-cache.md — "Stale derived data silently breaks incremental builds"
+
+Run /wiki-ingest (or /data-ingest) to promote these to full wiki pages.
+```
+
+If nothing was captured, say: "Nothing worth capturing found in this session."
+
+## What This Skill Does NOT Do
+
+- No manifest writes — `_raw/` files are not tracked in `.manifest.json`
+- No `index.md` or `log.md` updates — those happen during promotion
+- No `hot.md` update — not a full write operation
+- No QMD refresh — raw files are drafts, not indexed content
+- No subagents — everything runs inline, in this context window
+
+These are intentional constraints. The whole point is speed. Promotion via `/wiki-ingest` handles
+all of the above when the user is ready.

--- a/.skills/wiki-quick-chat-capture/SKILL.md
+++ b/.skills/wiki-quick-chat-capture/SKILL.md
@@ -8,6 +8,10 @@ description: >
   wiki-ingest run. Writes one _raw/ file per topic cluster in under 60 seconds — no subagents,
   no QMD updates, no manifest writes. Run /wiki-ingest or /data-ingest later to promote raw
   files to proper wiki pages.
+compatibility: Requires ~/.obsidian-wiki/config or OBSIDIAN_VAULT_PATH env var. qmd CLI optional.
+metadata:
+  version: "1.0"
+allowed-tools: Bash Read Write
 ---
 
 # Wiki Quick Chat Capture
@@ -16,28 +20,32 @@ Extract reusable technical findings from the current conversation and stage them
 later promotion. The goal is zero-friction capture of discoveries that would otherwise be lost
 when the session ends.
 
+**Speed contract:** Inline only. No subagents. No QMD. No manifest writes. Target: <60 seconds.
+
 ## When to Use This Skill
 
-This is the right tool when:
+Right tool when:
 - The user just hit a non-obvious bug or confirmed a framework gotcha mid-session
 - There's a concrete finding worth keeping but a full `/wiki-ingest` run would be too disruptive
 - The user wants to offload the knowledge now and defer promotion to end-of-day
 
-It is NOT a replacement for `wiki-capture` (which promotes directly to a final wiki page) or
-`wiki-ingest` (which handles full document ingestion with cross-links and manifest tracking).
+NOT a replacement for `wiki-capture` (promotes directly to a final wiki page) or
+`wiki-ingest` (full document ingestion with cross-links and manifest tracking).
 
 ## Before You Start
 
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up
-   CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
-2. Ensure `$OBSIDIAN_VAULT_PATH/_raw/` exists. If not, create it.
+   CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). Extract:
+   - `OBSIDIAN_VAULT_PATH`
+   - `OBSIDIAN_RAW_DIR` (default: `$OBSIDIAN_VAULT_PATH/_raw`)
+2. Ensure `$OBSIDIAN_RAW_DIR` exists. If not, create it.
 
 ## Step 1: Scan the Conversation for Findings
 
-Read the current conversation and extract **reusable technical findings** — knowledge that would
-be valuable in 3 months with no memory of this chat.
+Extract **reusable technical knowledge** — things worth having in 3 months with no memory of
+this session.
 
-**Worth capturing:**
+**Capture:**
 - Non-obvious bugs and their root causes
 - Framework or library gotchas (undocumented behavior, edge cases)
 - API behavior that surprised the user
@@ -46,116 +54,61 @@ be valuable in 3 months with no memory of this chat.
 - Patterns that emerged from debugging or testing
 
 **Skip:**
-- Greetings, logistics, meta-conversation
+- Project management updates, roadmap changes, config already in CLAUDE.md
 - Exploratory back-and-forth where no conclusion was reached
-- Things already known or obvious from documentation
-- Content the user has already saved elsewhere
+- Things obvious from the docs or boilerplate any developer finds on first read
+- Pleasantries, meta-conversation, status updates
 
 If nothing material emerged, tell the user and stop.
 
 ## Step 2: Cluster by Topic
 
-Group related findings under a single topic. One cluster → one raw file.
+Group related findings — one raw file per topic cluster, not per individual finding.
 
-- If a single bug was investigated, that's one cluster
-- If two unrelated API gotchas came up, those are two clusters
-- If a sequence of related fixes all point to the same root cause, that's one cluster
+Examples: "Swift 6 concurrency gotchas", "Next.js hydration edge cases", "Postgres advisory locks".
 
-Name each cluster with a brief slug: `swift-actor-reentrancy`, `nextjs-hydration-mismatch`,
-`postgres-advisory-locks`, etc.
+Name each cluster as a kebab-case slug: `swift-actor-reentrancy`, `nextjs-hydration-mismatch`.
 
 ## Step 3: Infer Project Context
 
-Check the conversation for clues about the active project: repository names, file paths,
-framework mentions, error messages. Use the most specific project name you can reliably infer.
-If unclear, use `null`.
+Check the conversation for clues — repo names, file paths, framework mentions, error messages.
+Use the most specific project name you can reliably infer. If unclear, use `null`.
 
 ## Step 4: Write Raw Files
 
-For each cluster, write a file to `$OBSIDIAN_VAULT_PATH/_raw/YYYY-MM-DD-<slug>.md` using
-today's date. Use the format below exactly — it is designed to be compatible with `wiki-ingest`
-and `data-ingest` for seamless promotion.
+For each cluster, write `$OBSIDIAN_RAW_DIR/<ISO-date>-<slug>.md`.
 
-```yaml
----
-title: "<descriptive title>"
-category: skills
-tags: [<2-4 domain tags matching the vault taxonomy>]
-summary: "<1-2 sentences, ≤200 chars — what is the finding?>""
-tier: supporting
-related: []
-extends: null
-contradicts: null
-superseded_by: null
-capture_source: claude-session
-project: <project-name or null>
-base_confidence: <0.6-0.9 based on how clearly confirmed the finding was>
-lifecycle: draft
-lifecycle_changed: <ISO date today>
-provenance:
-  extracted: <0.0-1.0 — how much was stated directly in the session>
-  inferred: <0.0-1.0 — how much was synthesized or generalized>
-sources:
-  - "claude-session <ISO date today>"
----
-```
+Read `references/RAW-FORMAT.md` for the full frontmatter spec, body structure (finding block
+format), and the provenance/confidence calibration table.
 
-**Calibrating `base_confidence`:**
-- 0.6 — finding was discussed but not fully confirmed
-- 0.75 — fix was applied and appeared to work in the session
-- 0.9 — finding was confirmed with a reproducible test or clear evidence
-
-**Body structure** — use the finding block format:
-
-```markdown
-# <Title>
-
-## Problem
-<What went wrong or what was surprising — be specific about the symptom>
-
-## Root Cause
-<Why it happened — the underlying mechanism, not just the surface error>
-
-## Fix
-<What resolved it — commands, code patterns, config changes>
-
-## Confirmed By
-<How the fix was validated — test passed, behavior changed, error disappeared>
-
-## Notes
-<Caveats, related edge cases, follow-up questions — omit if none>
-```
-
-If the finding is a "gotcha" rather than a bug/fix, adapt freely:
-- **Gotcha** → use "Behavior" instead of "Problem", "Explanation" instead of "Root Cause",
-  "Workaround / Pattern" instead of "Fix"
-
-Apply provenance markers per the `llm-wiki` convention:
-- No marker — explicitly stated in the conversation
-- `^[inferred]` — synthesized or generalized beyond what was explicitly said
-- `^[ambiguous]` — uncertain or potentially incomplete
+Quick reference for frontmatter fields that vary per cluster:
+- `title` — descriptive cluster title
+- `tags` — 2–4 domain tags matching the vault taxonomy
+- `summary` — 1–2 sentences, ≤200 chars
+- `project` — inferred project name or `null`
+- `base_confidence` — 0.6 (discussed, unconfirmed) → 0.75 (fix applied) → 0.9 (test confirmed)
+- `provenance.extracted` / `provenance.inferred` — must sum to 1.0
+- `lifecycle_changed` — today's ISO date
+- `sources` — `"<project> session (<YYYY-MM-DD>)"`
 
 ## Step 5: Confirm to User
 
-Report what was written, one line per file:
-
 ```
 Staged to _raw/:
-  _raw/2026-05-27-swift-actor-reentrancy.md  — "Actor reentrancy causes deadlock in async forEach"
+  _raw/2026-05-27-swift-actor-reentrancy.md   — "Actor reentrancy causes deadlock in async forEach"
   _raw/2026-05-27-xcode-derived-data-cache.md — "Stale derived data silently breaks incremental builds"
 
 Run /wiki-ingest (or /data-ingest) to promote these to full wiki pages.
 ```
 
-If nothing was captured, say: "Nothing worth capturing found in this session."
+If nothing was captured: "Nothing worth capturing found in this session."
 
 ## What This Skill Does NOT Do
 
 - No manifest writes — `_raw/` files are not tracked in `.manifest.json`
-- No `index.md` or `log.md` updates — those happen during promotion
-- No `hot.md` update — not a full write operation
+- No `index.md`, `log.md`, or `hot.md` updates — those happen during promotion
 - No QMD refresh — raw files are drafts, not indexed content
-- No subagents — everything runs inline, in this context window
+- No subagents — everything runs inline in this context window
 
-These are intentional constraints. The whole point is speed. Promotion via `/wiki-ingest` handles
+These constraints are intentional. Speed is the point. Promotion via `/wiki-ingest` handles
 all of the above when the user is ready.

--- a/.skills/wiki-quick-chat-capture/references/RAW-FORMAT.md
+++ b/.skills/wiki-quick-chat-capture/references/RAW-FORMAT.md
@@ -1,0 +1,115 @@
+# Raw File Format Reference
+
+Full specification for `_raw/` files written by `wiki-quick-chat-capture`.
+These files are designed to be promoted by `/wiki-ingest` or `/data-ingest`.
+
+## Frontmatter
+
+```yaml
+---
+title: "<Descriptive cluster title>"
+category: skills
+tags:
+  - topic/<primary-tech>
+  - <1-3 additional domain tags from vault taxonomy>
+summary: "<1–2 sentences, ≤200 chars — what is this finding about?>"
+tier: supporting
+related: []
+extends: null
+contradicts: null
+superseded_by: null
+capture_source: claude-session
+project: "<project name or null>"
+base_confidence: 0.75
+lifecycle: draft
+lifecycle_changed: <YYYY-MM-DD>
+provenance:
+  extracted: 0.85
+  inferred: 0.15
+sources:
+  - "<project> session (<YYYY-MM-DD>)"
+---
+```
+
+## Body: Finding Block
+
+For bugs and fixes:
+
+```markdown
+## <Finding Title>
+
+**Problem:** <what was non-obvious or broken — be specific about the symptom>
+
+**Root cause:** <why it happened — the underlying mechanism, not just the error message>
+
+**Fix:**
+```<lang>
+// ❌ before
+// ✅ after
+```
+
+**Confirmed by:** <build pass / test pass / live app / error disappeared>
+```
+
+For gotchas and API quirks (no traditional bug/fix arc):
+
+```markdown
+## <Gotcha Title>
+
+**Behavior:** <what surprised the user>
+
+**Explanation:** <why it works this way>
+
+**Workaround / Pattern:** <what to do instead>
+
+**Confirmed by:** <how it was validated>
+```
+
+Omit sections that have nothing to say. Add a `**Notes:**` block at the end for caveats,
+related edge cases, or follow-up questions.
+
+---
+
+## Provenance + Confidence Calibration
+
+Apply provenance markers inline per the `llm-wiki` convention:
+
+| Marker | When to use |
+|---|---|
+| *(none)* | Explicitly stated in the conversation |
+| `^[inferred]` | Synthesized or generalized beyond what was directly said |
+| `^[ambiguous]` | Uncertain, potentially incomplete, or contradicted elsewhere |
+
+Use the table below to set `base_confidence` and the `provenance` split:
+
+| Evidence strength | `extracted` | `inferred` | `base_confidence` |
+|---|---|---|---|
+| Build error + test pass | 0.90 | 0.10 | 0.80–0.90 |
+| Fix applied, appeared to work | 0.75 | 0.25 | 0.70–0.75 |
+| Discussed, not fully confirmed | 0.60 | 0.40 | 0.60 |
+| Reasoned from a single case | 0.50 | 0.50 | 0.55 |
+
+`extracted + inferred` should sum to 1.0 (or include a small `ambiguous` fraction if applicable).
+
+---
+
+## Multiple Findings in One File
+
+When several related findings belong to the same topic cluster, place them sequentially
+in the body — each as its own finding block with a `##` heading. Use a short intro paragraph
+before the first block to explain what ties them together.
+
+```markdown
+# Swift 6 Concurrency Gotchas
+
+Findings from migrating an iOS app to strict concurrency checking. All confirmed during
+the build phase.
+
+## Actor reentrancy in async forEach
+
+**Problem:** ...
+
+## MainActor isolation not inferred on @Observable
+
+**Problem:** ...
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | "export wiki" / "export graph" / "graphml" / "neo4j" | `wiki-export` |
 | "color my graph" / "color code obsidian" / "color by tag/category/visibility" | `graph-colorize` |
 | "save this" / "/wiki-capture" / "capture this" / "file this conversation" | `wiki-capture` |
+| "/wiki-quick-chat-capture" / "quick capture" / "capture this finding" / "save this gotcha" / "drop to raw" | `wiki-quick-chat-capture` |
 | "/wiki-research [topic]" / "research X" / "find everything about Y" | `wiki-research` |
 | "create a dashboard" / "vault dashboard" / "show all X as a table" / "dynamic view" | `wiki-dashboard` |
 | "synthesize my wiki" / "find connections" / "what concepts keep coming up together" / "/wiki-synthesize" | `wiki-synthesize` |


### PR DESCRIPTION
Closes #69

## Summary

- Adds `.skills/wiki-quick-chat-capture/SKILL.md` — a new lightweight inline skill that extracts reusable technical findings from the current conversation and writes structured draft files to `_raw/`
- Registers the skill in `AGENTS.md` skill routing table with its trigger phrases
- No subagents, no QMD refresh, no manifest writes — completes in < 60 seconds

## How It Works

```
[during session]
/wiki-quick-chat-capture

→ scans current chat for bugs, gotchas, non-obvious API behaviour
→ clusters findings by topic
→ writes _raw/YYYY-MM-DD-<slug>.md per cluster (frontmatter + Problem/Root Cause/Fix/Confirmed By body)
→ reports staged paths to user

[end of day]
/wiki-ingest   (or /data-ingest)

→ promotes _raw/ files to proper wiki pages with cross-links, QMD, and manifest tracking
```

## Raw File Format

Each staged file carries `wiki-ingest`/`data-ingest`-compatible frontmatter including `capture_source: claude-session`, `lifecycle: draft`, `provenance` block, and `base_confidence` calibrated to how clearly the finding was confirmed in the session.

## Test Plan

- [ ] Trigger `/wiki-quick-chat-capture` mid-session and confirm `_raw/` files appear with correct frontmatter
- [ ] Verify `base_confidence` and `provenance` fields are reasonable for the conversation content
- [ ] Run `/wiki-ingest` after capture and confirm raw files are promoted correctly
- [ ] Confirm no manifest, QMD, index, or log files are touched during quick capture