### PR TITLE
Package as a pip-installable PyPI distribution

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,63 @@
+name: publish
+
+# Build and publish obsidian-wiki to PyPI when a version tag is pushed.
+#
+# Setup (one-time): on PyPI, add a Trusted Publisher for this repo with
+# workflow `publish.yml` and environment `pypi`. No API token needed — the
+# `id-token: write` permission below mints a short-lived OIDC credential.
+#
+# Release: bump `version` in pyproject.toml, commit, then
+#   git tag v0.1.0 && git push origin v0.1.0
+
+on:
+  push:
+    tags:
+      - "v*"
+  # Allow a manual build (artifacts only, no publish) for verification.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade build
+          python -m build
+      - name: Verify wheel bundles the skills
+        run: |
+          python -m pip install --upgrade twine
+          twine check dist/*
+          wheel=$(ls dist/*.whl)
+          echo "Inspecting $wheel"
+          if ! python -m zipfile -l "$wheel" | grep -q "obsidian_wiki/_data/skills/wiki-setup/SKILL.md"; then
+            echo "::error::wheel is missing bundled skills under obsidian_wiki/_data/skills/"
+            exit 1
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish on a real tag push, not workflow_dispatch.
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    environment: pypi
+    permissions:
+      id-token: write  # required for PyPI Trusted Publishing (OIDC)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,3 +61,5 @@ jobs:
           path: dist/
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,11 @@
 *.pyc
 __pycache__/
 
+# Python build artifacts (pyproject.toml / `python -m build`)
+/dist/
+/build/
+*.egg-info/
+
 # Agent skill symlinks (created by setup.sh) — these are just pointers to .skills/
 # We track them so cloners get the symlinks too, but if your git doesn't
 # preserve symlinks, run `bash setup.sh` after cloning.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,25 @@ We took that and built a framework around it. The whole thing is a set of markdo
 
 ## Quick Start
 
-### Install via Skills CLI (recommended)
+### Install via pip (recommended)
+
+```bash
+pip install obsidian-wiki
+obsidian-wiki setup --vault /path/to/your/vault
+```
+
+`obsidian-wiki setup` writes the config to `~/.obsidian-wiki/config` and installs every wiki skill into all your AI agents (Claude Code, Cursor, Codex, Gemini, Hermes, Pi, and more). Skills are symlinked to the installed package, so `pip install -U obsidian-wiki` upgrades them everywhere — just re-run `obsidian-wiki setup` to pick up new skills. Then open a project in your agent and say **"set up my wiki"**.
+
+```bash
+obsidian-wiki list              # list the bundled skills
+obsidian-wiki info              # show install paths, version, and config
+obsidian-wiki setup --project . # also drop project-local skills + AGENTS.md into the current repo
+obsidian-wiki setup --copy      # copy skill files instead of symlinking
+```
+
+`OBSIDIAN_VAULT_PATH` is just any directory where you want your wiki documents to live — a new empty folder or an existing Obsidian vault. Omit `--vault` to be prompted (or set it later in `~/.obsidian-wiki/config`).
+
+### Install via Skills CLI
 
 ```bash
 npx skills add Ar9av/obsidian-wiki

--- a/SETUP.md
+++ b/SETUP.md
@@ -4,7 +4,18 @@ A skill-based framework for AI coding agents — Claude Code, Cursor, Windsurf, 
 
 > Running `bash setup.sh` wires up every supported agent: project-local skill symlinks (`.claude/skills/`, `.cursor/skills/`, `.windsurf/skills/`, `.agents/skills/`, `.kiro/skills/`), global symlinks (`~/.claude/skills/`, `~/.gemini/skills/`, `~/.codex/skills/`, `~/.hermes/skills/`, `~/.openclaw/skills/`, `~/.copilot/skills/`, `~/.trae/skills/`, `~/.trae-cn/skills/`, `~/.kiro/skills/`, `~/.agents/skills/`), and always-on rule files (`CLAUDE.md`, `GEMINI.md`, `AGENTS.md`, `.hermes.md`, `.cursor/rules/…`, `.windsurf/rules/…`, `.kiro/steering/…`, `.agent/rules/…`, `.agent/workflows/…`, `.github/copilot-instructions.md`). See the [Agent Compatibility table in README.md](README.md#agent-compatibility) for the full matrix.
 
-## Quick Start
+## Install via pip (no clone needed)
+
+```bash
+pip install obsidian-wiki
+obsidian-wiki setup --vault /path/to/your/vault
+```
+
+This does everything `setup.sh` does without a clone: writes `~/.obsidian-wiki/config` and installs every skill into all supported agents' skills directories (symlinked to the installed package, so `pip install -U obsidian-wiki` upgrades them everywhere). Add `--project .` to also drop project-local skills and the `AGENTS.md` / rule files into the current repo, or `--copy` to copy skill files instead of symlinking. Run `obsidian-wiki info` to see resolved paths.
+
+The rest of this doc covers the `git clone` + `setup.sh` path.
+
+## Quick Start (git clone)
 
 ### 1. Set your vault path
 

--- a/obsidian_wiki/__init__.py
+++ b/obsidian_wiki/__init__.py
@@ -1,0 +1,14 @@
+"""obsidian-wiki: install the LLM-Wiki agent skills into your AI coding agents.
+
+The product is the markdown skill content under ``.skills/`` (bundled into this
+package as data). This module is just the installer CLI — see ``cli.py``.
+"""
+
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("obsidian-wiki")
+except PackageNotFoundError:  # running from a source tree without an install
+    __version__ = "0.0.0+dev"
+
+__all__ = ["__version__"]

--- a/obsidian_wiki/__main__.py
+++ b/obsidian_wiki/__main__.py
@@ -1,0 +1,6 @@
+"""Enable ``python -m obsidian_wiki``."""
+
+from obsidian_wiki.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -1,0 +1,398 @@
+"""obsidian-wiki installer CLI.
+
+Python port of ``setup.sh`` for the pip-installed package. The skill content
+lives inside the installed package (``obsidian_wiki/_data/skills``) instead of a
+cloned repo, so this wires the bundled skills into every supported AI agent's
+skills directory and writes ``~/.obsidian-wiki/config`` so the skills resolve
+the vault from any project.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+from obsidian_wiki import __version__
+
+HOME = Path.home()
+GLOBAL_CONFIG_DIR = HOME / ".obsidian-wiki"
+GLOBAL_CONFIG = GLOBAL_CONFIG_DIR / "config"
+
+# Skills usable from any project (no vault context needed beyond the global
+# config). These are also installed globally for agents that only scope skills
+# per-project, so cross-project sync/query work everywhere.
+PORTABLE_SKILLS = ("wiki-update", "wiki-query")
+
+
+# ── Data resolution ──────────────────────────────────────────────────────────
+# Works for both a built wheel (data under <pkg>/_data) and an editable/source
+# checkout (data at the repo root next to the package).
+def _pkg_dir() -> Path:
+    return Path(__file__).resolve().parent
+
+
+def skills_dir() -> Path:
+    """Return the directory holding the bundled skill folders."""
+    for cand in (_pkg_dir() / "_data" / "skills", _pkg_dir().parent / ".skills"):
+        if cand.is_dir():
+            return cand
+    raise FileNotFoundError(
+        "Could not locate bundled skills. Reinstall obsidian-wiki "
+        "(`pip install --force-reinstall obsidian-wiki`)."
+    )
+
+
+def bootstrap_dir() -> Path | None:
+    """Return the directory containing agent bootstrap context files.
+
+    For a wheel this is ``_data/bootstrap``; for a source checkout the files are
+    spread across the repo root, so we return the repo root and resolve each
+    file via the repo-relative layout in ``_bootstrap_files``.
+    """
+    built = _pkg_dir() / "_data" / "bootstrap"
+    if built.is_dir():
+        return built
+    repo = _pkg_dir().parent
+    if (repo / "AGENTS.md").is_file():
+        return repo
+    return None
+
+
+def list_skills() -> list[str]:
+    return sorted(p.name for p in skills_dir().iterdir() if p.is_dir())
+
+
+# ── Skill installation ───────────────────────────────────────────────────────
+def install_skills(
+    target_dir: Path,
+    label: str,
+    *,
+    subset: tuple[str, ...] | None = None,
+    mode: str = "symlink",
+    quiet: bool = False,
+) -> int:
+    """Install bundled skills into *target_dir*. Returns the count installed."""
+    src_root = skills_dir()
+    target_dir.mkdir(parents=True, exist_ok=True)
+    installed = 0
+    for skill in sorted(p for p in src_root.iterdir() if p.is_dir()):
+        name = skill.name
+        if subset is not None and name not in subset:
+            continue
+        link_path = target_dir / name
+
+        if link_path.is_symlink() or link_path.is_file():
+            link_path.unlink()
+        elif link_path.is_dir():
+            # A real directory we previously copied here is safe to replace;
+            # anything else is the user's and we leave it alone.
+            if (link_path / "SKILL.md").exists():
+                shutil.rmtree(link_path)
+            else:
+                print(f"   ⚠️  {link_path} is not a managed skill, skipping")
+                continue
+
+        if mode == "symlink":
+            link_path.symlink_to(skill, target_is_directory=True)
+        else:  # copy
+            shutil.copytree(skill, link_path)
+
+        if not (link_path / "SKILL.md").exists():
+            raise RuntimeError(f"broken skill install: {link_path} -> {skill}")
+        installed += 1
+
+    if not quiet:
+        print(f"✅  Installed {installed} skills → {label}")
+    return installed
+
+
+# Agents whose skills directory lives under $HOME. (path-under-home, label,
+# subset). All get every skill — pip users have no cloned repo to host
+# project-scoped skills, so everything must be globally discoverable.
+GLOBAL_AGENT_DIRS: list[tuple[str, str, tuple[str, ...] | None]] = [
+    (".claude/skills", "~/.claude/skills/ (Claude Code)", None),
+    (".gemini/skills", "~/.gemini/skills/ (Gemini CLI)", None),
+    (".gemini/antigravity/skills", "~/.gemini/antigravity/skills/ (Antigravity, legacy)", None),
+    (".codex/skills", "~/.codex/skills/ (Codex)", None),
+    (".hermes/skills", "~/.hermes/skills/ (Hermes default)", None),
+    (".openclaw/skills", "~/.openclaw/skills/ (OpenClaw)", None),
+    (".copilot/skills", "~/.copilot/skills/ (GitHub Copilot CLI)", None),
+    (".trae/skills", "~/.trae/skills/ (Trae)", None),
+    (".trae-cn/skills", "~/.trae-cn/skills/ (Trae CN)", None),
+    (".kiro/skills", "~/.kiro/skills/ (Kiro CLI)", None),
+    (".pi/agent/skills", "~/.pi/agent/skills/ (Pi)", None),
+    (".agents/skills", "~/.agents/skills/ (OpenCode, Aider, Droid, generic)", None),
+]
+
+
+def install_global_skills(mode: str) -> None:
+    for rel, label, subset in GLOBAL_AGENT_DIRS:
+        install_skills(HOME / rel, label, subset=subset, mode=mode)
+    _install_hermes_profiles(mode)
+
+
+def _install_hermes_profiles(mode: str) -> None:
+    """Mirror setup.sh: install into the active and all named Hermes profiles."""
+    hermes_home = os.environ.get("HERMES_HOME")
+    handled: set[Path] = set()
+    if hermes_home:
+        hp = Path(hermes_home).expanduser()
+        if hp != HOME / ".hermes":
+            install_skills(hp / "skills", f"{hp}/skills/ (Hermes active profile)", mode=mode)
+            handled.add(hp)
+    profiles = HOME / ".hermes" / "profiles"
+    if profiles.is_dir():
+        for prof in sorted(p for p in profiles.iterdir() if p.is_dir()):
+            if prof in handled:
+                continue
+            install_skills(
+                prof / "skills",
+                f"~/.hermes/profiles/{prof.name}/skills/ (Hermes profile: {prof.name})",
+                mode=mode,
+            )
+
+
+# ── Project-local install (opt-in) ───────────────────────────────────────────
+PROJECT_AGENT_DIRS = [
+    (".claude/skills", "Claude Code"),
+    (".cursor/skills", "Cursor"),
+    (".windsurf/skills", "Windsurf"),
+    (".agents/skills", "OpenCode / generic"),
+    (".pi/skills", "Pi"),
+    (".kiro/skills", "Kiro"),
+]
+
+# (bootstrap-relative source path, destination relative to project dir).
+# The source path is resolved against bootstrap_dir() for a wheel, or mapped to
+# the repo layout for a source checkout (see _resolve_bootstrap_src).
+BOOTSTRAP_FILES = [
+    ("AGENTS.md", "AGENTS.md"),
+    ("cursor/rules/obsidian-wiki.mdc", ".cursor/rules/obsidian-wiki.mdc"),
+    ("windsurf/rules/obsidian-wiki.md", ".windsurf/rules/obsidian-wiki.md"),
+    ("kiro/steering/obsidian-wiki.md", ".kiro/steering/obsidian-wiki.md"),
+    ("agent/rules/obsidian-wiki.md", ".agent/rules/obsidian-wiki.md"),
+    ("agent/workflows/obsidian-wiki.md", ".agent/workflows/obsidian-wiki.md"),
+    ("github/copilot-instructions.md", ".github/copilot-instructions.md"),
+]
+
+# AGENTS.md aliases created as symlinks within the project (single source).
+AGENTS_ALIASES = ("CLAUDE.md", "GEMINI.md", ".hermes.md")
+
+
+def _resolve_bootstrap_src(boot_root: Path, rel: str) -> Path | None:
+    """Resolve a bootstrap source path under a wheel layout or repo layout."""
+    built = boot_root / rel
+    if built.exists():
+        return built
+    # Source checkout: boot_root is the repo root; files use the repo layout.
+    repo_rel = {
+        "AGENTS.md": "AGENTS.md",
+        "cursor/rules/obsidian-wiki.mdc": ".cursor/rules/obsidian-wiki.mdc",
+        "windsurf/rules/obsidian-wiki.md": ".windsurf/rules/obsidian-wiki.md",
+        "kiro/steering/obsidian-wiki.md": ".kiro/steering/obsidian-wiki.md",
+        "agent/rules/obsidian-wiki.md": ".agent/rules/obsidian-wiki.md",
+        "agent/workflows/obsidian-wiki.md": ".agent/workflows/obsidian-wiki.md",
+        "github/copilot-instructions.md": ".github/copilot-instructions.md",
+    }.get(rel)
+    if repo_rel and (boot_root / repo_rel).exists():
+        return boot_root / repo_rel
+    return None
+
+
+def install_project(project_dir: Path, mode: str) -> None:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    print(f"\n📁  Installing project-local files → {project_dir}")
+    for rel, _label in PROJECT_AGENT_DIRS:
+        install_skills(project_dir / rel, f"{rel}/", mode=mode)
+
+    boot_root = bootstrap_dir()
+    if boot_root is None:
+        print("   ⚠️  Bootstrap files not found in package; skipping context files")
+        return
+
+    for rel, dest in BOOTSTRAP_FILES:
+        src = _resolve_bootstrap_src(boot_root, rel)
+        if src is None:
+            continue
+        dst = project_dir / dest
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if dst.is_symlink() or dst.exists():
+            if dst.is_dir() and not dst.is_symlink():
+                continue
+            dst.unlink()
+        shutil.copyfile(src, dst)
+    print("✅  Installed bootstrap context files (AGENTS.md, rules, workflows)")
+
+    # AGENTS.md aliases as relative symlinks (copy fallback for symlink-hostile FS).
+    for alias in AGENTS_ALIASES:
+        link = project_dir / alias
+        if link.is_symlink() or link.exists():
+            link.unlink()
+        try:
+            link.symlink_to("AGENTS.md")
+        except OSError:
+            shutil.copyfile(project_dir / "AGENTS.md", link)
+    print(f"✅  Linked AGENTS.md aliases ({', '.join(AGENTS_ALIASES)})")
+
+
+# ── Config ───────────────────────────────────────────────────────────────────
+def _read_config_value(key: str) -> str:
+    if not GLOBAL_CONFIG.is_file():
+        return ""
+    for line in GLOBAL_CONFIG.read_text().splitlines():
+        if line.startswith(f"{key}="):
+            return line.split("=", 1)[1].strip().strip('"')
+    return ""
+
+
+def resolve_vault_path(cli_vault: str | None) -> str:
+    if cli_vault:
+        return os.path.expanduser(cli_vault)
+    existing = _read_config_value("OBSIDIAN_VAULT_PATH")
+    if existing and existing != "/path/to/your/vault":
+        return existing
+    if sys.stdin.isatty():
+        try:
+            entered = input("  Where is your Obsidian vault? (absolute path): ").strip()
+        except EOFError:
+            entered = ""
+        if entered:
+            return os.path.expanduser(entered)
+    return existing
+
+
+def write_config(vault_path: str) -> None:
+    GLOBAL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    # OBSIDIAN_WIKI_REPO points at the bundled data root so skills that reference
+    # framework assets (templates, references) can find them post-install.
+    repo_root = skills_dir().parent
+    GLOBAL_CONFIG.write_text(
+        f'OBSIDIAN_VAULT_PATH="{vault_path}"\n'
+        f'OBSIDIAN_WIKI_REPO="{repo_root}"\n'
+    )
+    print(f"✅  Global config written to {GLOBAL_CONFIG}")
+
+
+# ── Commands ─────────────────────────────────────────────────────────────────
+def cmd_setup(args: argparse.Namespace) -> int:
+    mode = "copy" if args.copy else "symlink"
+    print("\n╔══════════════════════════════════════════════════╗")
+    print("║         obsidian-wiki — Agent Setup              ║")
+    print("╚══════════════════════════════════════════════════╝\n")
+
+    vault_path = resolve_vault_path(args.vault)
+    write_config(vault_path)
+    if not vault_path:
+        print("    → Vault path not set yet. Re-run with `--vault /path/to/vault`")
+        print("      or edit OBSIDIAN_VAULT_PATH in ~/.obsidian-wiki/config.")
+
+    if not args.project_only:
+        print()
+        install_global_skills(mode)
+
+    if args.project is not None:
+        project_dir = Path(args.project or os.getcwd()).expanduser().resolve()
+        install_project(project_dir, mode)
+
+    n = len(list_skills())
+    print("\n───────────────────────────────────────────────────")
+    print(" Setup complete!\n")
+    print(f" Skills installed: {n}  (mode: {mode})")
+    if vault_path:
+        print(f" Vault:            {vault_path}")
+    print("\n Next steps:")
+    print("   1. Open a project in your agent")
+    print('   2. Say: "set up my wiki"\n')
+    print(" From any project:")
+    print("   /wiki-update    → sync knowledge into your vault")
+    print("   /wiki-query     → ask questions against your wiki")
+    print("───────────────────────────────────────────────────\n")
+    return 0
+
+
+def cmd_list(args: argparse.Namespace) -> int:
+    for name in list_skills():
+        print(name)
+    return 0
+
+
+def cmd_info(args: argparse.Namespace) -> int:
+    print(f"obsidian-wiki {__version__}")
+    print(f"skills:    {skills_dir()}")
+    boot = bootstrap_dir()
+    print(f"bootstrap: {boot if boot else '(not found)'}")
+    print(f"config:    {GLOBAL_CONFIG}{'' if GLOBAL_CONFIG.exists() else ' (not written yet)'}")
+    if GLOBAL_CONFIG.exists():
+        vp = _read_config_value("OBSIDIAN_VAULT_PATH")
+        print(f"vault:     {vp or '(unset)'}")
+    print(f"skill count: {len(list_skills())}")
+    return 0
+
+
+# ── Argument parsing ─────────────────────────────────────────────────────────
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="obsidian-wiki",
+        description="Install the LLM-Wiki agent skills into your AI coding agents.",
+    )
+    p.add_argument("-V", "--version", action="version", version=f"obsidian-wiki {__version__}")
+    sub = p.add_subparsers(dest="command")
+
+    sp = sub.add_parser("setup", help="install skills into your agents and write config (default)")
+    _add_setup_args(sp)
+    sp.set_defaults(func=cmd_setup)
+
+    lp = sub.add_parser("list", help="list bundled skills")
+    lp.set_defaults(func=cmd_list)
+
+    ip = sub.add_parser("info", help="show install paths, version, and config")
+    ip.set_defaults(func=cmd_info)
+
+    return p
+
+
+def _add_setup_args(sp: argparse.ArgumentParser) -> None:
+    sp.add_argument("--vault", metavar="PATH", help="absolute path to your Obsidian vault")
+    sp.add_argument(
+        "--project",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="DIR",
+        help="also install project-local skills + bootstrap files into DIR "
+        "(defaults to the current directory if no DIR given)",
+    )
+    sp.add_argument(
+        "--project-only",
+        action="store_true",
+        help="skip the global agent install (use with --project)",
+    )
+    sp.add_argument(
+        "--copy",
+        action="store_true",
+        help="copy skill files instead of symlinking to the installed package",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    argv = list(sys.argv[1:] if argv is None else argv)
+    # No subcommand → default to `setup` (the common case).
+    if not argv or (argv[0].startswith("-") and argv[0] not in ("-h", "--help", "-V", "--version")):
+        argv = ["setup", *argv]
+    args = parser.parse_args(argv)
+    if not getattr(args, "func", None):
+        parser.print_help()
+        return 0
+    try:
+        return args.func(args)
+    except (FileNotFoundError, RuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,83 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "obsidian-wiki"
+version = "0.1.0"
+description = "A skill-based framework for building and maintaining an AI-maintained Obsidian knowledge base (Karpathy's LLM Wiki pattern) across any AI coding agent."
+readme = "README.md"
+requires-python = ">=3.9"
+license = "MIT"
+license-files = ["LICENSE"]
+authors = [{ name = "Ar9av" }]
+keywords = [
+  "obsidian",
+  "wiki",
+  "knowledge-base",
+  "llm",
+  "claude",
+  "agent-skills",
+  "second-brain",
+]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Topic :: Documentation",
+  "Topic :: Text Processing :: Markup :: Markdown",
+  "Topic :: Utilities",
+]
+# Pure-stdlib CLI — installing skills needs no third-party runtime dependencies.
+dependencies = []
+
+[project.urls]
+Homepage = "https://github.com/Ar9av/obsidian-wiki"
+Repository = "https://github.com/Ar9av/obsidian-wiki"
+Issues = "https://github.com/Ar9av/obsidian-wiki/issues"
+
+[project.scripts]
+obsidian-wiki = "obsidian_wiki.cli:main"
+
+# ── Build configuration ──────────────────────────────────────────────────────
+# The Python package is just the thin CLI in obsidian_wiki/. The actual product
+# is the markdown skill content under .skills/ plus the agent bootstrap files.
+# We force-include those into the wheel under obsidian_wiki/_data/ so the
+# installed package is self-contained and the CLI can install skills without a
+# cloned repo. Source paths stay at the repo root (single source of truth).
+
+[tool.hatch.build.targets.wheel]
+packages = ["obsidian_wiki"]
+
+[tool.hatch.build.targets.wheel.force-include]
+".skills" = "obsidian_wiki/_data/skills"
+".env.example" = "obsidian_wiki/_data/.env.example"
+"AGENTS.md" = "obsidian_wiki/_data/bootstrap/AGENTS.md"
+".cursor/rules/obsidian-wiki.mdc" = "obsidian_wiki/_data/bootstrap/cursor/rules/obsidian-wiki.mdc"
+".windsurf/rules/obsidian-wiki.md" = "obsidian_wiki/_data/bootstrap/windsurf/rules/obsidian-wiki.md"
+".kiro/steering/obsidian-wiki.md" = "obsidian_wiki/_data/bootstrap/kiro/steering/obsidian-wiki.md"
+".agent/rules/obsidian-wiki.md" = "obsidian_wiki/_data/bootstrap/agent/rules/obsidian-wiki.md"
+".agent/workflows/obsidian-wiki.md" = "obsidian_wiki/_data/bootstrap/agent/workflows/obsidian-wiki.md"
+".github/copilot-instructions.md" = "obsidian_wiki/_data/bootstrap/github/copilot-instructions.md"
+
+[tool.hatch.build.targets.sdist]
+# Prune build noise and the committed agent symlink mirrors (the CLI
+# regenerates those; left in, hatchling's VCS walker treats them as the
+# canonical path for each skill and drops the real .skills/<name> files).
+exclude = [
+  "/.claude",
+  "/.cursor/skills",
+  "/.windsurf/skills",
+  "/.agents/skills",
+  "/.pi/skills",
+  "/.kiro/skills",
+  "/dist",
+  "/build",
+]
+
+# Force the real .skills/ tree into the sdist regardless of the VCS walker, so
+# the wheel (built from the sdist) can in turn force-include it under _data/.
+[tool.hatch.build.targets.sdist.force-include]
+".skills" = ".skills"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "obsidian-wiki"
-version = "0.1.0"
+dynamic = ["version"]
 description = "A skill-based framework for building and maintaining an AI-maintained Obsidian knowledge base (Karpathy's LLM Wiki pattern) across any AI coding agent."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -40,6 +40,11 @@ Issues = "https://github.com/Ar9av/obsidian-wiki/issues"
 
 [project.scripts]
 obsidian-wiki = "obsidian_wiki.cli:main"
+
+# Version is derived from the git tag (CalVer, e.g. v2026.05.2 -> 2026.5.2),
+# matching the repo's release tags. Tagging a release is the version bump.
+[tool.hatch.version]
+source = "vcs"
 
 # ── Build configuration ──────────────────────────────────────────────────────
 # The Python package is just the thin CLI in obsidian_wiki/. The actual product


### PR DESCRIPTION
Closes #71.

Publishes `obsidian-wiki` to PyPI so users can install without cloning the repo.

## What's in here
- **`pyproject.toml`** (hatchling, zero runtime deps). The Python package is the thin CLI; the markdown skills (`.skills/`) and bootstrap files are `force-include`d into the wheel under `obsidian_wiki/_data/` — repo root stays the single source of truth, no duplication.
- **`obsidian_wiki/` CLI** — a Python port of `setup.sh`:
  - `obsidian-wiki setup [--vault PATH]` writes `~/.obsidian-wiki/config` and **symlinks all skills** into every supported agent's skills dir (Claude, Codex, Gemini, Hermes + profiles, Pi, Copilot, Trae, Kiro, …). Symlinks point into the installed package, so `pip install -U obsidian-wiki` propagates updates everywhere.
  - `--copy` (instead of symlink), `--project [DIR]` (project-local skills + `AGENTS.md`/rule files), `--project-only`, plus `list` and `info`.
- **`.github/workflows/publish.yml`** — build + `twine check` + a guard asserting the wheel actually bundles the skills, then publish on `v*` tags via PyPI **Trusted Publishing** (OIDC, no token).
- **Docs** — pip install section added to `README.md` and `SETUP.md`; `.gitignore` covers build artifacts.

## Package name
`obsidian-wiki` — confirmed available on PyPI (matches the repo). `obsidian-llm-wiki` is already taken by an unrelated project.

## Design decisions (confirmed with maintainer)
- **Symlink** to the installed package by default (single source of truth; `--copy` available for symlink-hostile filesystems).
- **All** skills into the global `~/.claude/skills/` — pip users have no cloned repo to host project-scoped skills.

## Verified locally
- sdist + wheel both bundle all 37 skills (incl. nested `references/`, `scripts/`, `agents/` assets); `twine check` PASSED.
- Clean-venv install: CLI resolves data from `_data`, symlinks resolve to real `SKILL.md`s, `--version`/`info`/`list` work, and copy/project/project-only modes + idempotent re-runs all verified.

> Implementation note: the repo's committed agent symlink mirrors (`.claude/skills/<name>` → `.skills/<name>`) confuse hatchling's sdist VCS walker (it treats the symlink as canonical and drops the real `.skills` files), so `python -m build` initially shipped 1/37 skills. Fixed with an sdist `force-include` of `.skills`.

## Before first release (maintainer action)
1. On PyPI, register a Trusted Publisher for this repo: workflow `publish.yml`, environment `pypi`.
2. `git tag v0.1.0 && git push origin v0.1.0`.