### PR TITLE
fix(wiki-ingest): derive promoted page sources from _raw frontmatter, not _raw path

### DIFF
--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -64,6 +64,13 @@ Process draft pages from the `_raw/` staging directory inside the vault. Use whe
 
 In raw mode, each file in `OBSIDIAN_VAULT_PATH/_raw/` (or `OBSIDIAN_RAW_DIR`) is treated as a source. After promoting a file to a proper wiki page, **delete the original from `_raw/`**. Never leave promoted files in `_raw/` — they'll be double-processed on the next run.
 
+**Source inheritance:** The `_raw/` path is a staging artifact — never use it as the `sources:` value on the promoted page. Derive the source entry from the `_raw/` file's own frontmatter instead:
+
+- If the file has both `capture_source` and `sources:` fields, synthesize a combined entry:
+  `"agent:<capture_source> source:<capture_source> project:<project> date:<lifecycle_changed>"`
+- If the file has only `sources:`, copy those entries verbatim.
+- Only fall back to the `_raw/` filename if the file has no `sources:` or `capture_source` fields at all.
+
 **Deletion safety:** Only delete the specific file that was just promoted. Before deleting, verify the resolved path is inside `$OBSIDIAN_VAULT_PATH/_raw/` — never delete files outside this directory. Never use wildcards or recursive deletion (`rm -rf`, `rm *`). Delete one file at a time by its exact path.
 
 ## The Ingest Process
@@ -229,7 +236,7 @@ For each page in your plan:
 - Use the page template from the llm-wiki skill (frontmatter + sections)
 - Place in the correct category directory
 - Add `[[wikilinks]]` to at least 2-3 existing pages
-- Include the source in the `sources` frontmatter field
+- Include the source in the `sources` frontmatter field. In raw mode: derive from `capture_source` + `sources` frontmatter of the `_raw/` file — never use the `_raw/` path itself (see Raw Mode section)
 
 **If updating an existing page:**
 - Read the current page first


### PR DESCRIPTION
## Problem

When promoting `_raw/` drafts in Raw Mode, the skill instructed agents
to "include the source in the `sources` frontmatter field" with no
guidance on which source to use. Agents defaulted to the `_raw/<filename>`
path — a staging artifact — instead of the real origin.

`wiki-quick-chat-capture` already writes two relevant frontmatter fields
into every `_raw/` file:
- `capture_source: claude-session` — who wrote the draft
- `sources: "<project> session (<YYYY-MM-DD>)"` — what session it came from

The ingest step was silently discarding both and recording the internal
staging path instead.

## Fix

Two edits to `.skills/wiki-ingest/SKILL.md`:

1. **Raw Mode section** — added a `Source inheritance:` rule with a
   priority ladder:
   - Both `capture_source` + `sources` present → synthesize combined entry:
     `"agent:<capture_source> source:<capture_source> project:<project> date:<lifecycle_changed>"`
   - Only `sources` present → copy verbatim
   - Neither present → fall back to `_raw/` filename

2. **Step 5 "Include the source" bullet** — inline reminder pointing to
   the Raw Mode rule so the instruction is visible at the point of action.

## Why this matters

`wiki-quick-chat-capture` (and any future capture tool) writes structured
provenance into `_raw/` files precisely so promoted pages carry accurate
origin data. The ingest step must not discard it.