### PR TITLE
feat(setup): GitHub sync for vault — wiki-sync command

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,10 @@ OBSIDIAN_VAULT_PATH=
 
 # --- Optional ---
 
+# GitHub remote for vault sync (set by setup.sh when you enable GitHub sync)
+# wiki-sync uses this to push committed vault changes
+VAULT_GITHUB_REMOTE=
+
 # Comma-separated source directories to ingest documents from
 # Leave empty to skip document ingestion
 OBSIDIAN_SOURCES_DIR=

--- a/README.md
+++ b/README.md
@@ -298,6 +298,48 @@ The directory is created automatically by `wiki-setup`. The path is configurable
 
 ---
 
+## Syncing your vault to GitHub
+
+Your vault is a directory of plain markdown files — push it to a private GitHub repo and you get version history, backup, and cross-device sync for free. `setup.sh` (and `obsidian-wiki setup`) will ask you to configure this during the initial install.
+
+**What setup does:**
+
+1. `git init` your vault if it isn't already a repo
+2. Creates a `.gitignore` that excludes Obsidian workspace/cache files
+3. Sets the GitHub remote you supply
+4. Writes `~/.obsidian-wiki/sync.sh` — a one-shot script that stages all changes, commits with a timestamp, and pushes
+5. Optionally adds a `wiki-sync` shell alias
+6. Optionally installs an hourly cron job
+
+**Run a sync at any time:**
+
+```bash
+wiki-sync                    # alias added by setup
+~/.obsidian-wiki/sync.sh     # or call the script directly
+```
+
+Each run commits staged changes as `sync 2026-06-08 14:00` and pushes.
+
+**Manual setup (skip the prompt):**
+
+```bash
+cd /path/to/your/vault
+git init
+git remote add origin https://github.com/you/my-wiki.git
+
+# then commit and push manually, or re-run setup.sh to get the sync script
+```
+
+**Hourly auto-sync via cron (can be enabled during setup):**
+
+```
+0 * * * * ~/.obsidian-wiki/sync.sh >> ~/.obsidian-wiki/sync.log 2>&1
+```
+
+> Keep the repo **private** if your vault contains personal notes. Nothing is sent to any third-party service — your vault lives on your machines and your GitHub account only.
+
+---
+
 ## Skills
 
 Everything lives in `.skills/`. Each skill is a markdown file the agent reads when triggered:

--- a/setup.sh
+++ b/setup.sh
@@ -210,7 +210,92 @@ install_skills "$HOME/.kiro/skills"               "~/.kiro/skills/ (Kiro CLI)"
 install_skills "$HOME/.pi/agent/skills"           "~/.pi/agent/skills/ (Pi)"
 install_skills "$HOME/.agents/skills"             "~/.agents/skills/ (OpenCode, Aider, Droid, generic)"
 
-# ── Step 4: Summary ──────────────────────────────────────────
+# ── Step 4: GitHub sync (optional) ───────────────────────────
+SYNC_CONFIGURED=false
+VAULT_REMOTE=""
+
+echo ""
+read -p "  Set up GitHub sync for your vault? [y/N]: " SETUP_SYNC || true
+if [[ "$SETUP_SYNC" =~ ^[Yy]$ ]]; then
+  read -p "  GitHub repo URL (e.g. https://github.com/you/my-wiki.git): " VAULT_REMOTE || true
+  if [ -n "$VAULT_REMOTE" ] && [ -n "$VAULT_PATH" ] && [ -d "$VAULT_PATH" ]; then
+    # Init git repo in vault if needed
+    if [ ! -d "$VAULT_PATH/.git" ]; then
+      git -C "$VAULT_PATH" init -q
+      echo "✅  Initialized git repo in vault"
+    fi
+    # Create .gitignore if missing
+    if [ ! -f "$VAULT_PATH/.gitignore" ]; then
+      cat > "$VAULT_PATH/.gitignore" <<'GITIGNORE'
+.obsidian/workspace.json
+.obsidian/workspace-mobile.json
+.obsidian/cache
+.trash/
+GITIGNORE
+      echo "✅  Created .gitignore in vault"
+    fi
+    # Add or update remote
+    if git -C "$VAULT_PATH" remote get-url origin &>/dev/null 2>&1; then
+      git -C "$VAULT_PATH" remote set-url origin "$VAULT_REMOTE"
+    else
+      git -C "$VAULT_PATH" remote add origin "$VAULT_REMOTE"
+    fi
+    echo "✅  Git remote → $VAULT_REMOTE"
+    # Persist remote in global config
+    echo "VAULT_GITHUB_REMOTE=\"$VAULT_REMOTE\"" >> "$GLOBAL_CONFIG"
+    # Write ~/.obsidian-wiki/sync.sh
+    cat > "$GLOBAL_CONFIG_DIR/sync.sh" <<'SYNC_SCRIPT'
+#!/bin/bash
+# wiki-sync — commit and push vault changes to GitHub
+set -e
+# shellcheck source=/dev/null
+source "$HOME/.obsidian-wiki/config" 2>/dev/null || true
+VAULT="${OBSIDIAN_VAULT_PATH:-}"
+[ -d "$VAULT" ] || { echo "wiki-sync: vault not found at '$VAULT'" >&2; exit 1; }
+cd "$VAULT"
+git add -A
+if git diff --cached --quiet; then
+  echo "wiki-sync: nothing to commit"
+  exit 0
+fi
+git commit -m "sync $(date '+%Y-%m-%d %H:%M')"
+git push
+echo "wiki-sync: pushed to $(git remote get-url origin)"
+SYNC_SCRIPT
+    chmod +x "$GLOBAL_CONFIG_DIR/sync.sh"
+    echo "✅  Wrote ~/.obsidian-wiki/sync.sh"
+    SYNC_CONFIGURED=true
+
+    # Offer shell alias
+    echo ""
+    read -p "  Add 'wiki-sync' alias to your shell? [Y/n]: " ADD_ALIAS || true
+    if [[ ! "$ADD_ALIAS" =~ ^[Nn]$ ]]; then
+      SHELL_RC=""
+      [ -f "$HOME/.zshrc" ]  && SHELL_RC="$HOME/.zshrc"
+      [ -z "$SHELL_RC" ] && [ -f "$HOME/.bashrc" ] && SHELL_RC="$HOME/.bashrc"
+      if [ -n "$SHELL_RC" ]; then
+        if ! grep -q "wiki-sync" "$SHELL_RC"; then
+          printf '\n# wiki-sync — push Obsidian vault to GitHub\nalias wiki-sync='"'"'~/.obsidian-wiki/sync.sh'"'"'\n' >> "$SHELL_RC"
+          echo "✅  Added wiki-sync alias to $SHELL_RC"
+          echo "    → Run: source $SHELL_RC  (or open a new terminal)"
+        else
+          echo "    ℹ️  wiki-sync alias already in $SHELL_RC"
+        fi
+      fi
+    fi
+
+    # Offer hourly cron
+    echo ""
+    read -p "  Enable hourly auto-sync (cron)? [y/N]: " ADD_CRON || true
+    if [[ "$ADD_CRON" =~ ^[Yy]$ ]]; then
+      CRON_LINE="0 * * * * $GLOBAL_CONFIG_DIR/sync.sh >> $GLOBAL_CONFIG_DIR/sync.log 2>&1"
+      ( crontab -l 2>/dev/null; echo "$CRON_LINE" ) | sort -u | crontab -
+      echo "✅  Hourly cron installed  (logs: ~/.obsidian-wiki/sync.log)"
+    fi
+  fi
+fi
+
+# ── Step 5: Summary ──────────────────────────────────────────
 SKILL_COUNT=$(echo "$SKILLS_DIR"/*/  | tr ' ' '\n' | grep -c /)
 
 echo ""
@@ -221,6 +306,9 @@ echo " Skills found:    $SKILL_COUNT"
 echo " Agents ready:    Claude Code, Cursor, Windsurf, Gemini CLI, Antigravity,"
 echo "                  Codex, Hermes, OpenClaw, OpenCode, Aider, Factory Droid,"
 echo "                  Trae, Trae CN, Kiro, Pi, GitHub Copilot (CLI + VS Code Chat)"
+if $SYNC_CONFIGURED; then
+echo " GitHub sync:     wiki-sync  (script: ~/.obsidian-wiki/sync.sh)"
+fi
 echo ""
 echo " Bootstrap files:"
 echo "   CLAUDE.md                            → Claude Code"
@@ -240,6 +328,9 @@ echo "   2. Say: \"Set up my wiki\""
 echo ""
 echo " From any other project:"
 echo "   /wiki-update    → sync knowledge into your vault"
-echo "   /wiki-query    → ask questions against your wiki"
+echo "   /wiki-query     → ask questions against your wiki"
+if $SYNC_CONFIGURED; then
+echo "   wiki-sync       → push all vault changes to GitHub"
+fi
 echo "───────────────────────────────────────────────────"
 echo ""


### PR DESCRIPTION
## Summary

- **`setup.sh`** gains an optional GitHub sync step (Step 4): prompts for a GitHub repo URL, git-inits the vault if needed, creates a `.gitignore` for Obsidian workspace/cache files, sets the remote, writes `~/.obsidian-wiki/sync.sh`, offers to add a `wiki-sync` shell alias, and optionally installs an hourly cron job
- **`README.md`** gets a new "Syncing your vault to GitHub" section (before the Skills table) explaining the setup flow, `wiki-sync` usage, manual setup, and a privacy note
- **`.env.example`** documents the `VAULT_GITHUB_REMOTE` config key

## Motivation

The common pattern for keeping a local knowledge base versioned is a simple `brainsync`-style alias (`git add -A && git commit -m "sync $(date)" && git push`). This wires that pattern into the obsidian-wiki setup flow so users get it automatically — using the configured `OBSIDIAN_VAULT_PATH` rather than a hardcoded path.

## UX flow (new prompt in setup.sh)

```
  Set up GitHub sync for your vault? [y/N]: y
  GitHub repo URL (e.g. https://github.com/you/my-wiki.git): https://github.com/you/my-wiki.git
✅  Initialized git repo in vault
✅  Created .gitignore in vault
✅  Git remote → https://github.com/you/my-wiki.git
✅  Wrote ~/.obsidian-wiki/sync.sh

  Add 'wiki-sync' alias to your shell? [Y/n]: y
✅  Added wiki-sync alias to ~/.zshrc
    → Run: source ~/.zshrc  (or open a new terminal)

  Enable hourly auto-sync (cron)? [y/N]: y
✅  Hourly cron installed  (logs: ~/.obsidian-wiki/sync.log)
```

Saying `n` to the first prompt skips the whole step — no impact on existing users.

## Test plan

- [ ] Run `bash setup.sh` on a fresh clone, answer `n` to sync prompt — existing flow unchanged
- [ ] Run with `y`, supply a real remote — vault gets `git init`, `.gitignore`, remote set, `sync.sh` written
- [ ] `wiki-sync` (after sourcing shell) commits and pushes; re-running with no changes prints "nothing to commit"
- [ ] Verify cron entry appears in `crontab -l` when hourly sync is accepted