### PR TITLE
feat(capture): auto-capture findings at session end via Stop hook

### DIFF
--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Fires on Claude Code Stop event.
+# Reads the session transcript; if significant work happened (file edits or
+# substantial shell activity), asks Claude to run /wiki-quick-chat-capture so
+# findings aren't silently lost at session end.
+#
+# Exit 0 → no-op (nothing worth capturing, or hook suppressed).
+# Exit 2 → output is fed back to Claude as a user message, triggering capture.
+#
+# The stop_hook_active flag in the payload prevents re-entry (this hook won't
+# fire again for the follow-up capture turn).
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+# Suppress if already in a stop-hook-triggered turn (prevents infinite loops)
+IS_HOOK_TURN=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print('1' if d.get('stop_hook_active') else '0')
+" 2>/dev/null || echo "0")
+[[ "$IS_HOOK_TURN" == "1" ]] && exit 0
+
+TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+print(d.get('transcript_path', ''))
+" 2>/dev/null || echo "")
+
+[[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
+
+# Count meaningful tool uses: Write/Edit = file mutations, Bash = shell work
+COUNTS=$(python3 - "$TRANSCRIPT_PATH" <<'PYEOF'
+import json, sys
+
+path = sys.argv[1]
+write_edit = 0
+bash_count = 0
+
+with open(path) as f:
+    for line in f:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        msg = entry.get("message") or {}
+        if msg.get("role") != "assistant":
+            continue
+        for block in msg.get("content") or []:
+            if not isinstance(block, dict) or block.get("type") != "tool_use":
+                continue
+            name = block.get("name", "")
+            if name in ("Write", "Edit", "NotebookEdit"):
+                write_edit += 1
+            elif name == "Bash":
+                bash_count += 1
+
+print(write_edit, bash_count)
+PYEOF
+)
+
+WRITE_EDIT=$(echo "$COUNTS" | awk '{print $1}')
+BASH_COUNT=$(echo "$COUNTS" | awk '{print $2}')
+
+# Trigger if any file was written/edited, or if there were ≥ 4 shell calls
+# (suggesting investigation/debugging worth preserving).
+if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || [[ "${BASH_COUNT:-0}" -ge 4 ]]; then
+  echo "Session ended with ${WRITE_EDIT} file edit(s) and ${BASH_COUNT} shell call(s). Please run /wiki-quick-chat-capture now to preserve any reusable findings before this context closes."
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -5,7 +5,8 @@
 # findings aren't silently lost at session end.
 #
 # Exit 0 → no-op (nothing worth capturing, or hook suppressed).
-# Exit 2 → output is fed back to Claude as a user message, triggering capture.
+# Exit 2 → stderr content is fed back to Claude as a user message, triggering capture.
+# Note: Claude Code Stop hooks deliver rewake content via stderr, not stdout.
 #
 # The stop_hook_active flag in the payload prevents re-entry (this hook won't
 # fire again for the follow-up capture turn).
@@ -69,7 +70,7 @@ BASH_COUNT=$(echo "$COUNTS" | awk '{print $2}')
 # Trigger if any file was written/edited, or if there were ≥ 4 shell calls
 # (suggesting investigation/debugging worth preserving).
 if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || [[ "${BASH_COUNT:-0}" -ge 4 ]]; then
-  echo "Session ended with ${WRITE_EDIT} file edit(s) and ${BASH_COUNT} shell call(s). Please run /wiki-quick-chat-capture now to preserve any reusable findings before this context closes."
+  echo "Session ended with ${WRITE_EDIT} file edit(s) and ${BASH_COUNT} shell call(s). Please run /wiki-quick-chat-capture now to preserve any reusable findings before this context closes." >&2
   exit 2
 fi
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/wiki-stop-capture.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.skills/wiki-quick-chat-capture/SKILL.md
+++ b/.skills/wiki-quick-chat-capture/SKILL.md
@@ -40,6 +40,29 @@ NOT a replacement for `wiki-capture` (promotes directly to a final wiki page) or
    - `OBSIDIAN_RAW_DIR` (default: `$OBSIDIAN_VAULT_PATH/_raw`)
 2. Ensure `$OBSIDIAN_RAW_DIR` exists. If not, create it.
 
+## Step 0: Gate Evaluation — KEEP or SKIP?
+
+Before extracting anything, make a quick judgment about whether this session has capture value.
+This gate makes the skill safe to call automatically (e.g. from a Stop hook) without spamming
+`_raw/` with noise from routine or inconclusive sessions.
+
+**SKIP** — exit immediately with "Nothing worth capturing in this session." if ALL of the
+following are true:
+- The conversation is purely conversational (planning, Q&A, explanations) with no implementation
+- No error messages, debugging steps, or problem-solving exchanges are visible
+- No surprising or undocumented behavior was encountered
+- Every finding is already obvious from the official docs
+
+**KEEP** — proceed to Step 1 if ANY of the following are true:
+- A fix was applied or a workaround discovered through investigation
+- Non-obvious library/API/framework behavior was discussed and confirmed (e.g. an edge case,
+  an undocumented constraint, a gotcha that cost time)
+- A debugging session reached a concrete conclusion
+- A reusable pattern or technique emerged that isn't obvious from first principles
+
+When invoked automatically via the Stop hook, err toward SKIP — only KEEP if the evidence is
+clear. When invoked manually by the user, err toward KEEP — they called it for a reason.
+
 ## Step 1: Scan the Conversation for Findings
 
 Extract **reusable technical knowledge** — things worth having in 3 months with no memory of

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -177,6 +177,53 @@ Report the results and tell the user they can now:
 5. Run `codex-history-ingest` to mine their Codex sessions (if they use Codex)
 6. Run `wiki-status` again anytime to check the delta
 
+## Optional: Install the Stop Hook (Auto-Capture)
+
+Ask the user: **"Want to auto-capture findings at session end?"**
+
+If yes, install the Stop hook into their global Claude Code settings so that every session
+with meaningful work automatically prompts `/wiki-quick-chat-capture` before closing.
+
+**What the hook does:** reads the session transcript on Stop, counts file edits and shell
+calls, and if significant work happened, asks Claude to run `/wiki-quick-chat-capture` once.
+The `wiki-quick-chat-capture` skill's own KEEP/SKIP gate prevents noise — routine or
+inconclusive sessions are skipped automatically.
+
+**Installation steps:**
+
+1. Find the obsidian-wiki repo path (the directory where this skill lives). If
+   `OBSIDIAN_WIKI_REPO` is set in config, use that. Otherwise, check common locations:
+   `~/Documents/projects/obsidian-wiki`, `~/obsidian-wiki`, or ask the user.
+
+2. Merge the hook entry into `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash <REPO_PATH>/.claude/hooks/wiki-stop-capture.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+   If `~/.claude/settings.json` already exists and has a `hooks.Stop` array, **append** the new
+   entry rather than replacing — don't clobber existing hooks.
+
+3. Confirm: "Stop hook installed. Claude Code will prompt `/wiki-quick-chat-capture` at the
+   end of any session where you write files or run ≥ 4 shell commands."
+
+**To uninstall later:** remove the hook entry from `~/.claude/settings.json` or set
+`HIVEMIND_CAPTURE=false` in your shell to skip capture for a single session.
+
 ## Optional: Refresh QMD After Setup
 
 If `QMD_WIKI_COLLECTION` is configured and the local QMD CLI is available, run `qmd update` after the initial vault files exist so the fresh vault is immediately queryable. No embedding pass is usually needed at setup time because the vault starts empty, so a plain update is enough unless you have already populated pages.


### PR DESCRIPTION
## Summary

Ports the core insight from [activeloopai/hivemind](https://github.com/activeloopai/hivemind) — automatic session-end knowledge capture — into the wiki framework.

- **`.claude/hooks/wiki-stop-capture.sh`** — shell hook that fires on Claude Code `Stop` event. Reads the session transcript JSONL, counts file edits (`Write`/`Edit`) and shell calls (`Bash`), and if significant work happened (≥1 file edit or ≥4 shell calls), feeds back a message prompting `/wiki-quick-chat-capture`. The `stop_hook_active` guard prevents infinite re-entry.
- **`.claude/settings.json`** — wires the hook into the project's Claude Code settings so it activates automatically for sessions in this repo.
- **`wiki-quick-chat-capture/SKILL.md`** — adds a **KEEP/SKIP gate** as Step 0. Makes the skill safe to auto-invoke: purely conversational sessions exit immediately; sessions with concrete findings proceed. Manual invocations err toward KEEP; automatic invocations err toward SKIP.
- **`wiki-setup/SKILL.md`** — new optional step to install the hook globally into `~/.claude/settings.json` so it fires across all projects, not just this repo.

## Test plan

- [ ] Start a Claude Code session in the repo, make a file edit, let it stop — hook should fire and prompt `/wiki-quick-chat-capture`
- [ ] Start a session, ask only conversational questions (no tool use), let it stop — hook should exit 0 silently
- [ ] Run `/wiki-quick-chat-capture` in a session with only meta-conversation — gate should return SKIP with "Nothing worth capturing"
- [ ] Run `/wiki-quick-chat-capture` after a debugging session with a concrete fix — gate should return KEEP and write a `_raw/` file
- [ ] Run `wiki-setup` and confirm the optional hook installation step appears at the end