### PR TITLE
fix(stop-hook): skip already-captured work via mtime checkpoint

### DIFF
--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -31,11 +31,22 @@ print(d.get('transcript_path', ''))
 
 [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
 
+# Checkpoint: after /wiki-quick-chat-capture runs it touches this file.
+# Only count tool uses in transcript entries timestamped after the checkpoint
+# so re-runs don't re-report already-captured work.
+CHECKPOINT="$HOME/.obsidian-wiki/capture-checkpoint"
+CHECKPOINT_TS=""
+if [[ -f "$CHECKPOINT" ]]; then
+  CHECKPOINT_TS=$(python3 -c "import os, datetime; print(datetime.datetime.fromtimestamp(os.path.getmtime('$CHECKPOINT')).isoformat())" 2>/dev/null || echo "")
+fi
+
 # Count meaningful tool uses: Write/Edit = file mutations, Bash = shell work
-COUNTS=$(python3 - "$TRANSCRIPT_PATH" <<'PYEOF'
+# Only entries with timestamp > CHECKPOINT_TS (or all entries if no checkpoint).
+COUNTS=$(python3 - "$TRANSCRIPT_PATH" "$CHECKPOINT_TS" <<'PYEOF'
 import json, sys
 
 path = sys.argv[1]
+cutoff = sys.argv[2] if len(sys.argv) > 2 else ""
 write_edit = 0
 bash_count = 0
 
@@ -48,6 +59,10 @@ with open(path) as f:
             entry = json.loads(line)
         except json.JSONDecodeError:
             continue
+        if cutoff:
+            ts = entry.get("timestamp", "")
+            if ts and ts <= cutoff:
+                continue
         msg = entry.get("message") or {}
         if msg.get("role") != "assistant":
             continue

--- a/.skills/wiki-quick-chat-capture/SKILL.md
+++ b/.skills/wiki-quick-chat-capture/SKILL.md
@@ -126,6 +126,13 @@ Run /wiki-ingest (or /data-ingest) to promote these to full wiki pages.
 
 If nothing was captured: "Nothing worth capturing found in this session."
 
+After confirming (whether files were staged or skipped), update the Stop hook checkpoint so
+it doesn't re-trigger for already-captured work in this session:
+
+```bash
+mkdir -p ~/.obsidian-wiki && touch ~/.obsidian-wiki/capture-checkpoint
+```
+
 ## What This Skill Does NOT Do
 
 - No manifest writes — `_raw/` files are not tracked in `.manifest.json`


### PR DESCRIPTION
Fixes #82.

## What changed

- **`.claude/hooks/wiki-stop-capture.sh`** — before counting tool uses, reads `~/.obsidian-wiki/capture-checkpoint` mtime as a cutoff. Transcript entries with `timestamp ≤ mtime` are skipped. If no checkpoint exists, all entries are counted (existing behavior preserved).

- **`.skills/wiki-quick-chat-capture/SKILL.md`** — adds a final instruction to `touch ~/.obsidian-wiki/capture-checkpoint` after confirming staged files (or SKIP). This resets the window so the next hook trigger only sees work done since the capture.

## Behavior

| Scenario | Before | After |
|---|---|---|
| First trigger in session | fires correctly | fires correctly |
| After capture, no new work | re-fires with same count | silent (exit 0) |
| After capture, 2 more edits | re-fires with full count | fires with count=2 only |
| New session (old checkpoint) | N/A | all entries counted (checkpoint older than session) |

## Test

```
=== Before checkpoint (should trigger) ===
exit=2 | Session ended with 11 file edit(s) and 53 shell call(s). ...

=== After checkpoint (touch now) ===
exit=0 | <silent>
```