### PR TITLE
Canonical manifest paths + project skip scoping + manifest helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,12 @@ OBSIDIAN_CATEGORIES=concepts,entities,skills,references,synthesis,journal
 # Max pages to create/update per ingest operation
 OBSIDIAN_MAX_PAGES_PER_INGEST=15
 
+# Projects to exclude from history ingest (claude/codex/hermes/… history-ingest skills).
+# Comma-separated substrings matched against the project directory name. A project
+# dir whose name contains any of these is skipped during scan, delta, and manifest steps.
+# Example: WIKI_SKIP_PROJECTS=archived,scratch,sandbox
+WIKI_SKIP_PROJECTS=
+
 # Claude conversation history path (auto-discovered from ~/.claude if empty)
 CLAUDE_HISTORY_PATH=
 

--- a/.skills/claude-history-ingest/SKILL.md
+++ b/.skills/claude-history-ingest/SKILL.md
@@ -19,6 +19,7 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `CLAUDE_HISTORY_PATH` (defaults to `~/.claude`)
 2. Read `.manifest.json` at the vault root to check what's already been ingested
 3. Read `index.md` at the vault root to know what the wiki already contains
+4. **Project Scoping** — read `WIKI_SKIP_PROJECTS` from config (comma-separated substrings). Exclude any project directory whose name contains one of them from **every** step below (scan, delta, sampling, manifest writes). If the user names extra projects to skip this run, add them. Apply the exclusion **once, uniformly** — don't hand-write `grep -v` filters into individual commands, which drifts between the scan and manifest steps.
 
 ## Ingest Modes
 
@@ -30,6 +31,26 @@ Check `.manifest.json` for each source file (conversation JSONL, memory file). O
 - Files whose modification time is newer than their `ingested_at` in the manifest
 
 This is usually what you want — the user ran a few new sessions and wants to capture the delta.
+
+> **Canonical paths when comparing.** The manifest keys are absolute paths with `~` expanded (see `llm-wiki/SKILL.md` → `.manifest.json`). Before deciding a file is "new", expand its path the same way — otherwise a file already tracked as `~/.claude/...` looks new when you scanned it as `/Users/me/.claude/...` (or vice-versa) and gets re-ingested. The `scripts/manifest.py` helper does this for you:
+>
+> ```bash
+> # New/modified sources, honoring WIKI_SKIP_PROJECTS + --skip, paths already canonical:
+> python3 "$OBSIDIAN_WIKI_REPO/scripts/manifest.py" delta "$OBSIDIAN_VAULT_PATH" \
+>   --scan "$CLAUDE_HISTORY_PATH/projects/*/memory/*.md"
+> # One-time repair if the manifest already mixes ~ and absolute keys:
+> python3 "$OBSIDIAN_WIKI_REPO/scripts/manifest.py" normalize "$OBSIDIAN_VAULT_PATH" --dry-run
+> ```
+>
+> The helper is optional — if it's unavailable, do the same expansion inline before every manifest lookup and write.
+
+### Conversation Sampling Heuristic
+
+A history path can hold hundreds of conversation JSONLs — do not try to read them all. Per project:
+
+- **If the project already has memory files** (`memory/*.md`), those are the pre-distilled signal. Ingest them and **skip the project's raw conversations** in append mode unless the user asks for a deeper pass.
+- **If the project has no memory files**, read only the **3 most recent** conversation JSONLs (by mtime) to characterize it.
+- Always report what you sampled vs skipped (e.g. "agenttower: 7 memory files ingested, 18 conversations skipped"), so the coverage gap is visible rather than silent.
 
 ### Full Mode
 
@@ -62,6 +83,13 @@ Claude Code stores data in two locations. Scan **both**.
 ```
 
 ### Source 2: `~/Library/Application Support/Claude/local-agent-mode-sessions/` (Desktop app agent sessions)
+
+> **Pre-check first.** Many users are CLI-only and have no desktop sessions. Before walking the structure below, confirm it's non-empty:
+> ```bash
+> DESKTOP_SESSIONS="$HOME/Library/Application Support/Claude/local-agent-mode-sessions"
+> [ -d "$DESKTOP_SESSIONS" ] && find "$DESKTOP_SESSIONS" -name "audit.jsonl" | head -1
+> ```
+> If that prints nothing, skip this entire section (Source 2 + Step 3b) and don't narrate it.
 
 The Claude desktop app stores local agent mode sessions here. The structure is deeply nested:
 
@@ -327,7 +355,7 @@ Update `index.md` and `log.md` per the standard process:
 - [TIMESTAMP] CLAUDE_HISTORY_INGEST projects=N conversations=M desktop_sessions=D audit_logs=A pages_updated=X pages_created=Y mode=append|full
 ```
 
-**`hot.md`** — Read `$OBSIDIAN_VAULT_PATH/hot.md` (create from the template in `wiki-ingest` if missing). Update **Recent Activity** with a one-line summary — e.g. "Ingested 5 Claude conversations across 2 projects; surfaced patterns in API design and testing strategy." Keep the last 3 operations. Update **Active Threads** if any ongoing project is now better understood. Update `updated` timestamp.
+**`hot.md`** — Read `$OBSIDIAN_VAULT_PATH/hot.md` (create from the template in `wiki-ingest` if missing). Update **Recent Activity** with a one-line summary — e.g. "Ingested 5 Claude conversations across 2 projects; surfaced patterns in API design and testing strategy." Keep the last 3 operations. Update **Active Threads** if any ongoing project is now better understood. **Update the `updated:` field in the frontmatter** to the current timestamp — this is easy to forget; the body edit and the frontmatter bump must both happen.
 
 ## Privacy
 

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -149,6 +149,10 @@ The manifest enables:
 - **Audit** — which source produced which wiki page
 - **Staleness detection** — source changed but wiki page hasn't been updated
 
+**Canonical source keys.** Source keys MUST be stored in a single canonical form: **absolute paths with `~` and env vars expanded** (e.g. `/Users/me/.claude/projects/.../abc.jsonl`, never `~/.claude/...`). The manifest is keyed by the raw string, so a mix of `~`-relative and absolute keys lets the *same file* be tracked twice — and the delta check then re-ingests an already-processed file because the lookup misses the other-form key. Always expand before you compare against the manifest and before you write a new entry. To repair an existing vault that already has both forms, run `scripts/manifest.py normalize <vault>` (merges colliding entries, keeps the newest `ingested_at`).
+
+**Recording provenance.** When you write a manifest entry, populate `pages_created` and `pages_updated` with the vault-relative page paths that source contributed to. This is what makes re-ingestion (when a source changes) able to find the pages to revisit, instead of guessing.
+
 ## Page Template
 
 When creating a new wiki page, use this structure:
@@ -488,6 +492,7 @@ The wiki is configured through environment variables (see `.env.example`). The o
 - `OBSIDIAN_VAULT_PATH` — Where the wiki lives **(required)**
 - `OBSIDIAN_SOURCES_DIR` — Where raw source documents are
 - `OBSIDIAN_CATEGORIES` — Comma-separated list of categories
+- `WIKI_SKIP_PROJECTS` — Comma-separated substrings; any project dir whose name contains one is excluded from history ingest (scan + delta + manifest). See the "Project Scoping" step in the history-ingest skills.
 - `CLAUDE_HISTORY_PATH` — Where to find Claude conversation data
 - `CODEX_HISTORY_PATH` — Where to find Codex session data
 - `HERMES_HOME` — Where to find Hermes agent data

--- a/.skills/wiki-status/SKILL.md
+++ b/.skills/wiki-status/SKILL.md
@@ -23,6 +23,8 @@ You are computing the current state of the wiki: what's been ingested, what's ne
 
 The manifest lives at `$OBSIDIAN_VAULT_PATH/.manifest.json`. It tracks every source file that has been ingested. If it doesn't exist, this is a fresh vault with nothing ingested.
 
+> **Source keys are canonical absolute paths** (`~` and env vars expanded). Never mix `~`-relative and absolute keys — the same file would be tracked twice and re-ingested. See `llm-wiki/SKILL.md` → `.manifest.json`. Repair a mixed manifest with `scripts/manifest.py normalize <vault>`.
+
 ```json
 {
   "version": 1,
@@ -37,7 +39,7 @@ The manifest lives at `$OBSIDIAN_VAULT_PATH/.manifest.json`. It tracks every sou
       "pages_created": ["concepts/transformers.md"],
       "pages_updated": ["entities/vaswani.md"]
     },
-    "~/.claude/projects/-Users-name-my-app/abc123.jsonl": {
+    "/Users/name/.claude/projects/-Users-name-my-app/abc123.jsonl": {
       "ingested_at": "2026-04-06T11:00:00Z",
       "size_bytes": 128000,
       "modified_at": "2026-04-06T09:00:00Z",
@@ -49,7 +51,7 @@ The manifest lives at `$OBSIDIAN_VAULT_PATH/.manifest.json`. It tracks every sou
   },
   "projects": {
     "my-app": {
-      "source_path": "~/.claude/projects/-Users-name-my-app",
+      "source_path": "/Users/name/.claude/projects/-Users-name-my-app",
       "vault_path": "projects/my-app",
       "last_ingested": "2026-04-06T11:00:00Z",
       "conversations_ingested": 5,

--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Manifest helper for the Obsidian wiki — normalize paths and compute ingest deltas.
+
+Pure stdlib, no dependencies. Optional accelerator for the ingest skills: the
+markdown instructions still work without it, but this makes the manifest steps
+deterministic and testable.
+
+Source keys in `.manifest.json` are stored in a single canonical form:
+**absolute paths with `~` and environment variables expanded.** This prevents
+the same file being tracked under both `~/.claude/...` and `/Users/me/.claude/...`,
+which otherwise causes silent re-ingestion in append mode (see issues #86/#88).
+
+Usage:
+  # Rewrite source keys to canonical absolute paths, merging any collisions.
+  python3 scripts/manifest.py normalize <vault_path> [--dry-run]
+
+  # List new/modified sources under a glob that aren't in the manifest yet.
+  # Honors $WIKI_SKIP_PROJECTS (comma-separated substrings) plus --skip.
+  python3 scripts/manifest.py delta <vault_path> --scan '<glob>' [--skip a,b]
+"""
+from __future__ import annotations
+
+import argparse
+import glob as globmod
+import json
+import os
+import sys
+
+
+def canonical(path: str) -> str:
+    """Single canonical key form: expand ~ and env vars, make absolute."""
+    return os.path.abspath(os.path.expanduser(os.path.expandvars(path)))
+
+
+def manifest_path(vault: str) -> str:
+    return os.path.join(canonical(vault), ".manifest.json")
+
+
+def load_manifest(vault: str) -> dict:
+    mp = manifest_path(vault)
+    if not os.path.exists(mp):
+        return {"version": 1, "sources": {}, "projects": {}, "stats": {}}
+    with open(mp) as f:
+        return json.load(f)
+
+
+def _newest(a: dict, b: dict) -> dict:
+    """Merge two entries for the same file, preferring the newer ingested_at and
+    unioning the pages_created / pages_updated lists."""
+    keep = a
+    other = b
+    if str(b.get("ingested_at", "")) > str(a.get("ingested_at", "")):
+        keep, other = b, a
+    merged = dict(keep)
+    for field in ("pages_created", "pages_updated"):
+        union = list(dict.fromkeys((other.get(field) or []) + (keep.get(field) or [])))
+        if union:
+            merged[field] = union
+    return merged
+
+
+def cmd_normalize(args: argparse.Namespace) -> int:
+    m = load_manifest(args.vault)
+    sources = m.get("sources", {})
+    new_sources: dict = {}
+    collisions = 0
+    rekeyed = 0
+    for key, entry in sources.items():
+        ckey = canonical(key)
+        if ckey != key:
+            rekeyed += 1
+        if ckey in new_sources:
+            new_sources[ckey] = _newest(new_sources[ckey], entry)
+            collisions += 1
+            print(f"  MERGE  {ckey}")
+        else:
+            new_sources[ckey] = entry
+
+    print(
+        f"sources: {len(sources)} -> {len(new_sources)} "
+        f"({rekeyed} re-keyed, {collisions} collisions merged)"
+    )
+    if args.dry_run:
+        print("(dry-run — no changes written)")
+        return 0
+    if collisions == 0 and rekeyed == 0:
+        print("already canonical — nothing to write")
+        return 0
+    m["sources"] = new_sources
+    mp = manifest_path(args.vault)
+    with open(mp, "w") as f:
+        json.dump(m, f, indent=2)
+        f.write("\n")
+    print(f"wrote {mp}")
+    return 0
+
+
+def _skip_patterns(cli_skip: str | None) -> list[str]:
+    pats: list[str] = []
+    env = os.environ.get("WIKI_SKIP_PROJECTS", "")
+    for raw in (env, cli_skip or ""):
+        pats.extend(p.strip() for p in raw.split(",") if p.strip())
+    return pats
+
+
+def cmd_delta(args: argparse.Namespace) -> int:
+    m = load_manifest(args.vault)
+    known = {canonical(k): v for k, v in m.get("sources", {}).items()}
+    skips = _skip_patterns(args.skip)
+
+    matched = sorted(globmod.glob(os.path.expanduser(args.scan), recursive=True))
+    new, modified, skipped = [], [], 0
+    for path in matched:
+        if not os.path.isfile(path):
+            continue
+        if any(s in path for s in skips):
+            skipped += 1
+            continue
+        ckey = canonical(path)
+        entry = known.get(ckey)
+        if entry is None:
+            new.append(ckey)
+        else:
+            mtime = os.path.getmtime(path)
+            ingested = str(entry.get("ingested_at", ""))
+            # modified if file changed after it was last ingested
+            from datetime import datetime, timezone
+
+            try:
+                ing_ts = datetime.fromisoformat(ingested.replace("Z", "+00:00")).timestamp()
+            except ValueError:
+                ing_ts = 0
+            if mtime > ing_ts:
+                modified.append(ckey)
+
+    if skips:
+        print(f"# skip patterns: {', '.join(skips)} ({skipped} files skipped)")
+    print(f"# {len(new)} new, {len(modified)} modified, {len(known)} known")
+    for p in new:
+        print(f"NEW\t{p}")
+    for p in modified:
+        print(f"MOD\t{p}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="command", required=True)
+
+    n = sub.add_parser("normalize", help="rewrite source keys to canonical absolute paths")
+    n.add_argument("vault", help="path to the Obsidian vault (contains .manifest.json)")
+    n.add_argument("--dry-run", action="store_true", help="preview without writing")
+    n.set_defaults(func=cmd_normalize)
+
+    d = sub.add_parser("delta", help="list new/modified sources vs the manifest")
+    d.add_argument("vault", help="path to the Obsidian vault")
+    d.add_argument("--scan", required=True, help="glob of source files (use ** with recursive)")
+    d.add_argument("--skip", default=None, help="comma-separated substrings to exclude")
+    d.set_defaults(func=cmd_delta)
+
+    args = p.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Resolves #86, #87, #88.

## Problem

Three frictions surfaced during a real history-ingest run:

1. **Mixed path forms (#86).** Source keys were stored as both `~/.claude/...` and `/Users/me/.claude/...` — the schema example in `wiki-status/SKILL.md` literally documented both. The manifest is keyed by the raw string, so the *same file* got tracked twice and re-ingested in append mode. **5 such collisions were found in a real 137-source vault.**
2. **No project scoping (#87).** History-ingest skills scan all projects; excluding private/scratch/noisy dirs meant hand-writing `grep -v` into every ad-hoc command, drifting between the scan and manifest steps.
3. **Ad-hoc manifest writes (#88).** The skills say 'update `.manifest.json`' with no helper, so the agent writes raw inline Python each run — easy to get quoting wrong, and it didn't normalize or honor skips.

## Changes

- **`scripts/manifest.py`** — pure-stdlib helper (matches existing `scripts/` convention):
  - `normalize <vault> [--dry-run]` — rewrite source keys to canonical absolute paths, merge collisions (keep newest `ingested_at`, union `pages_created`/`pages_updated`).
  - `delta <vault> --scan '<glob>' [--skip a,b]` — list new/modified sources vs the manifest, honoring `WIKI_SKIP_PROJECTS` + `--skip`, with paths already canonical.
- **`llm-wiki/SKILL.md`** — canonical-source-key rule + provenance recording note; `WIKI_SKIP_PROJECTS` in the env table.
- **`wiki-status/SKILL.md`** — schema example now uses absolute paths consistently; canonical-key callout.
- **`claude-history-ingest/SKILL.md`** — Project Scoping step, canonical-path compare note (with helper usage), conversation sampling heuristic (memory files → skip raw convos; else read 3 most recent), desktop-session pre-check, hot.md frontmatter-timestamp reminder.
- **`.env.example`** — `WIKI_SKIP_PROJECTS`.

The instructions still work without the helper — it's an optional accelerator that makes the manifest steps deterministic and testable.

## Testing

- **Local:** `normalize --dry-run` caught all 5 real collisions (137 → 132); `delta` with `WIKI_SKIP_PROJECTS` dropped new count 14 → 13 (8 files skipped).
- **Remote (st3ve, Ubuntu 24 / Python 3.12.3):** scp'd over; syntax + help OK; synthetic collision test confirmed merge keeps newest `ingested_at` and unions pages lists, and `--skip` excludes the right project. Live data untouched.
- **Real repair:** normalized a live vault manifest (removed 5 dup entries; verified 0 collisions remain, all keys absolute).
- Idempotent on already-canonical manifests; graceful on missing/empty manifests.