### PR TITLE
fix(stop-hook): fire at most once per session via session_id sentinel

### DIFF
--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -23,6 +23,16 @@ print('1' if d.get('stop_hook_active') else '0')
 " 2>/dev/null || echo "0")
 [[ "$IS_HOOK_TURN" == "1" ]] && exit 0
 
+# Fire at most once per session — sentinel file keyed to session_id prevents
+# repeated nudges after the threshold is crossed on the first turn.
+SESSION_ID=$(printf '%s' "$INPUT" | python3 -c "
+import json, sys; print(json.load(sys.stdin).get('session_id', ''))" 2>/dev/null || echo "")
+SENTINEL=""
+if [[ -n "$SESSION_ID" ]]; then
+  SENTINEL="${TMPDIR:-/tmp}/wiki-stop-capture-${SESSION_ID}.done"
+  [[ -f "$SENTINEL" ]] && exit 0
+fi
+
 TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | python3 -c "
 import json, sys
 d = json.load(sys.stdin)
@@ -70,6 +80,7 @@ BASH_COUNT=$(echo "$COUNTS" | awk '{print $2}')
 # Trigger if any file was written/edited, or if there were ≥ 4 shell calls
 # (suggesting investigation/debugging worth preserving).
 if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || [[ "${BASH_COUNT:-0}" -ge 4 ]]; then
+  [[ -n "$SENTINEL" ]] && : > "$SENTINEL" 2>/dev/null || true
   echo "Session ended with ${WRITE_EDIT} file edit(s) and ${BASH_COUNT} shell call(s). Please run /wiki-capture --quick now to preserve any reusable findings before this context closes." >&2
   exit 2
 fi


### PR DESCRIPTION
## Summary

- Extracts `session_id` from the Stop hook payload
- Derives a sentinel path `$TMPDIR/wiki-stop-capture-<session_id>.done`
- If the sentinel exists → exits 0 (already nudged this session, no-op)
- On first trigger → creates the sentinel, then emits the nudge (exit 2)
- Falls back gracefully when `session_id` is absent (no sentinel, old behavior)

This is Option B from #91. Chosen over Option A (checkpoint mtime) because it's fully self-contained in the hook — no cross-file dependency that can break on future skill renames (as happened with #82).

## Test plan

- [ ] New session → make ≥1 edit → Stop → nudge fires once ✓
- [ ] Continue session → make more edits → Stop again → silent (sentinel present) ✓
- [ ] New session (new session_id) → sentinel is absent → nudge fires again ✓
- [ ] Tested on st3ve remote sandbox

Closes #91
Refs #82, #81, #85