### PR TITLE
feat(export/import): OKF (Open Knowledge Format) bundle interop

### DIFF
--- a/.skills/wiki-export/SKILL.md
+++ b/.skills/wiki-export/SKILL.md
@@ -3,9 +3,11 @@ name: wiki-export
 description: >
   Export the Obsidian wiki's knowledge graph to structured formats for use in external tools.
   Use this skill when the user says "export wiki", "export graph", "export to JSON", "export to Gephi",
-  "export to Neo4j", "graphml", "visualize wiki", "knowledge graph export", or wants to use their
+  "export to Neo4j", "graphml", "visualize wiki", "knowledge graph export", "export to OKF",
+  "OKF bundle", "open knowledge format", "export as markdown bundle", or wants to use their
   wiki data in another tool. Outputs graph.json, graph.graphml, cypher.txt (Neo4j), and graph.html
-  (interactive browser visualization) into a wiki-export/ directory at the vault root.
+  (interactive browser visualization) into a wiki-export/ directory at the vault root, plus an
+  optional OKF (Open Knowledge Format) markdown bundle under wiki-export/okf/.
 ---
 
 # Wiki Export — Knowledge Graph Export
@@ -305,6 +307,55 @@ Replace `/* NODES_JSON */` and `/* EDGES_JSON */` with the actual JSON arrays yo
 
 ---
 
+## Step 3.5: OKF Bundle Export (optional)
+
+Run this step **only** when the user asks for OKF / a markdown bundle (phrases like "export to OKF", "OKF bundle", "open knowledge format", "export as markdown bundle"). It is additive — the four graph files above are always produced; this writes an extra full-fidelity markdown bundle.
+
+The four graph files are a *lossy* projection (graph skeleton only). An **OKF bundle is the actual page bodies**, so an export→`wiki-import` round-trip through OKF preserves full content, and the bundle drops straight into MkDocs, Notion, Hugo, GitHub's renderer, or any [Open Knowledge Format](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) consumer.
+
+### Canonical frontmatter mapping (obsidian-wiki ⇄ OKF)
+
+This table is the single source of truth for the mapping; `wiki-import` references it for the reverse direction.
+
+| OKF key       | ← export from           | → import to              | Notes |
+|---------------|-------------------------|--------------------------|-------|
+| `type` (required) | `category`, title-cased | `category` (lower-cased) | `concepts`→`Concept`, `entities`→`Entity`, `skills`→`Skill`, `references`→`Reference`, `synthesis`→`Synthesis`, `projects`→`Project`, `journal`→`Journal`. OKF requires `type`; consumers tolerate any string. |
+| `title`       | `title`                 | `title`                  | Verbatim. |
+| `description` | `summary`               | `summary`                | Our one-line `summary:` is exactly OKF's `description` (used in `index.md` entries). |
+| `tags`        | `tags`                  | `tags`                   | Verbatim list. `visibility/*` system tags pass through unchanged. |
+| `timestamp`   | `updated`               | `updated`                | ISO 8601 both sides. |
+| `resource`    | first `sources:` entry **iff** it is an `http(s)://` URL | — | Optional; omit when no source URL. Most pages describe abstract knowledge and have none. |
+| *(extensions)* | `category`, `sources`, `created`, `relationships`, `lifecycle`, `tier`, `base_confidence`, … | preserved verbatim | OKF §4.1 permits arbitrary keys and requires consumers to preserve them. **Writing our native keys as OKF extension frontmatter is what makes the round-trip lossless** — on import, preserved `category`/`created`/`sources` are preferred over re-deriving from `type`. |
+
+### Steps
+
+Reuse the node list from Step 1 (with any active project/visibility filters already applied). Write a directory tree under `wiki-export/okf/`:
+
+1. **One file per in-scope page.** For each page, parse its frontmatter, apply the mapping table above to build the OKF frontmatter (required `type` first, then `title`, `description`, `tags`, `timestamp`, optional `resource`, then the preserved extension keys), transform the body links (below), and write to `wiki-export/okf/<category>/<slug>.md` — same relative path the page has in the vault.
+
+2. **Body link transform** (`[[wikilinks]]` → standard markdown links):
+   - `[[concepts/transformers]]` → `[<target title>](<file-relative path>.md)`, e.g. from `entities/foo.md` a link to `concepts/transformers` becomes `[Transformer Architecture](../concepts/transformers.md)`. Link text = the target page's `title` (fall back to the target id if unknown).
+   - `[[target|display]]` → `[display](<rel path>.md)`.
+   - Use **file-relative** paths (`../concepts/x.md`), **never** `/`-absolute — `/`-rooted links break GitHub rendering. (This matches knowledge-catalog's own production agent.)
+   - Resolve link targets with the same normalization used in Step 1 (lowercase, spaces→hyphens, strip `.md`). Handle unresolved targets by form, so forward-references survive the round-trip:
+     - **Resolves to an in-scope page** → relative markdown link to it.
+     - **Path-form target** (contains a `/`, e.g. `[[concepts/attention-mechanism]]`) with **no page yet**, and not excluded by an active filter → still emit the relative markdown link. OKF §5.3 treats a missing target as not-yet-written knowledge, and keeping the link makes the user's forward-references lossless on re-import. (Verified on st3ve: dropping these silently deleted real `[[wikilinks]]`.)
+     - **Excluded by an active project/visibility filter** → plain text. Do not emit a path pointing into filtered-out content.
+     - **Bare-title target** with no match (e.g. `[[tractorex]]` when no such page exists in scope) → plain text; there is no reliable path to write.
+   - Leave existing external `http(s)://` links and `# Citations` sections untouched.
+
+3. **Generate `index.md` files** (OKF §6 progressive disclosure; these contain no per-entry frontmatter):
+   - Bundle root `wiki-export/okf/index.md` — a `# Subdirectories` section listing each category folder: `* [<category>](<category>/index.md) - <one-line description of the category>`. This is the **only** index permitted frontmatter: add a single key `okf_version: "0.1"` (OKF §11).
+   - One `index.md` per category folder listing its pages: `* [<title>](<slug>.md) - <description from the page's summary>`.
+
+4. **Copy `log.md`** from the vault root to `wiki-export/okf/log.md` as-is (OKF §7 treats the leading bold action word as convention, so the existing line-based log is conformant).
+
+5. **Filters.** Honor the same project/visibility filters as the graph export — filtered pages are omitted from the bundle and their inbound links degrade to plain text per step 2.
+
+Excluded from the bundle (same as the graph export): `_archives/`, `_raw/`, `.obsidian/`, `_insights.md`, `_meta/*.base`, and the vault root `index.md` (regenerated above).
+
+---
+
 ## Step 4: Print Summary
 
 ```
@@ -313,6 +364,11 @@ Wiki export complete → wiki-export/
   graph.graphml — N nodes, M edges (Gephi / yEd / Cytoscape)
   cypher.txt    — N MERGE nodes + M MERGE relationships (Neo4j)
   graph.html    — interactive browser visualization (open in any browser)
+```
+
+Append this line only when the OKF bundle was produced (Step 3.5):
+```
+  okf/          — OKF v0.1 markdown bundle (N pages, lossless; import via wiki-import)
 ```
 
 Append filter notes when active:
@@ -324,7 +380,8 @@ Only include lines for filters that were actually applied.
 
 ## Notes
 
-- **Re-running is safe** — all output files are overwritten on each run
-- **Broken wikilinks are skipped** — only edges to pages that exist in the vault are exported
+- **Re-running is safe** — all output files (and the `okf/` bundle) are overwritten on each run
+- **Broken wikilinks are skipped** — only edges to pages that exist in the vault are exported; in the OKF bundle, a wikilink to a missing/filtered page degrades to plain text
+- **OKF is the lossless format** — `graph.json` reconstructs only stubs on import, while the `okf/` bundle preserves full page bodies. Use OKF for vault-to-vault transfer and external markdown tools (MkDocs, Notion, GitHub); use the graph files for analysis tools (Gephi, Neo4j)
 - **The `wiki-export/` directory should be gitignored** if the vault is version-controlled — these are derived artifacts
 - **`graph.json` is the primary format** — the others are derived from it. If a future tool supports graph queries natively, point it at `graph.json`

--- a/.skills/wiki-import/SKILL.md
+++ b/.skills/wiki-import/SKILL.md
@@ -1,41 +1,66 @@
 ---
 name: wiki-import
 description: >
-  Import a wiki knowledge graph from a graph.json export file into the current vault.
+  Import a wiki knowledge graph into the current vault — either from a graph.json export
+  file (stubs) or from an OKF (Open Knowledge Format) markdown bundle (full page bodies).
   Use this skill when the user says "import wiki", "import from export", "load graph.json",
-  "import vault", "/wiki-import", or wants to transfer pages from one vault to another
-  using the output of wiki-export.
+  "import vault", "import OKF bundle", "import OKF", "load OKF", "import markdown bundle",
+  "/wiki-import", or wants to transfer pages from one vault to another using the output of wiki-export.
 ---
 
-# Wiki Import — Reconstruct Pages from graph.json
+# Wiki Import — Reconstruct Pages from an Export
 
-You are importing a vault's knowledge graph from a `graph.json` export (produced by `wiki-export`) into the current vault. This reconstructs page stubs with correct frontmatter, wikilinks, and typed relationships, then updates all vault metadata.
+You are importing a vault's knowledge into the current vault from one of two sources produced by `wiki-export`:
+
+- **`graph.json`** — the graph skeleton. Reconstructs page **stubs** (frontmatter, typed relationships, a `## Related` link list — no body). Lossy.
+- **OKF bundle** (a `wiki-export/okf/` directory) — the actual markdown files. Reconstructs **full pages** with their real bodies. Lossless. Use this for true vault-to-vault transfer.
+
+Either way, the import writes pages with correct frontmatter and wikilinks, then updates all vault metadata. **Step 2, Step 3 (graph only), and Step 5 are shared; Step 4 forks by source type.**
 
 ## Before You Start
 
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Read `$OBSIDIAN_VAULT_PATH/AGENTS.md` if it exists — apply any owner-specific conventions.
 
-## Step 1: Locate and Validate Source
+## Step 1: Locate and Detect Source Type
 
 **Find the import source:**
 - If the user provided a path argument, use it directly.
-- Otherwise auto-detect `./wiki-export/graph.json` in the current directory.
+- Otherwise auto-detect, in order: `./wiki-export/okf/` (a directory) → `./wiki-export/graph.json` (a file).
 - If neither exists, ask the user for the path.
 
-**Validate the file:**
+**Detect the source type:**
+- The path is a **file ending in `.json`** → **graph.json import** (validate below, then Step 3 + Step 4-Graph).
+- The path is a **directory** containing `.md` files with OKF frontmatter (a `type:` key), and/or a root `index.md` with `okf_version` → **OKF bundle import** (skip Step 3; go to Step 4-OKF).
+- Anything else → report what's wrong and stop.
+
+**Validate a graph.json source:**
 - Must be valid JSON
 - Must have top-level keys: `nodes` (array), `links` (array), `graph` (object)
 - Must have at least 1 node
 
 If validation fails, report what's wrong and stop.
 
+**Validate an OKF bundle source:**
+- Must contain at least 1 non-reserved `.md` file (i.e. not `index.md`/`log.md`) with parseable YAML frontmatter containing a non-empty `type`.
+- A `.md` with no frontmatter or no `type` is skipped (with a count), not fatal — OKF consumers are permissive (OKF §9).
+
 **Show a preview before importing:**
+
+graph.json:
 ```
-Import preview
+Import preview (graph.json — stubs)
   Source: <path>  (exported at <graph.exported_at>)
   Nodes:  N total  (concepts: A, entities: B, skills: C, references: D, ...)
   Links:  M edges  (X typed, Y untyped)
+  Target: $OBSIDIAN_VAULT_PATH
+```
+
+OKF bundle:
+```
+Import preview (OKF bundle — full pages)
+  Source: <dir>  (okf_version <ver if present>)
+  Pages:  N total  (concepts: A, entities: B, skills: C, references: D, ...)
   Target: $OBSIDIAN_VAULT_PATH
 ```
 
@@ -49,7 +74,7 @@ Read the user's phrasing to determine mode. Default is `merge`.
 | `skip` | "skip existing", "don't overwrite", "only new pages" | Leave existing pages completely untouched; only create pages that don't exist yet. |
 | `overwrite` | "overwrite", "replace existing", "force import" | Replace all matched pages with freshly reconstructed stubs regardless of existing content. |
 
-## Step 3: Build Internal Maps
+## Step 3: Build Internal Maps  *(graph.json only — skip for OKF bundles)*
 
 Before writing anything, build two maps from the `links` array:
 
@@ -66,7 +91,7 @@ typed_edges["concepts/transformers"] = [
 ]
 ```
 
-## Step 4: Reconstruct Pages
+## Step 4-Graph: Reconstruct Pages from graph.json  *(graph.json source only)*
 
 Record counts: `created = 0`, `skipped = 0`, `merged = 0`.
 
@@ -136,6 +161,39 @@ If `adjacency[node.id]` is empty, omit the `## Related` section entirely.
 6. **Body**: scan for a `## Related` section. If it exists, append any missing wikilinks from `adjacency[node.id]` that aren't already linked anywhere in the body. If no `## Related` section exists, append one with the missing links.
 7. Leave the rest of the body untouched.
 
+## Step 4-OKF: Reconstruct Pages from an OKF bundle  *(OKF source only)*
+
+Record counts: `created = 0`, `skipped = 0`, `merged = 0`, `unparseable = 0`.
+
+Walk the bundle directory tree. For each `.md` file that is **not** a reserved file (`index.md`, `log.md`):
+
+1. Parse the YAML frontmatter. If it has no frontmatter or no non-empty `type`, increment `unparseable` and skip the file.
+2. Compute the **concept id** = the file's path relative to the bundle root, with `.md` stripped (e.g. `concepts/transformers.md` → `concepts/transformers`). The target page is `$VAULT/<concept-id>.md`.
+3. **Reverse-map frontmatter** (the inverse of the canonical mapping table in `wiki-export` Step 3.5):
+   - `title` ← `title`.
+   - `category` ← the preserved `category` extension key if present; **else** lower-case the directory prefix of the concept id (`concepts/…` → `concepts`); **else** derive from `type` (`Concept`→`concepts`, `Entity`→`entities`, `Skill`→`skills`, `Reference`→`references`, `Synthesis`→`synthesis`, `Project`→`projects`, `Journal`→`journal`).
+   - `tags` ← `tags`.
+   - `summary` ← `description`.
+   - `updated` ← `timestamp` (or now if absent).
+   - `created` ← the preserved `created` extension key if present, else now.
+   - `sources` ← the preserved `sources` extension key if present; else `["imported from OKF bundle <bundle path>"]`. If a `resource` URL is present and not already in `sources`, add it.
+   - Carry through any other preserved extension keys verbatim (`relationships`, `lifecycle`, `tier`, `base_confidence`, …). These make the round-trip lossless.
+4. **Reverse-transform body links** — markdown links that point at `.md` paths become wikilinks (this restores both real cross-links and forward-references the exporter preserved per `wiki-export` Step 3.5):
+   - `[text](../concepts/transformers.md)` or `[text](/concepts/transformers.md)` → resolve the path (relative to this file's dir, or bundle-root for `/`-absolute) to a concept id → `[[concepts/transformers]]`, or `[[concepts/transformers|text]]` when `text` differs from the target's title. The target's title comes from the bundle page when it exists; otherwise compare against the last path segment.
+   - This applies **even when the target page is not in the bundle** — a path-form link to a not-yet-written page round-trips back to a dangling `[[wikilink]]` (Obsidian supports these; OKF §5.3 expects them). Do not leave it as a markdown link.
+   - When `OBSIDIAN_LINK_FORMAT=markdown` is set in config, **keep** markdown links (just rewrite the path to be vault-relative); do not convert to wikilinks.
+   - Leave external `http(s)://` links and `# Citations` sections untouched.
+5. **Write the page** using the conflict mode from Step 2:
+   - **merge + exists** → reverse-map frontmatter and merge it into the existing page (union `tags`; fill `summary`/`sources` only if missing; union `relationships`; refresh `updated`). For the body, OKF carries a real body: replace the existing body with the bundle body **only if the existing page is a stub** (body is just a heading + `## Related`); otherwise keep the existing body and append any bundle `# Citations` / new `##` sections not already present. Increment `merged`.
+   - **merge + doesn't exist** → write the full page (frontmatter + full bundle body). Increment `created`.
+   - **skip + exists** → increment `skipped`, continue.
+   - **skip + doesn't exist** → write the full page. Increment `created`.
+   - **overwrite + exists** → write the full page, replacing the existing one. Increment `merged` (label as `Replaced` in the summary).
+   - **overwrite + doesn't exist** → write the full page. Increment `created`.
+6. Ensure the parent directory (`$VAULT/concepts/`, etc.) exists before writing.
+
+Unlike the graph.json path, **do not** generate a `## Related` stub section — the bundle body already contains the real cross-links.
+
 ## Step 5: Update Vault Metadata
 
 ### `.manifest.json`
@@ -143,13 +201,15 @@ If `adjacency[node.id]` is empty, omit the `## Related` section entirely.
 Add a new entry keyed by the canonical path of the graph.json file:
 
 ```json
-"<absolute path to graph.json>": {
+"<absolute path to source>": {
   "ingested_at": "<ISO timestamp>",
   "source_type": "wiki-export",
   "pages_created": ["list/of/created/pages.md"],
   "pages_updated": ["list/of/merged/pages.md"]
 }
 ```
+
+Set `source_type` to `"wiki-export"` for a graph.json import or `"okf-bundle"` for an OKF bundle import. Key the entry by the absolute path of the source (the `graph.json` file or the bundle directory).
 
 Also increment:
 - `stats.total_sources_ingested` by 1
@@ -194,18 +254,18 @@ Update the `updated:` frontmatter timestamp. Leave other hot.md sections (Active
 
 ```
 Wiki import complete → $OBSIDIAN_VAULT_PATH
-  Source:  <graph.json path>
-           exported at <graph.exported_at>, <N> nodes, <M> links
+  Source:  <source path>  (<graph.json | OKF bundle>)
+           <graph: exported at <graph.exported_at>, N nodes, M links | okf: N pages, okf_version <ver>>
   Created: <X> pages
   Merged:  <Z> pages  (existing pages updated)
   Skipped: <Y> pages  (only when --skip mode was used)
 ```
 
-Only show the `Skipped` line if `skip` mode was explicitly requested. If `overwrite` mode was used, label merged pages as `Replaced` instead.
+Only show the `Skipped` line if `skip` mode was explicitly requested. If `overwrite` mode was used, label merged pages as `Replaced` instead. For an OKF import, also report `Unparseable: <U> files (no frontmatter/type, skipped)` when `U > 0`.
 
 ## Notes
 
-- **Stub quality**: Imported pages are stubs — they have structure and wikilinks but no full body content. They're starting points for future ingestion, not finished pages.
+- **Stub vs full pages**: A **graph.json** import produces stubs — structure and wikilinks but no body, a starting point for future ingestion. An **OKF bundle** import produces full pages with real bodies — it is the lossless, content-bearing path and the right choice for vault-to-vault transfer.
 - **Re-running is safe**: The default `merge` mode is idempotent — re-running on an unchanged export will update timestamps but won't destroy content. Use `overwrite` only when you want to fully reset pages to stubs.
 - **Directory creation**: Always create missing category directories before writing pages.
 - **Broken wikilinks**: Since pages are being created together from the same export, most links will resolve. Any node referenced in `links` but absent from `nodes` (broken in the original export) will still appear as a wikilink — it just won't have a corresponding page file, which is valid.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,8 +63,8 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | "link my pages" / "cross-reference" / "connect my wiki" | `cross-linker` |
 | "fix my tags" / "normalize tags" / "tag audit" | `tag-taxonomy` |
 | "update wiki" / "sync to wiki" / "save this to my wiki" | `wiki-update` |
-| "export wiki" / "export graph" / "graphml" / "neo4j" | `wiki-export` |
-| "import wiki" / "import from export" / "load graph.json" / "import vault" / "/wiki-import" | `wiki-import` |
+| "export wiki" / "export graph" / "graphml" / "neo4j" / "export to OKF" / "OKF bundle" / "open knowledge format" | `wiki-export` |
+| "import wiki" / "import from export" / "load graph.json" / "import vault" / "import OKF bundle" / "/wiki-import" | `wiki-import` |
 | "color my graph" / "color code obsidian" / "color by tag/category/visibility" | `graph-colorize` |
 | "save this" / "/wiki-capture" / "capture this" / "file this conversation" / "/wiki-capture --quick" / "quick capture" / "capture this finding" / "save this gotcha" / "drop to raw" | `wiki-capture` |
 | "/wiki-research [topic]" / "research X" / "find everything about Y" | `wiki-research` |
@@ -129,3 +129,5 @@ See `wiki-query` and `wiki-export` skills for how the filter is applied.
 ## Architecture Reference
 
 For the full pattern (three-layer architecture, page templates, project org), read `.skills/llm-wiki/SKILL.md`.
+
+The vault format is structurally conformant with the [Open Knowledge Format (OKF) v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) — markdown files with YAML frontmatter, category subfolders, reserved `index.md`/`log.md`. `wiki-export` (OKF mode) and `wiki-import` are the bridge: they translate between our native frontmatter (`title`/`category`/`tags`/`sources`/`created`/`updated` + `summary`) and OKF (`type`/`title`/`description`/`resource`/`tags`/`timestamp`), making vaults exchangeable with any OKF tool. The OKF round-trip is lossless; the `graph.json` round-trip is not.


### PR DESCRIPTION
## What

Teaches `wiki-export` and `wiki-import` to speak **OKF (Open Knowledge Format) v0.1** — the vendor-neutral spec from Google's [knowledge-catalog](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) for representing knowledge as a directory of markdown files with YAML frontmatter. OKF is, almost line-for-line, a *formalized spec* of what this vault already does — its §10 even name-checks "LLM wiki repositories" and Obsidian as prior art.

## Why

The existing `graph.json` round-trip is **lossy** — `wiki-import` rebuilds only stubs (frontmatter + a `## Related` link list, no body). An **OKF bundle is the actual markdown files**, so:

- **Lossless round-trip** — export→import preserves full page bodies.
- **Interoperability** — a bundle drops straight into MkDocs, Notion, Hugo, GitHub's renderer, or Google's reference agent with zero custom tooling.
- **Near-zero structural work** — we already have `index.md`, `log.md`, category subfolders, and required frontmatter.

OKF is **additive** — the four graph files (`graph.json`, `.graphml`, `cypher.txt`, `.html`) are unchanged.

## Changes

- **`.skills/wiki-export/SKILL.md`** — new "OKF bundle" output mode (`wiki-export/okf/`): the canonical frontmatter mapping table, `[[wikilink]]`→file-relative markdown link transform, per-folder `index.md` generation (`okf_version: "0.1"` on root), `log.md` copy.
- **`.skills/wiki-import/SKILL.md`** — source-type detection (graph.json file vs OKF directory) + **Step 4-OKF** that reconstructs *full pages* (not stubs) via reverse mapping.
- **`AGENTS.md`** (= `CLAUDE.md`) — routing triggers + an OKF-conformance architecture note.

### Mapping
`category`(title-cased) ⇄ `type` · `summary` ⇄ `description` · `updated` ⇄ `timestamp` · `resource` ← first `http(s)` source. All native keys (`sources`, `created`, `relationships`, `lifecycle`, `provenance`, …) ride along as OKF **extension frontmatter** — this is what makes the round-trip lossless.

### Notable design decision
Forward-references — `[[wikilinks]]` to not-yet-written pages — are **preserved as links** per OKF §5.3 ("a missing target may simply represent not-yet-written knowledge") rather than dropped to plain text. Dropping them silently deletes user data.

## Verification

Ran a reference implementation of the spec against a real 46-page vault (st3ve):

| Check | Result |
|---|---|
| Exported to bundle | 46/46 |
| OKF §9 conformance | 0 issues |
| Frontmatter lossless | 25/25 (21 frontmatter-less `projects/` pages gain frontmatter — expected) |
| Body / link-graph lossless | 46/46 |
| Round-trip problems | 0 |

The test also surfaced (and the export auto-fixes) a vault page with Obsidian-tolerated-but-strictly-invalid YAML (an unquoted colon in `summary:`).

Docs-only change (the framework is markdown instructions; no scripts).