### PR TITLE
feat(cache): content-hash cache for reliable incremental ingestion

### DIFF
--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -45,16 +45,28 @@ This applies to all ingest modes and all source formats.
 This skill supports three modes. Ask the user or infer from context:
 
 ### Append Mode (default)
-Only ingest sources that are **new or modified** since last ingest. Check the manifest using both timestamp **and content hash**:
+Only ingest sources that are **new or modified** since last ingest. Use the built-in cache command for a reliable, platform-independent check:
 
-- If a source path is not in `.manifest.json` → it's new, ingest it
-- If a source path is in `.manifest.json`:
-  - Compute the file's SHA-256 hash: `sha256sum -- "<file>"` (or `shasum -a 256 -- "<file>"` on macOS). Always double-quote the path and use `--` to prevent filenames with special characters or leading dashes from being interpreted by the shell.
-  - If the hash matches `content_hash` in the manifest → **skip it**, even if the modification time differs (file was touched but content is identical — git checkout, copy, NFS timestamp drift)
-  - If the hash differs → it's genuinely modified, re-ingest it
-- If a source path is in `.manifest.json` and has no `content_hash` (older entry) → fall back to mtime comparison as before
+```bash
+obsidian-wiki cache-check "$OBSIDIAN_VAULT_PATH" <source1> [source2 ...]
+```
 
-This is the right choice most of the time. It's fast and avoids redundant work even when timestamps are unreliable.
+Output: `{"new": [...], "modified": [...], "unchanged": [...], "missing": [...]}`.
+
+- `new` → ingest these
+- `modified` → re-ingest these (content changed since last run)
+- `unchanged` → skip entirely — hash matches, content is identical
+- `missing` → in manifest but no longer on disk; skip and optionally clean up
+
+After ingesting each source, record its hash:
+
+```bash
+obsidian-wiki cache-update "$OBSIDIAN_VAULT_PATH" <source> --pages <page1> [page2 ...]
+```
+
+**Fallback** (if `obsidian-wiki` is not installed): compute hashes manually with `sha256sum -- "<file>"` (Linux) or `shasum -a 256 -- "<file>"` (macOS) and compare against `content_hash` in `.manifest.json`. If the entry has no `content_hash`, fall back to mtime comparison.
+
+This avoids redundant work even when timestamps are unreliable (git checkout, NFS drift, copy operations).
 
 ### Full Mode
 Ingest everything regardless of manifest state. Use when:

--- a/obsidian_wiki/cache.py
+++ b/obsidian_wiki/cache.py
@@ -1,0 +1,151 @@
+"""Content-hash cache for wiki-ingest source tracking.
+
+Provides a reliable, platform-independent alternative to running `sha256sum`
+in the skill. The agent calls `obsidian-wiki cache-check` / `cache-update`
+instead of shelling out to sha256sum and manually parsing .manifest.json.
+
+Manifest format (.manifest.json in the vault root):
+{
+  "sources": {
+    "<abs-or-rel-path>": {
+      "content_hash": "<sha256-hex>",
+      "last_ingested": "<ISO-8601>",
+      "pages_produced": ["<vault-relative-page-path>", ...]
+    }
+  }
+}
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TypedDict
+
+
+class SourceEntry(TypedDict, total=False):
+    content_hash: str
+    last_ingested: str
+    pages_produced: list[str]
+
+
+class CheckResult(TypedDict):
+    new: list[str]
+    modified: list[str]
+    unchanged: list[str]
+    missing: list[str]   # in manifest but file no longer on disk
+
+
+def _manifest_path(vault: Path) -> Path:
+    return vault / ".manifest.json"
+
+
+def _load_manifest(vault: Path) -> dict[str, SourceEntry]:
+    mp = _manifest_path(vault)
+    if not mp.exists():
+        return {}
+    try:
+        data = json.loads(mp.read_text(encoding="utf-8"))
+        return data.get("sources", {})
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_manifest(vault: Path, sources: dict[str, SourceEntry]) -> None:
+    mp = _manifest_path(vault)
+    existing: dict = {}
+    if mp.exists():
+        try:
+            existing = json.loads(mp.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            pass
+    existing["sources"] = sources
+    mp.write_text(json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def sha256_file(path: Path, chunk: int = 1 << 20) -> str:
+    """Return the hex SHA-256 digest of *path* without loading it all into RAM."""
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        while True:
+            block = fh.read(chunk)
+            if not block:
+                break
+            h.update(block)
+    return h.hexdigest()
+
+
+def sha256_dir(path: Path) -> str:
+    """Stable SHA-256 over all files in a directory tree (sorted by relative path)."""
+    h = hashlib.sha256()
+    for fp in sorted(path.rglob("*")):
+        if fp.is_file():
+            rel = str(fp.relative_to(path))
+            h.update(rel.encode())
+            h.update(sha256_file(fp).encode())
+    return h.hexdigest()
+
+
+def compute_hash(path: Path) -> str:
+    if path.is_dir():
+        return sha256_dir(path)
+    return sha256_file(path)
+
+
+def check_sources(vault: Path, source_paths: list[Path]) -> CheckResult:
+    """Classify each source as new / modified / unchanged vs. the manifest.
+
+    Also reports manifest entries whose source file no longer exists on disk.
+    """
+    sources = _load_manifest(vault)
+    result: CheckResult = {"new": [], "modified": [], "unchanged": [], "missing": []}
+
+    for path in source_paths:
+        key = str(path)
+        if not path.exists():
+            result["missing"].append(key)
+            continue
+        current_hash = compute_hash(path)
+        entry = sources.get(key) or sources.get(os.path.abspath(key))
+        if entry is None:
+            result["new"].append(key)
+        elif entry.get("content_hash") != current_hash:
+            result["modified"].append(key)
+        else:
+            result["unchanged"].append(key)
+
+    # Report manifest keys that no longer exist on disk (not in source_paths scan)
+    checked = {str(p) for p in source_paths} | {os.path.abspath(p) for p in source_paths}
+    for key in sources:
+        if key not in checked and not Path(key).exists():
+            result["missing"].append(key)
+
+    return result
+
+
+def update_source(
+    vault: Path,
+    source_path: Path,
+    *,
+    pages_produced: list[str] | None = None,
+) -> str:
+    """Record the current hash of *source_path* in the manifest. Returns the hash."""
+    sources = _load_manifest(vault)
+    key = str(source_path)
+    current_hash = compute_hash(source_path)
+    entry: SourceEntry = sources.get(key, {})
+    entry["content_hash"] = current_hash
+    entry["last_ingested"] = datetime.now(timezone.utc).isoformat()
+    if pages_produced is not None:
+        entry["pages_produced"] = pages_produced
+    sources[key] = entry
+    _save_manifest(vault, sources)
+    return current_hash
+
+
+def hash_file(path: Path) -> str:
+    """Just compute and return the hash — no manifest I/O."""
+    return compute_hash(path)

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -349,6 +349,38 @@ def cmd_setup(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_cache_check(args: argparse.Namespace) -> int:
+    from obsidian_wiki.cache import check_sources
+    vault = Path(args.vault).expanduser().resolve()
+    sources = [Path(p).expanduser().resolve() for p in args.sources]
+    result = check_sources(vault, sources)
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0
+
+
+def cmd_cache_update(args: argparse.Namespace) -> int:
+    from obsidian_wiki.cache import update_source
+    vault = Path(args.vault).expanduser().resolve()
+    source = Path(args.source).expanduser().resolve()
+    pages = args.pages or []
+    h = update_source(vault, source, pages_produced=pages)
+    print(json.dumps({"path": str(source), "content_hash": h}))
+    return 0
+
+
+def cmd_cache_hash(args: argparse.Namespace) -> int:
+    from obsidian_wiki.cache import hash_file
+    path = Path(args.path).expanduser().resolve()
+    if not path.exists():
+        print(f"error: {path} does not exist", file=sys.stderr)
+        return 1
+    print(json.dumps({"path": str(path), "sha256": hash_file(path)}))
+    return 0
+
+
 def cmd_ast_extract(args: argparse.Namespace) -> int:
     from pathlib import Path
     from obsidian_wiki.ast_extractor import extract
@@ -422,6 +454,31 @@ def build_parser() -> argparse.ArgumentParser:
 
     ip = sub.add_parser("info", help="show install paths, version, and config")
     ip.set_defaults(func=cmd_info)
+
+    cc = sub.add_parser(
+        "cache-check",
+        help="check which sources are new/modified/unchanged vs. .manifest.json",
+    )
+    cc.add_argument("vault", help="path to the Obsidian vault")
+    cc.add_argument("sources", nargs="+", help="source file or directory paths to check")
+    cc.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
+    cc.set_defaults(func=cmd_cache_check)
+
+    cu = sub.add_parser(
+        "cache-update",
+        help="record a source's current SHA-256 hash in .manifest.json after ingestion",
+    )
+    cu.add_argument("vault", help="path to the Obsidian vault")
+    cu.add_argument("source", help="source file or directory that was just ingested")
+    cu.add_argument("--pages", nargs="*", metavar="PAGE", help="vault-relative paths of pages produced")
+    cu.set_defaults(func=cmd_cache_update)
+
+    ch = sub.add_parser(
+        "cache-hash",
+        help="compute the SHA-256 hash of a file or directory (no manifest I/O)",
+    )
+    ch.add_argument("path", help="file or directory to hash")
+    ch.set_defaults(func=cmd_cache_hash)
 
     ap = sub.add_parser(
         "ast-extract",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,206 @@
+"""Tests for the content-hash cache module."""
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from obsidian_wiki.cache import (
+    check_sources,
+    compute_hash,
+    hash_file,
+    sha256_file,
+    sha256_dir,
+    update_source,
+    _load_manifest,
+    _manifest_path,
+)
+
+
+@pytest.fixture
+def vault(tmp_path):
+    v = tmp_path / "vault"
+    v.mkdir()
+    return v
+
+
+@pytest.fixture
+def src_file(tmp_path):
+    f = tmp_path / "doc.md"
+    f.write_text("# Hello\nSome content.", encoding="utf-8")
+    return f
+
+
+@pytest.fixture
+def src_dir(tmp_path):
+    d = tmp_path / "repo"
+    d.mkdir()
+    (d / "a.py").write_text("x = 1")
+    (d / "b.py").write_text("y = 2")
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Hash functions
+# ---------------------------------------------------------------------------
+
+class TestHashing:
+    def test_sha256_file_deterministic(self, src_file):
+        assert sha256_file(src_file) == sha256_file(src_file)
+
+    def test_sha256_file_changes_on_edit(self, src_file):
+        h1 = sha256_file(src_file)
+        src_file.write_text("# Different content")
+        h2 = sha256_file(src_file)
+        assert h1 != h2
+
+    def test_sha256_dir_deterministic(self, src_dir):
+        assert sha256_dir(src_dir) == sha256_dir(src_dir)
+
+    def test_sha256_dir_changes_on_edit(self, src_dir):
+        h1 = sha256_dir(src_dir)
+        (src_dir / "a.py").write_text("x = 999")
+        h2 = sha256_dir(src_dir)
+        assert h1 != h2
+
+    def test_compute_hash_dispatches(self, src_file, src_dir):
+        assert len(compute_hash(src_file)) == 64  # hex SHA-256
+        assert len(compute_hash(src_dir)) == 64
+
+    def test_hash_file_alias(self, src_file):
+        assert hash_file(src_file) == sha256_file(src_file)
+
+
+# ---------------------------------------------------------------------------
+# check_sources
+# ---------------------------------------------------------------------------
+
+class TestCheckSources:
+    def test_new_source(self, vault, src_file):
+        result = check_sources(vault, [src_file])
+        assert str(src_file) in result["new"]
+        assert result["modified"] == []
+        assert result["unchanged"] == []
+
+    def test_unchanged_after_update(self, vault, src_file):
+        update_source(vault, src_file)
+        result = check_sources(vault, [src_file])
+        assert str(src_file) in result["unchanged"]
+        assert result["new"] == []
+        assert result["modified"] == []
+
+    def test_modified_after_content_change(self, vault, src_file):
+        update_source(vault, src_file)
+        src_file.write_text("# Changed content")
+        result = check_sources(vault, [src_file])
+        assert str(src_file) in result["modified"]
+
+    def test_missing_path(self, vault, tmp_path):
+        ghost = tmp_path / "ghost.md"
+        result = check_sources(vault, [ghost])
+        assert str(ghost) in result["missing"]
+
+    def test_empty_source_list(self, vault):
+        result = check_sources(vault, [])
+        assert result == {"new": [], "modified": [], "unchanged": [], "missing": []}
+
+    def test_multiple_sources(self, vault, src_file, src_dir):
+        update_source(vault, src_file)
+        result = check_sources(vault, [src_file, src_dir])
+        assert str(src_file) in result["unchanged"]
+        assert str(src_dir) in result["new"]
+
+    def test_timestamp_irrelevant(self, vault, src_file):
+        # Touch the file (change mtime) without changing content — still unchanged
+        update_source(vault, src_file)
+        src_file.touch()
+        result = check_sources(vault, [src_file])
+        assert str(src_file) in result["unchanged"]
+
+
+# ---------------------------------------------------------------------------
+# update_source / manifest
+# ---------------------------------------------------------------------------
+
+class TestUpdateSource:
+    def test_writes_manifest(self, vault, src_file):
+        update_source(vault, src_file)
+        assert _manifest_path(vault).exists()
+
+    def test_records_correct_hash(self, vault, src_file):
+        h = update_source(vault, src_file)
+        assert h == sha256_file(src_file)
+        sources = _load_manifest(vault)
+        assert sources[str(src_file)]["content_hash"] == h
+
+    def test_records_pages_produced(self, vault, src_file):
+        update_source(vault, src_file, pages_produced=["concepts/foo.md", "entities/bar.md"])
+        sources = _load_manifest(vault)
+        assert sources[str(src_file)]["pages_produced"] == ["concepts/foo.md", "entities/bar.md"]
+
+    def test_records_last_ingested_timestamp(self, vault, src_file):
+        update_source(vault, src_file)
+        sources = _load_manifest(vault)
+        assert "last_ingested" in sources[str(src_file)]
+
+    def test_update_overwrites_old_hash(self, vault, src_file):
+        update_source(vault, src_file)
+        src_file.write_text("new content")
+        h2 = update_source(vault, src_file)
+        sources = _load_manifest(vault)
+        assert sources[str(src_file)]["content_hash"] == h2
+
+    def test_preserves_other_manifest_entries(self, vault, src_file, src_dir):
+        update_source(vault, src_file)
+        update_source(vault, src_dir)
+        sources = _load_manifest(vault)
+        assert str(src_file) in sources
+        assert str(src_dir) in sources
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestCacheCLI:
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, "-m", "obsidian_wiki.cli", *args],
+            capture_output=True, text=True,
+        )
+
+    def test_cache_hash_file(self, src_file):
+        proc = self._run("cache-hash", str(src_file))
+        assert proc.returncode == 0
+        data = json.loads(proc.stdout)
+        assert data["sha256"] == sha256_file(src_file)
+
+    def test_cache_hash_missing_exits_nonzero(self, tmp_path):
+        proc = self._run("cache-hash", str(tmp_path / "nope.md"))
+        assert proc.returncode != 0
+
+    def test_cache_check_new(self, vault, src_file):
+        proc = self._run("cache-check", str(vault), str(src_file))
+        assert proc.returncode == 0
+        data = json.loads(proc.stdout)
+        assert str(src_file) in data["new"]
+
+    def test_cache_check_pretty(self, vault, src_file):
+        proc = self._run("cache-check", "--pretty", str(vault), str(src_file))
+        assert proc.returncode == 0
+        assert "\n  " in proc.stdout
+
+    def test_cache_update_then_check_unchanged(self, vault, src_file):
+        self._run("cache-update", str(vault), str(src_file))
+        proc = self._run("cache-check", str(vault), str(src_file))
+        data = json.loads(proc.stdout)
+        assert str(src_file) in data["unchanged"]
+
+    def test_cache_update_with_pages(self, vault, src_file):
+        proc = self._run("cache-update", str(vault), str(src_file),
+                         "--pages", "concepts/foo.md", "entities/bar.md")
+        assert proc.returncode == 0
+        sources = _load_manifest(vault)
+        assert sources[str(src_file)]["pages_produced"] == ["concepts/foo.md", "entities/bar.md"]


### PR DESCRIPTION
## Summary

- Replaces platform-specific `sha256sum` shell invocations in wiki-ingest with a dedicated Python module + 3 CLI commands
- `obsidian-wiki cache-check <vault> <sources...>` → JSON with `{new, modified, unchanged, missing}` — single call replaces the manual manifest-parse dance
- `obsidian-wiki cache-update <vault> <source> [--pages ...]` → records hash + pages_produced + timestamp after ingestion
- `obsidian-wiki cache-hash <path>` → just returns SHA-256 (file or directory tree)
- Directory hashing uses a stable sorted-walk so the same tree always produces the same hash regardless of filesystem order
- Pure stdlib — no new runtime dependencies
- wiki-ingest SKILL.md append-mode section updated to use the new commands

## Test plan

- [ ] `python3 -m pytest tests/ -q` — 53 tests pass
- [ ] `obsidian-wiki cache-check <vault> <file>` → `{"new": [...], ...}`
- [ ] Edit file, re-check → moves to `modified`
- [ ] `cache-update` → re-check → moves to `unchanged`
- [ ] Test on st3ve (Ubuntu): hash stability, manifest round-trips