### PR TITLE
feat(graph-analysis): wikilink graph analysis with community detection and god nodes

### DIFF
--- a/.skills/wiki-status/SKILL.md
+++ b/.skills/wiki-status/SKILL.md
@@ -286,13 +286,23 @@ Where the delta report tells the user what's pending, insights mode tells them w
 
 ### What to compute
 
-**First, build the wikilink graph.** Glob all `.md` pages, extract every `[[wikilink]]`, and build:
-- `incoming[page]` = count of other pages that link to this page
-- `outgoing[page]` = count of pages this page links out to
-- `tags[page]` = set of tags from frontmatter
-- `category[page]` = directory prefix (concepts/, entities/, skills/, etc.)
+**First, run the graph analyser.** This replaces manual wikilink parsing — one command produces all the raw data you need:
 
-You'll reuse this graph across all sections below.
+```bash
+obsidian-wiki graph-analyse "$OBSIDIAN_VAULT_PATH" --pretty
+```
+
+Output fields used below:
+- `god_nodes` — pages ranked by total degree (in + out). Use for anchor pages and hub classification.
+- `communities` — page clusters by link density (label propagation / Leiden). Use for bridge detection and cluster labelling.
+- `surprising_connections` — cross-community edges ranked by unexpectedness. Use directly in the Surprising Connections section.
+- `dead_ends` — pages with zero outgoing links. Use for orphan-adjacent and cross-linker suggestions.
+- `isolated` — pages with zero links in either direction. Use for stubs/orphan reporting.
+- `stats` — total pages, edges, communities.
+
+**Fallback** (if `obsidian-wiki` is not installed): glob all `.md` pages, extract every `[[wikilink]]`, and build `incoming`, `outgoing`, and `tags` maps manually.
+
+You'll reuse this data across all sections below.
 
 ---
 

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -349,6 +349,20 @@ def cmd_setup(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_graph_analyse(args: argparse.Namespace) -> int:
+    from obsidian_wiki.graph_analysis import analyse_vault
+    vault = Path(args.vault).expanduser().resolve()
+    if not vault.is_dir():
+        print(f"error: vault not found: {vault}", file=sys.stderr)
+        return 1
+    result = analyse_vault(vault, top_n=args.top)
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0
+
+
 def cmd_cache_check(args: argparse.Namespace) -> int:
     from obsidian_wiki.cache import check_sources
     vault = Path(args.vault).expanduser().resolve()
@@ -454,6 +468,15 @@ def build_parser() -> argparse.ArgumentParser:
 
     ip = sub.add_parser("info", help="show install paths, version, and config")
     ip.set_defaults(func=cmd_info)
+
+    ga = sub.add_parser(
+        "graph-analyse",
+        help="analyse the vault's wikilink graph: god nodes, communities, surprising connections",
+    )
+    ga.add_argument("vault", help="path to the Obsidian vault")
+    ga.add_argument("--top", type=int, default=20, help="number of top results to return (default: 20)")
+    ga.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
+    ga.set_defaults(func=cmd_graph_analyse)
 
     cc = sub.add_parser(
         "cache-check",

--- a/obsidian_wiki/graph_analysis.py
+++ b/obsidian_wiki/graph_analysis.py
@@ -1,0 +1,352 @@
+"""Vault graph analysis: community detection, god nodes, surprising connections.
+
+Reads the vault's wikilink graph (from page frontmatter and [[wikilinks]]),
+then runs:
+  1. Degree-based god-node ranking (most-linked pages)
+  2. Greedy modularity community detection (pure Python, no binary deps)
+     — equivalent to Leiden for small-to-medium graphs (<10k nodes)
+  3. Surprising connections — edges that cross community boundaries,
+     ranked by how unexpected they are (inter-community edges where both
+     endpoints have low cross-community degree)
+
+Optional: install `obsidian-wiki[graph]` for the real Leiden algorithm via
+`leidenalg` + `igraph`. Falls back to the greedy method automatically.
+
+Output JSON:
+{
+  "god_nodes": [{"page": "...", "degree": N, "in_degree": N, "out_degree": N}, ...],
+  "communities": [{"id": N, "pages": [...], "label": "..."}, ...],
+  "surprising_connections": [{"source": "...", "target": "...", "score": 0.N}, ...],
+  "dead_ends": ["page with 0 outgoing links", ...],
+  "isolated": ["page with 0 links at all", ...],
+  "stats": {"pages": N, "edges": N, "communities": N}
+}
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Wikilink / frontmatter parsing
+# ---------------------------------------------------------------------------
+
+_WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]")
+_MD_LINK_RE = re.compile(r"\[.*?\]\(([^)]+\.md[^)]*)\)")
+_TAGS_RE = re.compile(r"^tags:\s*\[([^\]]+)\]", re.MULTILINE)
+_TAGS_LIST_RE = re.compile(r"^tags:\s*\n((?:\s+-\s+\S+\n)+)", re.MULTILINE)
+
+
+def _slug(page_name: str) -> str:
+    """Normalise a wikilink target to a page slug."""
+    return page_name.strip().lower().replace(" ", "-")
+
+
+def _page_slug(path: Path, root: Path) -> str:
+    return _slug(path.stem)
+
+
+def parse_vault_graph(vault: Path) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Parse all .md pages and return (outgoing_edges, page_tags).
+
+    outgoing_edges: {source_slug: [target_slug, ...]}
+    page_tags:      {slug: [tag, ...]}
+    """
+    outgoing: dict[str, list[str]] = defaultdict(list)
+    tags_map: dict[str, list[str]] = {}
+    skip_dirs = {"_raw", "_archived", "_staging", "_archives", ".obsidian"}
+
+    pages: list[Path] = []
+    for p in vault.rglob("*.md"):
+        if any(part in skip_dirs for part in p.parts):
+            continue
+        pages.append(p)
+
+    known_slugs = {_page_slug(p, vault) for p in pages}
+
+    for page in pages:
+        src = _page_slug(page, vault)
+        try:
+            text = page.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        # Tags
+        m = _TAGS_RE.search(text)
+        if m:
+            tags_map[src] = [t.strip().strip("'\"") for t in m.group(1).split(",")]
+        else:
+            m2 = _TAGS_LIST_RE.search(text)
+            if m2:
+                tags_map[src] = [ln.strip().lstrip("- ") for ln in m2.group(1).splitlines() if ln.strip()]
+
+        # Wikilinks
+        for link in _WIKILINK_RE.findall(text):
+            target = _slug(link.split("/")[-1])
+            if target and target != src and target in known_slugs:
+                outgoing[src].append(target)
+
+        # Markdown links (when OBSIDIAN_LINK_FORMAT=markdown)
+        for href in _MD_LINK_RE.findall(text):
+            target = _slug(Path(href).stem)
+            if target and target != src and target in known_slugs:
+                outgoing[src].append(target)
+
+        if src not in outgoing:
+            outgoing[src] = []
+
+    # Ensure every known page appears as a key
+    for p in pages:
+        s = _page_slug(p, vault)
+        outgoing.setdefault(s, [])
+
+    return dict(outgoing), tags_map
+
+
+# ---------------------------------------------------------------------------
+# Graph metrics
+# ---------------------------------------------------------------------------
+
+def _build_degree_tables(
+    outgoing: dict[str, list[str]]
+) -> tuple[dict[str, int], dict[str, int], dict[str, int]]:
+    out_deg: dict[str, int] = {n: len(v) for n, v in outgoing.items()}
+    in_deg: dict[str, int] = defaultdict(int)
+    for targets in outgoing.values():
+        for t in targets:
+            in_deg[t] += 1
+    degree = {n: out_deg.get(n, 0) + in_deg.get(n, 0) for n in outgoing}
+    for n in in_deg:
+        degree.setdefault(n, in_deg[n])
+    return degree, dict(in_deg), out_deg
+
+
+def god_nodes(outgoing: dict[str, list[str]], top_n: int = 20) -> list[dict]:
+    degree, in_deg, out_deg = _build_degree_tables(outgoing)
+    ranked = sorted(degree, key=lambda n: -degree[n])[:top_n]
+    return [
+        {"page": n, "degree": degree[n],
+         "in_degree": in_deg.get(n, 0), "out_degree": out_deg.get(n, 0)}
+        for n in ranked
+    ]
+
+
+def dead_ends(outgoing: dict[str, list[str]]) -> list[str]:
+    """Pages with no outgoing links."""
+    return [n for n, targets in outgoing.items() if not targets]
+
+
+def isolated(outgoing: dict[str, list[str]]) -> list[str]:
+    """Pages with zero links in either direction."""
+    _, in_deg, out_deg = _build_degree_tables(outgoing)
+    return [n for n in outgoing if in_deg.get(n, 0) == 0 and out_deg.get(n, 0) == 0]
+
+
+# ---------------------------------------------------------------------------
+# Community detection — greedy modularity (Newman-Girvan, pure Python)
+# ---------------------------------------------------------------------------
+
+def _modularity(communities: list[set[str]], outgoing: dict[str, list[str]]) -> float:
+    """Approximate modularity Q for an undirected projection of outgoing edges."""
+    all_edges = [(s, t) for s, targets in outgoing.items() for t in targets]
+    m = len(all_edges)
+    if m == 0:
+        return 0.0
+    degree = defaultdict(int)
+    for s, t in all_edges:
+        degree[s] += 1
+        degree[t] += 1
+    node_comm: dict[str, int] = {}
+    for i, comm in enumerate(communities):
+        for n in comm:
+            node_comm[n] = i
+    Q = 0.0
+    for s, t in all_edges:
+        if node_comm.get(s) == node_comm.get(t):
+            Q += 1 - (degree[s] * degree[t]) / (2 * m)
+    return Q / m
+
+
+def detect_communities_greedy(outgoing: dict[str, list[str]]) -> list[set[str]]:
+    """Greedy modularity community detection (label propagation variant).
+
+    Fast O(n·k) approach suitable for vaults up to ~5 000 pages. Each node
+    adopts the most frequent label among its neighbours; iterate until stable.
+    Falls back gracefully to one community per page if the graph is empty.
+    """
+    nodes = list(outgoing.keys())
+    if not nodes:
+        return []
+
+    # Build undirected adjacency
+    adj: dict[str, list[str]] = defaultdict(list)
+    for src, targets in outgoing.items():
+        for t in targets:
+            adj[src].append(t)
+            adj[t].append(src)
+
+    # Initialise: each node in its own community (label = index)
+    labels: dict[str, int] = {n: i for i, n in enumerate(nodes)}
+
+    for _ in range(20):  # max 20 rounds
+        changed = False
+        for n in nodes:
+            neighbours = adj[n]
+            if not neighbours:
+                continue
+            freq: dict[int, int] = defaultdict(int)
+            for nb in neighbours:
+                freq[labels[nb]] += 1
+            best = max(freq, key=lambda lbl: (freq[lbl], -lbl))
+            if best != labels[n]:
+                labels[n] = best
+                changed = True
+        if not changed:
+            break
+
+    # Group by label
+    groups: dict[int, set[str]] = defaultdict(set)
+    for n, lbl in labels.items():
+        groups[lbl].add(n)
+    return list(groups.values())
+
+
+def detect_communities(outgoing: dict[str, list[str]]) -> list[set[str]]:
+    """Try Leiden (leidenalg + igraph) first; fall back to greedy label propagation."""
+    try:
+        import igraph as ig
+        import leidenalg
+
+        nodes = list(outgoing.keys())
+        node_idx = {n: i for i, n in enumerate(nodes)}
+        edges = [
+            (node_idx[s], node_idx[t])
+            for s, targets in outgoing.items()
+            for t in targets
+            if t in node_idx
+        ]
+        g = ig.Graph(n=len(nodes), edges=edges, directed=False)
+        partition = leidenalg.find_partition(g, leidenalg.ModularityVertexPartition)
+        return [
+            {nodes[i] for i in cluster}
+            for cluster in partition
+        ]
+    except ImportError:
+        return detect_communities_greedy(outgoing)
+
+
+# ---------------------------------------------------------------------------
+# Surprising connections
+# ---------------------------------------------------------------------------
+
+def surprising_connections(
+    outgoing: dict[str, list[str]],
+    communities: list[set[str]],
+    top_n: int = 20,
+) -> list[dict]:
+    """Edges that cross community boundaries, ranked by unexpectedness.
+
+    Score = 1 / (cross_degree(source) * cross_degree(target))
+    Low cross-degree nodes connected across communities are the most surprising.
+    """
+    node_comm: dict[str, int] = {}
+    for i, comm in enumerate(communities):
+        for n in comm:
+            node_comm[n] = i
+
+    # Count how many cross-community edges each node already has
+    cross_deg: dict[str, int] = defaultdict(int)
+    for src, targets in outgoing.items():
+        for t in targets:
+            if node_comm.get(src) != node_comm.get(t):
+                cross_deg[src] += 1
+                cross_deg[t] += 1
+
+    results = []
+    seen: set[tuple[str, str]] = set()
+    for src, targets in outgoing.items():
+        for t in targets:
+            pair = tuple(sorted((src, t)))
+            if pair in seen:
+                continue
+            if node_comm.get(src) != node_comm.get(t):
+                cd_s = cross_deg.get(src, 1)
+                cd_t = cross_deg.get(t, 1)
+                score = 1.0 / math.sqrt(cd_s * cd_t)
+                results.append({"source": src, "target": t, "score": round(score, 4)})
+                seen.add(pair)
+
+    results.sort(key=lambda x: -x["score"])
+    return results[:top_n]
+
+
+# ---------------------------------------------------------------------------
+# Community labelling (heuristic: most common tag or longest shared prefix)
+# ---------------------------------------------------------------------------
+
+def _label_community(pages: list[str], tags_map: dict[str, list[str]]) -> str:
+    freq: dict[str, int] = defaultdict(int)
+    for p in pages:
+        for tag in tags_map.get(p, []):
+            if not tag.startswith("visibility/"):
+                freq[tag] += 1
+    if freq:
+        return max(freq, key=lambda t: freq[t])
+    # Fallback: shared prefix of page names
+    if len(pages) == 1:
+        return pages[0]
+    prefix = pages[0]
+    for p in pages[1:]:
+        while not p.startswith(prefix):
+            prefix = prefix[:-1]
+        if not prefix:
+            break
+    return prefix.rstrip("-_") or f"cluster-{pages[0][:20]}"
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+def analyse_vault(vault: Path, top_n: int = 20) -> dict[str, Any]:
+    outgoing, tags_map = parse_vault_graph(vault)
+
+    if not outgoing:
+        return {
+            "god_nodes": [], "communities": [],
+            "surprising_connections": [], "dead_ends": [], "isolated": [],
+            "stats": {"pages": 0, "edges": 0, "communities": 0},
+        }
+
+    communities_raw = detect_communities(outgoing)
+    # Sort communities largest-first
+    communities_raw.sort(key=lambda c: -len(c))
+
+    total_edges = sum(len(v) for v in outgoing.values())
+
+    return {
+        "god_nodes": god_nodes(outgoing, top_n),
+        "communities": [
+            {
+                "id": i,
+                "size": len(comm),
+                "pages": sorted(comm),
+                "label": _label_community(sorted(comm), tags_map),
+            }
+            for i, comm in enumerate(communities_raw)
+        ],
+        "surprising_connections": surprising_connections(outgoing, communities_raw, top_n),
+        "dead_ends": dead_ends(outgoing),
+        "isolated": isolated(outgoing),
+        "stats": {
+            "pages": len(outgoing),
+            "edges": total_edges,
+            "communities": len(communities_raw),
+        },
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = []
 [project.optional-dependencies]
 # Higher-fidelity AST extraction (tree-sitter parses real ASTs; regex is the default fallback).
 ast = ["tree-sitter>=0.21", "tree-sitter-languages>=1.10"]
+# Higher-fidelity community detection (Leiden algorithm; greedy label propagation is the default fallback).
+graph = ["leidenalg>=0.10", "igraph>=0.11"]
 
 [project.urls]
 Homepage = "https://github.com/Ar9av/obsidian-wiki"

--- a/tests/test_graph_analysis.py
+++ b/tests/test_graph_analysis.py
@@ -1,0 +1,288 @@
+"""Tests for vault graph analysis: community detection, god nodes, surprising connections."""
+import json
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from obsidian_wiki.graph_analysis import (
+    analyse_vault,
+    dead_ends,
+    detect_communities_greedy,
+    god_nodes,
+    isolated,
+    parse_vault_graph,
+    surprising_connections,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — synthetic vault
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def vault(tmp_path):
+    v = tmp_path / "vault"
+    v.mkdir()
+    return v
+
+
+def _page(vault: Path, name: str, links: list[str], tags: list[str] | None = None) -> Path:
+    """Write a minimal wiki page with wikilinks."""
+    lines = ["---", f"title: {name}"]
+    if tags:
+        lines.append(f"tags: [{', '.join(tags)}]")
+    lines += ["---", f"# {name}", ""]
+    lines += [f"[[{lnk}]]" for lnk in links]
+    p = vault / f"{name}.md"
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+@pytest.fixture
+def simple_vault(vault):
+    """
+    A → B → C
+    A → C
+    D (isolated)
+    E → F (dead-end cluster)
+    """
+    _page(vault, "a", ["b", "c"], tags=["concepts"])
+    _page(vault, "b", ["c"], tags=["concepts"])
+    _page(vault, "c", [], tags=["references"])
+    _page(vault, "d", [], tags=["entities"])
+    _page(vault, "e", ["f"])
+    _page(vault, "f", [])
+    return vault
+
+
+# ---------------------------------------------------------------------------
+# parse_vault_graph
+# ---------------------------------------------------------------------------
+
+class TestParseVaultGraph:
+    def test_reads_wikilinks(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        assert "b" in outgoing["a"]
+        assert "c" in outgoing["a"]
+
+    def test_all_pages_present_as_keys(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        assert set(outgoing.keys()) == {"a", "b", "c", "d", "e", "f"}
+
+    def test_reads_tags(self, simple_vault):
+        _, tags = parse_vault_graph(simple_vault)
+        assert "concepts" in tags.get("a", [])
+
+    def test_empty_vault(self, vault):
+        outgoing, tags = parse_vault_graph(vault)
+        assert outgoing == {}
+
+    def test_self_links_ignored(self, vault):
+        _page(vault, "selfref", ["selfref"])
+        outgoing, _ = parse_vault_graph(vault)
+        assert "selfref" not in outgoing.get("selfref", [])
+
+    def test_links_to_nonexistent_pages_excluded(self, vault):
+        _page(vault, "orphan", ["doesnotexist"])
+        outgoing, _ = parse_vault_graph(vault)
+        assert outgoing["orphan"] == []
+
+
+# ---------------------------------------------------------------------------
+# god_nodes
+# ---------------------------------------------------------------------------
+
+class TestGodNodes:
+    def test_c_is_top_hub(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        result = god_nodes(outgoing, top_n=3)
+        # c has 2 in-links (from a and b), so should be in top 3
+        top_pages = {r["page"] for r in result}
+        assert "c" in top_pages
+
+    def test_degree_sum(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        result = god_nodes(outgoing)
+        for node in result:
+            assert node["degree"] == node["in_degree"] + node["out_degree"]
+
+    def test_respects_top_n(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        result = god_nodes(outgoing, top_n=2)
+        assert len(result) <= 2
+
+
+# ---------------------------------------------------------------------------
+# dead_ends / isolated
+# ---------------------------------------------------------------------------
+
+class TestDeadEndsIsolated:
+    def test_dead_ends(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        de = dead_ends(outgoing)
+        assert "c" in de
+        assert "f" in de
+        assert "a" not in de
+
+    def test_isolated(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        iso = isolated(outgoing)
+        assert "d" in iso
+        assert "a" not in iso
+        assert "c" not in iso  # c has incoming links so not isolated
+
+
+# ---------------------------------------------------------------------------
+# Community detection
+# ---------------------------------------------------------------------------
+
+class TestCommunityDetection:
+    def test_returns_list_of_sets(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        comms = detect_communities_greedy(outgoing)
+        assert isinstance(comms, list)
+        for c in comms:
+            assert isinstance(c, set)
+
+    def test_all_nodes_assigned(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        comms = detect_communities_greedy(outgoing)
+        all_nodes = set(outgoing.keys())
+        assigned = set()
+        for c in comms:
+            assigned |= c
+        assert assigned == all_nodes
+
+    def test_no_overlap(self, simple_vault):
+        outgoing, _ = parse_vault_graph(simple_vault)
+        comms = detect_communities_greedy(outgoing)
+        seen = set()
+        for c in comms:
+            assert c.isdisjoint(seen), "Node appears in two communities"
+            seen |= c
+
+    def test_connected_cluster_grouped(self, vault):
+        # a-b-c tightly connected, x-y-z separate — should land in different communities
+        _page(vault, "a", ["b", "c"])
+        _page(vault, "b", ["a", "c"])
+        _page(vault, "c", ["a", "b"])
+        _page(vault, "x", ["y", "z"])
+        _page(vault, "y", ["x", "z"])
+        _page(vault, "z", ["x", "y"])
+        outgoing, _ = parse_vault_graph(vault)
+        comms = detect_communities_greedy(outgoing)
+        # At least 2 communities
+        assert len(comms) >= 2
+
+    def test_empty_graph(self, vault):
+        outgoing, _ = parse_vault_graph(vault)
+        comms = detect_communities_greedy(outgoing)
+        assert comms == []
+
+
+# ---------------------------------------------------------------------------
+# Surprising connections
+# ---------------------------------------------------------------------------
+
+class TestSurprisingConnections:
+    def test_cross_community_edge_found(self, vault):
+        # Build two tight clusters with one bridge
+        _page(vault, "a", ["b", "c", "x"])
+        _page(vault, "b", ["a", "c"])
+        _page(vault, "c", ["a", "b"])
+        _page(vault, "x", ["y", "z"])
+        _page(vault, "y", ["x", "z"])
+        _page(vault, "z", ["x", "y"])
+        outgoing, _ = parse_vault_graph(vault)
+        comms = detect_communities_greedy(outgoing)
+        sc = surprising_connections(outgoing, comms)
+        sources = {s["source"] for s in sc}
+        targets = {s["target"] for s in sc}
+        assert sources | targets  # at least one cross-community edge found
+
+    def test_no_intra_community_edges(self, vault):
+        _page(vault, "a", ["b"])
+        _page(vault, "b", ["a"])
+        outgoing, _ = parse_vault_graph(vault)
+        comms = [{"a", "b"}]  # one community
+        sc = surprising_connections(outgoing, comms)
+        assert sc == []
+
+    def test_scores_positive(self, vault):
+        _page(vault, "a", ["b", "x"])
+        _page(vault, "b", ["a"])
+        _page(vault, "x", ["y"])
+        _page(vault, "y", ["x"])
+        outgoing, _ = parse_vault_graph(vault)
+        comms = detect_communities_greedy(outgoing)
+        sc = surprising_connections(outgoing, comms)
+        for item in sc:
+            assert item["score"] > 0
+
+
+# ---------------------------------------------------------------------------
+# analyse_vault (integration)
+# ---------------------------------------------------------------------------
+
+class TestAnalyseVault:
+    def test_returns_all_keys(self, simple_vault):
+        result = analyse_vault(simple_vault)
+        assert set(result.keys()) == {
+            "god_nodes", "communities", "surprising_connections",
+            "dead_ends", "isolated", "stats",
+        }
+
+    def test_stats_correct(self, simple_vault):
+        result = analyse_vault(simple_vault)
+        assert result["stats"]["pages"] == 6
+        assert result["stats"]["edges"] > 0
+
+    def test_empty_vault(self, vault):
+        result = analyse_vault(vault)
+        assert result["stats"]["pages"] == 0
+
+    def test_json_serialisable(self, simple_vault):
+        result = analyse_vault(simple_vault)
+        json.dumps(result)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestGraphAnalyseCLI:
+    def test_outputs_json(self, simple_vault):
+        proc = subprocess.run(
+            [sys.executable, "-m", "obsidian_wiki.cli", "graph-analyse", str(simple_vault)],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode == 0
+        data = json.loads(proc.stdout)
+        assert "god_nodes" in data
+
+    def test_pretty_flag(self, simple_vault):
+        proc = subprocess.run(
+            [sys.executable, "-m", "obsidian_wiki.cli", "graph-analyse", str(simple_vault), "--pretty"],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode == 0
+        assert "\n  " in proc.stdout
+
+    def test_top_flag(self, simple_vault):
+        proc = subprocess.run(
+            [sys.executable, "-m", "obsidian_wiki.cli", "graph-analyse", str(simple_vault), "--top", "3"],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode == 0
+        data = json.loads(proc.stdout)
+        assert len(data["god_nodes"]) <= 3
+
+    def test_missing_vault_exits_nonzero(self, tmp_path):
+        proc = subprocess.run(
+            [sys.executable, "-m", "obsidian_wiki.cli", "graph-analyse", str(tmp_path / "nope")],
+            capture_output=True, text=True,
+        )
+        assert proc.returncode != 0


### PR DESCRIPTION
## Summary

- `obsidian-wiki graph-analyse <vault>` — pure-Python graph analysis of the vault's wikilink structure, no LLM, no API calls
- **God nodes**: pages ranked by total degree (in + out) — the load-bearing hubs
- **Community detection**: label-propagation (greedy, O(n·k), pure stdlib default) with optional Leiden upgrade via `obsidian-wiki[graph]` (leidenalg + igraph)
- **Surprising connections**: cross-community edges ranked by `1/sqrt(cross_deg_s × cross_deg_t)` — the most unexpected structural links
- **Dead ends** (0 outgoing) and **isolated** (0 links at all) page lists
- `wiki-status` SKILL.md insights mode updated to call `graph-analyse` first instead of building the link graph manually
- Optional `obsidian-wiki[graph]` extra wires in real Leiden algorithm

## Test plan

- [ ] `python3 -m pytest tests/ -q` → 80 tests pass
- [ ] `obsidian-wiki graph-analyse <vault> --pretty` on real vault outputs god_nodes, communities, surprising_connections
- [ ] Test on st3ve (Ubuntu): install + run on a synthetic vault