### PR TITLE
feat(graphrag): graph-index query pre-pass eliminates speculative page reads

### DIFF
--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -56,6 +56,31 @@ In filtered mode, note the filter in the Step 6 log entry: `mode=filtered`.
 
 **Follow the Retrieval Primitives table in `llm-wiki/SKILL.md`.** Reading is the dominant cost of this skill — use the cheapest primitive that answers the question and escalate only when it can't. Never jump straight to full-page reads.
 
+### Step 0: GraphRAG Pre-pass (fast index query — no page reads)
+
+Before opening any pages, query the compiled graph index:
+
+```bash
+obsidian-wiki graph-query "$OBSIDIAN_VAULT_PATH" "<question>" --pretty
+```
+
+Output fields:
+
+- **`answer_type`**: `direct` | `path` | `list` | `gap` — shapes what to do next
+- **`candidates`**: top-ranked pages by title/tag/summary match + degree, with scores and summaries
+- **`should_read`**: the pages most worth opening — start here instead of speculatively reading many files
+- **`path`**: for multi-hop queries, the shortest wikilink path between the two concepts
+- **`god_nodes_relevant`**: hub pages related to your query terms — always useful context
+- **`index_only`**: if `true`, the top candidate's summary already answers the question — skip page reads
+
+**Decision tree:**
+
+1. If `index_only: true` → answer directly from `candidates[0].summary`. Skip Steps 1–4, go to Step 5.
+2. If `answer_type == "path"` and `path` is non-empty → the connection is in `path`. Read only those pages.
+3. Otherwise → open only `should_read` pages (not all candidates). This replaces the speculative 5–10 page reads the old flow required.
+
+**Fallback** (if `obsidian-wiki` is not installed): proceed with Step 1 as normal using grep and index.md.
+
 ### Step 1: Understand the Question
 
 Classify the query type:

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -349,6 +349,20 @@ def cmd_setup(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_graph_query(args: argparse.Namespace) -> int:
+    from obsidian_wiki.graphrag import query
+    vault = Path(args.vault).expanduser().resolve()
+    if not vault.is_dir():
+        print(f"error: vault not found: {vault}", file=sys.stderr)
+        return 1
+    result = query(vault, args.question, top_n=args.top, max_should_read=args.max_read)
+    if args.pretty:
+        print(json.dumps(result, indent=2))
+    else:
+        print(json.dumps(result))
+    return 0
+
+
 def cmd_batch_plan(args: argparse.Namespace) -> int:
     from obsidian_wiki.batch import plan_batches
     source_dir = Path(args.source_dir).expanduser().resolve()
@@ -490,6 +504,17 @@ def build_parser() -> argparse.ArgumentParser:
 
     ip = sub.add_parser("info", help="show install paths, version, and config")
     ip.set_defaults(func=cmd_info)
+
+    gq = sub.add_parser(
+        "graph-query",
+        help="answer a question from the vault's wikilink index without reading page bodies",
+    )
+    gq.add_argument("vault", help="path to the Obsidian vault")
+    gq.add_argument("question", help="question to answer")
+    gq.add_argument("--top", type=int, default=8, help="number of candidate pages to rank (default: 8)")
+    gq.add_argument("--max-read", type=int, default=3, help="max pages to return in should_read (default: 3)")
+    gq.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
+    gq.set_defaults(func=cmd_graph_query)
 
     bp = sub.add_parser(
         "batch-plan",

--- a/obsidian_wiki/graphrag.py
+++ b/obsidian_wiki/graphrag.py
@@ -1,0 +1,367 @@
+"""GraphRAG query index for wiki-query.
+
+Builds a compact in-memory index from vault page frontmatter and wikilinks,
+then answers structural and factual queries against it without opening any
+page bodies. Equivalent to graphify's "query the compiled graph instead of
+raw files" — saves reading 10–50 pages for questions answerable from the
+graph structure.
+
+The agent calls:
+  obsidian-wiki graph-query <vault> "<question>" [options]
+
+And gets back a JSON response:
+{
+  "answer_type": "direct" | "path" | "list" | "gap",
+  "candidates": [{"page": "...", "score": 0.N, "summary": "..."}, ...],
+  "path": ["page-a", "page-b", "page-c"],   # multi-hop, if applicable
+  "god_nodes_relevant": ["page", ...],        # hub pages related to query terms
+  "should_read": ["page-a.md", "page-b.md"], # pages worth opening for full detail
+  "index_only": true/false                    # true = answer is complete without page reads
+}
+
+The `should_read` list is the key output: it tells the agent exactly which pages
+to open, replacing the current approach of opening 10+ pages speculatively.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict, deque
+from pathlib import Path
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Index building
+# ---------------------------------------------------------------------------
+
+_FRONT_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
+_TITLE_RE = re.compile(r"^title:\s*(.+)$", re.MULTILINE)
+_TAGS_RE = re.compile(r"^tags:\s*\[([^\]]+)\]", re.MULTILINE)
+_TAGS_LIST_RE = re.compile(r"^tags:\s*\n((?:\s+-\s+\S+\n)+)", re.MULTILINE)
+_SUMMARY_RE = re.compile(r"^summary:\s*(.+?)$", re.MULTILINE)
+_CATEGORY_RE = re.compile(r"^category:\s*(\w+)", re.MULTILINE)
+_TIER_RE = re.compile(r"^tier:\s*(\w+)", re.MULTILINE)
+_WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]")
+_MD_LINK_RE = re.compile(r"\[.*?\]\(([^)]+\.md[^)]*)\)")
+
+SKIP_DIRS = frozenset(
+    "_raw _archived _staging _archives .obsidian".split()
+)
+
+
+def _slug(s: str) -> str:
+    return s.strip().lower().replace(" ", "-")
+
+
+def build_index(vault: Path) -> dict[str, dict]:
+    """Build a lightweight index dict from vault frontmatter and wikilinks.
+
+    Returns:
+        {slug: {title, tags, summary, category, tier, out_links, in_links, path}}
+    """
+    pages: dict[str, dict] = {}
+
+    md_files = [
+        p for p in vault.rglob("*.md")
+        if not any(part in SKIP_DIRS for part in p.relative_to(vault).parts)
+    ]
+
+    # First pass: collect all slugs and frontmatter
+    for page in md_files:
+        slug = _slug(page.stem)
+        try:
+            text = page.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        front_m = _FRONT_RE.match(text)
+        front = front_m.group(1) if front_m else ""
+
+        title = ""
+        m = _TITLE_RE.search(front)
+        if m:
+            title = m.group(1).strip().strip(">-").strip()
+
+        tags: list[str] = []
+        m = _TAGS_RE.search(front)
+        if m:
+            tags = [t.strip().strip("'\"") for t in m.group(1).split(",")]
+        else:
+            m2 = _TAGS_LIST_RE.search(front)
+            if m2:
+                tags = [ln.strip().lstrip("- ") for ln in m2.group(1).splitlines() if ln.strip()]
+
+        summary = ""
+        m = _SUMMARY_RE.search(front)
+        if m:
+            summary = m.group(1).strip()
+
+        category = str(page.relative_to(vault).parent)
+        m = _CATEGORY_RE.search(front)
+        if m:
+            category = m.group(1).strip()
+
+        tier = "supporting"
+        m = _TIER_RE.search(front)
+        if m:
+            tier = m.group(1).strip()
+
+        pages[slug] = {
+            "title": title or page.stem,
+            "tags": tags,
+            "summary": summary,
+            "category": category,
+            "tier": tier,
+            "path": str(page.relative_to(vault)),
+            "out_links": [],
+            "in_links": [],
+        }
+
+    # Second pass: extract wikilinks
+    known = set(pages.keys())
+    for page in md_files:
+        slug = _slug(page.stem)
+        if slug not in pages:
+            continue
+        try:
+            text = page.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+
+        for link in _WIKILINK_RE.findall(text):
+            target = _slug(link.split("/")[-1])
+            if target and target != slug and target in known:
+                pages[slug]["out_links"].append(target)
+                pages[target]["in_links"].append(slug)
+
+        for href in _MD_LINK_RE.findall(text):
+            target = _slug(Path(href).stem)
+            if target and target != slug and target in known:
+                pages[slug]["out_links"].append(target)
+                pages[target]["in_links"].append(slug)
+
+    return pages
+
+
+# ---------------------------------------------------------------------------
+# Scoring / ranking
+# ---------------------------------------------------------------------------
+
+_TIER_WEIGHT = {"core": 1.3, "supporting": 1.0, "peripheral": 0.7}
+
+
+def _score(slug: str, entry: dict, terms: list[str]) -> float:
+    score = 0.0
+    title_lower = entry["title"].lower()
+    summary_lower = entry["summary"].lower()
+    tags_lower = [t.lower() for t in entry["tags"]]
+    for term in terms:
+        t = term.lower()
+        if t == slug or t == title_lower:
+            score += 10.0
+        elif t in title_lower:
+            score += 6.0
+        elif any(t in tag for tag in tags_lower):
+            score += 4.0
+        elif t in summary_lower:
+            score += 2.0
+
+    if score > 0:
+        # Degree bonus only when at least one term matched — prevents degree
+        # noise from surfacing irrelevant pages
+        degree = len(entry["in_links"]) + len(entry["out_links"])
+        score += min(degree * 0.1, 2.0)
+        score *= _TIER_WEIGHT.get(entry.get("tier", "supporting"), 1.0)
+    return score
+
+
+def rank_candidates(
+    index: dict[str, dict],
+    terms: list[str],
+    top_n: int = 8,
+) -> list[dict]:
+    scored = [
+        {
+            "slug": slug,
+            "page": entry["path"],
+            "title": entry["title"],
+            "score": _score(slug, entry, terms),
+            "summary": entry["summary"],
+            "tier": entry["tier"],
+            "in_degree": len(entry["in_links"]),
+        }
+        for slug, entry in index.items()
+    ]
+    scored.sort(key=lambda x: (-x["score"], -x["in_degree"]))
+    return [c for c in scored[:top_n] if c["score"] > 0]
+
+
+# ---------------------------------------------------------------------------
+# Multi-hop path finding (BFS)
+# ---------------------------------------------------------------------------
+
+def find_path(
+    index: dict[str, dict],
+    source_slug: str,
+    target_slug: str,
+    max_depth: int = 4,
+) -> list[str] | None:
+    """BFS shortest path from source to target through wikilinks."""
+    if source_slug not in index or target_slug not in index:
+        return None
+    if source_slug == target_slug:
+        return [source_slug]
+
+    queue: deque[tuple[str, list[str]]] = deque([(source_slug, [source_slug])])
+    visited = {source_slug}
+
+    while queue:
+        node, path = queue.popleft()
+        if len(path) > max_depth:
+            continue
+        for neighbour in index[node]["out_links"] + index[node]["in_links"]:
+            if neighbour in visited:
+                continue
+            visited.add(neighbour)
+            new_path = path + [neighbour]
+            if neighbour == target_slug:
+                return new_path
+            queue.append((neighbour, new_path))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Query classification
+# ---------------------------------------------------------------------------
+
+_PATH_PATTERNS = re.compile(
+    r"how (?:is|are|does) (.+?) (?:connected|related|linked) to (.+?)[\?]?$"
+    r"|trace (?:the )?(?:chain|path) from (.+?) to (.+?)[\?]?$"
+    r"|what connects (.+?) (?:to|and) (.+?)[\?]?$",
+    re.IGNORECASE,
+)
+
+_GAP_PATTERNS = re.compile(
+    r"what (?:do|don'?t) I (?:not )?know about|what.?s missing|what gaps|open questions",
+    re.IGNORECASE,
+)
+
+_LIST_PATTERNS = re.compile(
+    r"(?:list|show|find|give me) (?:all|every|pages about)",
+    re.IGNORECASE,
+)
+
+
+def classify_query(question: str) -> tuple[str, list[str]]:
+    """Return (answer_type, extracted_terms).
+
+    answer_type: "path" | "gap" | "list" | "direct"
+    """
+    m = _PATH_PATTERNS.search(question)
+    if m:
+        groups = [g for g in m.groups() if g]
+        terms = groups[:2] if len(groups) >= 2 else [question]
+        return "path", terms
+
+    if _GAP_PATTERNS.search(question):
+        # Extract what the gap is about
+        terms = re.sub(r"what (?:do|don't) I (?:not )?know about|what.?s missing", "", question, flags=re.IGNORECASE).strip().split()
+        return "gap", terms
+
+    if _LIST_PATTERNS.search(question):
+        terms = re.sub(r"(?:list|show|find|give me) (?:all|every|pages about)", "", question, flags=re.IGNORECASE).strip().split()
+        return "list", terms
+
+    # Default: extract meaningful terms (drop stop words)
+    stop = {"what", "the", "a", "an", "is", "are", "how", "does", "do", "in", "of", "to", "for", "and", "or"}
+    terms = [w.strip("?,.'\"") for w in question.split() if w.lower().strip("?,.'\"") not in stop and len(w) > 2]
+    return "direct", terms
+
+
+# ---------------------------------------------------------------------------
+# Main query entry point
+# ---------------------------------------------------------------------------
+
+def query(
+    vault: Path,
+    question: str,
+    *,
+    top_n: int = 8,
+    max_should_read: int = 3,
+) -> dict[str, Any]:
+    index = build_index(vault)
+    if not index:
+        return {
+            "answer_type": "direct",
+            "candidates": [],
+            "path": [],
+            "god_nodes_relevant": [],
+            "should_read": [],
+            "index_only": True,
+            "note": "Vault appears empty.",
+        }
+
+    answer_type, terms = classify_query(question)
+
+    # God nodes relevant to the query
+    degree = {s: len(e["in_links"]) + len(e["out_links"]) for s, e in index.items()}
+    god_slugs = sorted(degree, key=lambda s: -degree[s])[:10]
+    term_set = {t.lower() for t in terms}
+    god_relevant = [
+        index[s]["path"] for s in god_slugs
+        if any(t in index[s]["title"].lower() or t in " ".join(index[s]["tags"]).lower() for t in term_set)
+    ][:5]
+
+    path_result: list[str] = []
+    if answer_type == "path" and len(terms) >= 2:
+        src_slug = _slug(terms[0])
+        tgt_slug = _slug(terms[1])
+        # Try to find slugs by scoring if exact match fails
+        if src_slug not in index:
+            cands = rank_candidates(index, [terms[0]], top_n=1)
+            src_slug = cands[0]["slug"] if cands else src_slug
+        if tgt_slug not in index:
+            cands = rank_candidates(index, [terms[1]], top_n=1)
+            tgt_slug = cands[0]["slug"] if cands else tgt_slug
+        raw_path = find_path(index, src_slug, tgt_slug)
+        if raw_path:
+            path_result = [index[s]["path"] for s in raw_path if s in index]
+
+    candidates = rank_candidates(index, terms, top_n=top_n)
+
+    # Decide whether page reads are needed
+    top_candidate = candidates[0] if candidates else None
+    index_only = False
+    if top_candidate and top_candidate["score"] >= 10.0 and top_candidate["summary"]:
+        index_only = True  # Exact title match with a summary — likely answerable from index
+
+    should_read = [c["page"] for c in candidates[:max_should_read] if not index_only]
+    if path_result and not index_only:
+        # Add path pages to should_read, deduplicated
+        for p in path_result:
+            if p not in should_read:
+                should_read.append(p)
+        should_read = should_read[:max_should_read + 2]
+
+    return {
+        "answer_type": answer_type,
+        "candidates": [
+            {
+                "page": c["page"],
+                "title": c["title"],
+                "score": round(c["score"], 2),
+                "summary": c["summary"],
+                "tier": c["tier"],
+            }
+            for c in candidates
+        ],
+        "path": path_result,
+        "god_nodes_relevant": god_relevant,
+        "should_read": should_read,
+        "index_only": index_only,
+        "stats": {
+            "indexed_pages": len(index),
+            "query_terms": terms,
+        },
+    }

--- a/tests/test_graphrag.py
+++ b/tests/test_graphrag.py
@@ -1,0 +1,276 @@
+"""Tests for the GraphRAG query index module."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from obsidian_wiki.graphrag import (
+    build_index,
+    classify_query,
+    find_path,
+    query,
+    rank_candidates,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def vault(tmp_path):
+    v = tmp_path / "vault"
+    v.mkdir()
+    return v
+
+
+def _page(vault: Path, name: str, *, title: str = "", summary: str = "",
+          tags: list[str] | None = None, links: list[str] | None = None,
+          tier: str = "supporting", category: str = "concepts") -> Path:
+    lines = ["---", f"title: {title or name}"]
+    if summary:
+        lines.append(f"summary: {summary}")
+    if tags:
+        lines.append(f"tags: [{', '.join(tags)}]")
+    lines.append(f"tier: {tier}")
+    lines.append(f"category: {category}")
+    lines.append("---")
+    lines.append(f"# {title or name}")
+    for lnk in (links or []):
+        lines.append(f"[[{lnk}]]")
+    p = vault / f"{name}.md"
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+@pytest.fixture
+def simple_vault(vault):
+    _page(vault, "transformer", title="Transformer Architecture",
+          summary="Self-attention mechanism for sequence modelling.",
+          tags=["deep-learning", "nlp"], tier="core", links=["attention", "embedding"])
+    _page(vault, "attention", title="Attention Mechanism",
+          summary="Computes weighted sums over value vectors.",
+          tags=["deep-learning"], links=["transformer"])
+    _page(vault, "embedding", title="Word Embedding",
+          summary="Dense vector representation of tokens.",
+          tags=["nlp"])
+    _page(vault, "python", title="Python",
+          summary="General-purpose programming language.",
+          tags=["programming"])
+    return vault
+
+
+# ---------------------------------------------------------------------------
+# build_index
+# ---------------------------------------------------------------------------
+
+class TestBuildIndex:
+    def test_returns_slugs(self, simple_vault):
+        idx = build_index(simple_vault)
+        assert "transformer" in idx
+        assert "attention" in idx
+
+    def test_reads_title(self, simple_vault):
+        idx = build_index(simple_vault)
+        assert idx["transformer"]["title"] == "Transformer Architecture"
+
+    def test_reads_summary(self, simple_vault):
+        idx = build_index(simple_vault)
+        assert "Self-attention" in idx["transformer"]["summary"]
+
+    def test_reads_tags(self, simple_vault):
+        idx = build_index(simple_vault)
+        assert "deep-learning" in idx["transformer"]["tags"]
+
+    def test_reads_tier(self, simple_vault):
+        idx = build_index(simple_vault)
+        assert idx["transformer"]["tier"] == "core"
+
+    def test_out_links(self, simple_vault):
+        idx = build_index(simple_vault)
+        assert "attention" in idx["transformer"]["out_links"]
+
+    def test_in_links_reverse(self, simple_vault):
+        idx = build_index(simple_vault)
+        assert "transformer" in idx["attention"]["in_links"]
+
+    def test_empty_vault(self, vault):
+        idx = build_index(vault)
+        assert idx == {}
+
+    def test_skips_raw_dir(self, vault):
+        (vault / "_raw").mkdir()
+        _page(vault / "_raw", "draft", title="Draft")
+        idx = build_index(vault)
+        assert "draft" not in idx
+
+
+# ---------------------------------------------------------------------------
+# rank_candidates
+# ---------------------------------------------------------------------------
+
+class TestRankCandidates:
+    def test_exact_title_match_scores_highest(self, simple_vault):
+        idx = build_index(simple_vault)
+        result = rank_candidates(idx, ["transformer"])
+        assert result[0]["slug"] == "transformer"
+
+    def test_tag_match_included(self, simple_vault):
+        idx = build_index(simple_vault)
+        result = rank_candidates(idx, ["nlp"])
+        slugs = [r["slug"] for r in result]
+        assert "transformer" in slugs or "embedding" in slugs
+
+    def test_no_match_returns_empty(self, simple_vault):
+        idx = build_index(simple_vault)
+        result = rank_candidates(idx, ["zzznomatch"])
+        assert result == []
+
+    def test_core_tier_boosted(self, simple_vault):
+        idx = build_index(simple_vault)
+        result = rank_candidates(idx, ["deep-learning"])
+        # transformer is tier:core; attention is tier:supporting — transformer should score higher
+        transformer_score = next((r["score"] for r in result if r["slug"] == "transformer"), 0)
+        attention_score = next((r["score"] for r in result if r["slug"] == "attention"), 0)
+        assert transformer_score > attention_score
+
+    def test_respects_top_n(self, simple_vault):
+        idx = build_index(simple_vault)
+        result = rank_candidates(idx, ["deep-learning"], top_n=1)
+        assert len(result) <= 1
+
+
+# ---------------------------------------------------------------------------
+# find_path
+# ---------------------------------------------------------------------------
+
+class TestFindPath:
+    def test_direct_link(self, simple_vault):
+        idx = build_index(simple_vault)
+        path = find_path(idx, "transformer", "attention")
+        assert path is not None
+        assert "transformer" in path
+        assert "attention" in path
+
+    def test_same_node(self, simple_vault):
+        idx = build_index(simple_vault)
+        path = find_path(idx, "transformer", "transformer")
+        assert path == ["transformer"]
+
+    def test_unknown_node_returns_none(self, simple_vault):
+        idx = build_index(simple_vault)
+        path = find_path(idx, "transformer", "zzznone")
+        assert path is None
+
+    def test_multi_hop(self, vault):
+        _page(vault, "a", links=["b"])
+        _page(vault, "b", links=["c"])
+        _page(vault, "c", links=[])
+        idx = build_index(vault)
+        path = find_path(idx, "a", "c")
+        assert path is not None
+        assert len(path) == 3
+
+    def test_no_path_returns_none(self, vault):
+        _page(vault, "x", links=[])
+        _page(vault, "y", links=[])
+        idx = build_index(vault)
+        path = find_path(idx, "x", "y")
+        assert path is None
+
+
+# ---------------------------------------------------------------------------
+# classify_query
+# ---------------------------------------------------------------------------
+
+class TestClassifyQuery:
+    def test_direct_query(self):
+        qt, terms = classify_query("What is a transformer?")
+        assert qt == "direct"
+        assert any("transformer" in t.lower() for t in terms)
+
+    def test_path_query(self):
+        qt, terms = classify_query("How is transformer connected to embedding?")
+        assert qt == "path"
+        assert len(terms) == 2
+
+    def test_gap_query(self):
+        qt, _ = classify_query("What do I not know about reinforcement learning?")
+        assert qt == "gap"
+
+    def test_list_query(self):
+        qt, _ = classify_query("List all pages about deep learning")
+        assert qt == "list"
+
+    def test_stop_words_filtered(self):
+        _, terms = classify_query("What is the difference?")
+        assert "the" not in terms
+        assert "is" not in terms
+
+
+# ---------------------------------------------------------------------------
+# query (integration)
+# ---------------------------------------------------------------------------
+
+class TestQuery:
+    def test_returns_required_keys(self, simple_vault):
+        result = query(simple_vault, "What is a transformer?")
+        assert set(result.keys()) >= {"answer_type", "candidates", "path",
+                                       "god_nodes_relevant", "should_read", "index_only"}
+
+    def test_finds_exact_match(self, simple_vault):
+        result = query(simple_vault, "transformer architecture")
+        pages = [c["page"] for c in result["candidates"]]
+        assert any("transformer" in p for p in pages)
+
+    def test_path_query_populated(self, simple_vault):
+        result = query(simple_vault, "How is transformer connected to embedding?")
+        assert result["answer_type"] == "path"
+
+    def test_index_only_on_exact_with_summary(self, simple_vault):
+        result = query(simple_vault, "Transformer Architecture")
+        # Title exact match + summary → index_only should be True
+        assert result["index_only"] is True
+
+    def test_should_read_empty_when_index_only(self, simple_vault):
+        result = query(simple_vault, "Transformer Architecture")
+        if result["index_only"]:
+            assert result["should_read"] == []
+
+    def test_empty_vault(self, vault):
+        result = query(vault, "anything")
+        assert result["candidates"] == []
+        assert result["index_only"] is True
+
+    def test_json_serialisable(self, simple_vault):
+        result = query(simple_vault, "deep learning")
+        json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+class TestGraphQueryCLI:
+    def _run(self, *args):
+        return subprocess.run(
+            [sys.executable, "-m", "obsidian_wiki.cli", *args],
+            capture_output=True, text=True,
+        )
+
+    def test_outputs_json(self, simple_vault):
+        proc = self._run("graph-query", str(simple_vault), "transformer")
+        assert proc.returncode == 0
+        data = json.loads(proc.stdout)
+        assert "candidates" in data
+
+    def test_pretty_flag(self, simple_vault):
+        proc = self._run("graph-query", str(simple_vault), "transformer", "--pretty")
+        assert proc.returncode == 0
+        assert "\n  " in proc.stdout
+
+    def test_missing_vault_exits_nonzero(self, tmp_path):
+        proc = self._run("graph-query", str(tmp_path / "nope"), "anything")
+        assert proc.returncode != 0


### PR DESCRIPTION
## Summary

- `obsidian-wiki graph-query <vault> "<question>"` — queries a compiled index of vault frontmatter + wikilinks before opening any page bodies
- **Ranking**: title/tag/summary match + degree bonus + tier weight (`core` > `supporting` > `peripheral`)  
- **`should_read`**: 1–3 pages that are actually worth opening, instead of speculative 5–10 page reads
- **`index_only: true`**: when the top candidate has an exact title match + non-empty summary, the answer is in the index — zero page reads needed
- **Multi-hop path**: for "how is X connected to Y?" queries, BFS finds the shortest wikilink path
- **Query classification**: routes `direct`, `path`, `gap`, and `list` queries differently
- `wiki-query` SKILL.md updated with Step 0: run `graph-query` first, use `should_read` shortlist, skip page reads when `index_only: true`

## Test plan

- [ ] `python3 -m pytest tests/ -q` → 144 tests pass
- [ ] `obsidian-wiki graph-query <vault> "what do I know about X" --pretty` returns ranked candidates and should_read
- [ ] `obsidian-wiki graph-query <vault> "how is X connected to Y" --pretty` returns a path
- [ ] Exact title match with summary → `index_only: true`, `should_read: []`
- [ ] Test on st3ve