### PR TITLE
fix: two silent delta-detection bugs in ingest helpers (manifest.py, extract-jsonl.py)

### DIFF
--- a/scripts/extract-jsonl.py
+++ b/scripts/extract-jsonl.py
@@ -116,12 +116,14 @@ def needs_extraction(
     depend on the caller passing the right --since.  --since only narrows the
     scan range; it never suppresses extraction of a file with a fresh output.
     """
-    mtime = os.path.getmtime(source_path)
-    # --since narrows the scan range: skip files not modified since the cutoff.
-    if since_ts is not None and mtime < since_ts:
-        return False
+    # A missing output is always (re)extracted, regardless of --since.
     if not os.path.exists(out_path):
         return True
+    mtime = os.path.getmtime(source_path)
+    # --since narrows the scan range: among files that already have an output,
+    # skip those not modified since the cutoff.
+    if since_ts is not None and mtime < since_ts:
+        return False
     # Re-extract if the source changed after the output was last written.
     return mtime > os.path.getmtime(out_path)
 

--- a/scripts/extract-jsonl.py
+++ b/scripts/extract-jsonl.py
@@ -11,7 +11,6 @@ Output layout
   <output_dir>/                           default: ~/.claude/extracted/
     <project-dir-name>/
       <session-uuid>.json                 one per conversation
-    .extract-manifest.json                tracks which source files have been extracted
 
 Extracted file format
 ---------------------
@@ -65,7 +64,6 @@ from pathlib import Path
 # Constants
 # ---------------------------------------------------------------------------
 
-EXTRACT_MANIFEST_NAME = ".extract-manifest.json"
 # Truncate very long individual text blocks (assistant text that includes
 # e.g. a pasted file read) to keep extracted files reasonable.
 MAX_BLOCK_CHARS = 8_000
@@ -103,45 +101,29 @@ def is_skipped(path: str, patterns: list[str]) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Extract-manifest helpers
+# Staleness check
 # ---------------------------------------------------------------------------
-
-def load_extract_manifest(output_dir: str) -> dict:
-    mp = os.path.join(output_dir, EXTRACT_MANIFEST_NAME)
-    if not os.path.exists(mp):
-        return {}
-    with open(mp) as f:
-        return json.load(f)
-
-
-def save_extract_manifest(output_dir: str, manifest: dict) -> None:
-    mp = os.path.join(output_dir, EXTRACT_MANIFEST_NAME)
-    with open(mp, "w") as f:
-        json.dump(manifest, f, indent=2)
-        f.write("\n")
-
 
 def needs_extraction(
     source_path: str,
-    manifest: dict,
+    out_path: str,
     since_ts: float | None,
 ) -> bool:
-    """Return True if the source JSONL should be (re)extracted."""
+    """Return True if the source JSONL should be (re)extracted.
+
+    Idempotent staleness check keyed on the output file: (re)extract when the
+    output is missing or the source is newer than it, so the extractor does not
+    depend on the caller passing the right --since.  --since only narrows the
+    scan range; it never suppresses extraction of a file with a fresh output.
+    """
     mtime = os.path.getmtime(source_path)
-    # --since filter: skip files not modified since the cutoff
+    # --since narrows the scan range: skip files not modified since the cutoff.
     if since_ts is not None and mtime < since_ts:
         return False
-    entry = manifest.get(source_path)
-    if entry is None:
+    if not os.path.exists(out_path):
         return True
-    # Re-extract if the source changed after last extraction
-    try:
-        extracted_ts = datetime.fromisoformat(
-            entry["extracted_at"].replace("Z", "+00:00")
-        ).timestamp()
-    except (KeyError, ValueError):
-        return True
-    return mtime > extracted_ts
+    # Re-extract if the source changed after the output was last written.
+    return mtime > os.path.getmtime(out_path)
 
 
 # ---------------------------------------------------------------------------
@@ -277,10 +259,8 @@ def run(args: argparse.Namespace) -> int:
         print(f"No JSONL files found under {pattern}")
         return 0
 
-    # Load the extraction manifest (tracks what's already been extracted)
     if not args.dry_run:
         os.makedirs(output_dir, exist_ok=True)
-    ext_manifest = load_extract_manifest(output_dir) if not args.dry_run else {}
 
     stats = {"scanned": 0, "skipped_pattern": 0, "skipped_since": 0,
              "skipped_unchanged": 0, "extracted": 0, "empty": 0, "error": 0}
@@ -294,7 +274,13 @@ def run(args: argparse.Namespace) -> int:
                 print(f"  SKIP(pattern)  {source_path}")
             continue
 
-        if not needs_extraction(source_path, ext_manifest, since_ts):
+        # Derive the output path from the source path (project dir + file stem)
+        # so the staleness check can compare against the actual output file.
+        project = os.path.basename(os.path.dirname(source_path))
+        session_id = os.path.splitext(os.path.basename(source_path))[0]
+        out_path = os.path.join(output_dir, project, session_id + ".json")
+
+        if not needs_extraction(source_path, out_path, since_ts):
             stats["skipped_unchanged"] += 1
             if args.verbose:
                 print(f"  SKIP(unchanged) {source_path}")
@@ -309,9 +295,6 @@ def run(args: argparse.Namespace) -> int:
             stats["empty"] += 1
             if args.verbose:
                 print(f"    -> empty (no usable turns)")
-            if not args.dry_run:
-                # Still mark as extracted so we don't retry unless the file changes
-                _mark_extracted(ext_manifest, source_path)
             continue
 
         project_dir = os.path.join(output_dir, result["project"])
@@ -322,14 +305,10 @@ def run(args: argparse.Namespace) -> int:
             with open(out_path, "w", encoding="utf-8") as f:
                 json.dump(result, f, ensure_ascii=False, indent=2)
                 f.write("\n")
-            _mark_extracted(ext_manifest, source_path)
 
         stats["extracted"] += 1
         if not args.verbose and stats["extracted"] % 25 == 0:
             print(f"  ... {stats['extracted']} extracted so far")
-
-    if not args.dry_run:
-        save_extract_manifest(output_dir, ext_manifest)
 
     # Summary
     print(
@@ -343,16 +322,6 @@ def run(args: argparse.Namespace) -> int:
         f"  Output dir:       {output_dir if not args.dry_run else '(dry-run, nothing written)'}"
     )
     return 0
-
-
-def _mark_extracted(manifest: dict, source_path: str) -> None:
-    manifest[source_path] = {
-        "extracted_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "size_bytes": os.path.getsize(source_path),
-        "modified_at": datetime.fromtimestamp(
-            os.path.getmtime(source_path), tz=timezone.utc
-        ).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    }
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -66,6 +66,12 @@ def cmd_normalize(args: argparse.Namespace) -> int:
     collisions = 0
     rekeyed = 0
     for key, entry in sources.items():
+        if not os.path.isabs(key):
+            # Real vaults store some keys relative to the ingest root (e.g.
+            # "-Users-x-github/abc.jsonl" under ~/.claude/projects/). canonical()
+            # resolves those against the CWD, so normalize would rewrite them to
+            # a bogus absolute path. Warn rather than silently corrupt them.
+            print(f"  WARN   relative key resolved against CWD: {key}")
         ckey = canonical(key)
         if ckey != key:
             rekeyed += 1
@@ -103,9 +109,35 @@ def _skip_patterns(cli_skip: str | None) -> list[str]:
     return pats
 
 
+def _relative_key_index(sources: dict) -> dict[str, list[tuple[str, dict]]]:
+    """Index relative source keys by basename for suffix matching.
+
+    Real vaults store many keys relative to the ingest root (e.g.
+    "-Users-x-github/abc.jsonl" under ~/.claude/projects/). canonical()
+    resolves those against the CWD, so they never equal a scanned absolute
+    path. Keying by basename lets cmd_delta fall back to an O(1) suffix check
+    instead of scanning every key per file.
+    """
+    index: dict[str, list[tuple[str, dict]]] = {}
+    for k, v in sources.items():
+        if not os.path.isabs(k):
+            index.setdefault(os.path.basename(k), []).append((k, v))
+    return index
+
+
+def _match_relative(path: str, index: dict[str, list[tuple[str, dict]]]) -> dict | None:
+    """Return the manifest entry whose relative key is a suffix of `path`."""
+    for relkey, entry in index.get(os.path.basename(path), ()):
+        if path == relkey or path.endswith(os.sep + relkey):
+            return entry
+    return None
+
+
 def cmd_delta(args: argparse.Namespace) -> int:
     m = load_manifest(args.vault)
-    known = {canonical(k): v for k, v in m.get("sources", {}).items()}
+    sources = m.get("sources", {})
+    known = {canonical(k): v for k, v in sources.items()}
+    rel_index = _relative_key_index(sources)
     skips = _skip_patterns(args.skip)
 
     matched = sorted(globmod.glob(os.path.expanduser(args.scan), recursive=True))
@@ -118,6 +150,8 @@ def cmd_delta(args: argparse.Namespace) -> int:
             continue
         ckey = canonical(path)
         entry = known.get(ckey)
+        if entry is None:
+            entry = _match_relative(path, rel_index)
         if entry is None:
             new.append(ckey)
         else:

--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -69,12 +69,15 @@ def cmd_normalize(args: argparse.Namespace) -> int:
         if not os.path.isabs(key):
             # Real vaults store some keys relative to the ingest root (e.g.
             # "-Users-x-github/abc.jsonl" under ~/.claude/projects/). canonical()
-            # resolves those against the CWD, so normalize would rewrite them to
-            # a bogus absolute path. Warn rather than silently corrupt them.
-            print(f"  WARN   relative key resolved against CWD: {key}")
-        ckey = canonical(key)
-        if ckey != key:
-            rekeyed += 1
+            # would resolve those against the CWD and rewrite them to a bogus
+            # absolute path. normalize only dedups/canonicalizes absolute keys, so
+            # preserve relative keys untouched (safe no-op) and warn.
+            print(f"  WARN   preserving relative key as-is (not canonicalized): {key}")
+            ckey = key
+        else:
+            ckey = canonical(key)
+            if ckey != key:
+                rekeyed += 1
         if ckey in new_sources:
             new_sources[ckey] = _newest(new_sources[ckey], entry)
             collisions += 1

--- a/tests/test_extract_staleness.py
+++ b/tests/test_extract_staleness.py
@@ -86,6 +86,14 @@ class ExtractStalenessTest(unittest.TestCase):
         self.assertIn("EXTRACT", out)
         self.assertNotIn("SKIP(unchanged)", out)
 
+    def test_missing_output_reextracted_despite_since_gate(self) -> None:
+        # Missing output must (re)extract even when --since would exclude the
+        # (older) source; --since only narrows files that already have output.
+        os.utime(self.source, (1000, 1000))  # source well in the past
+        out = self._run("--since", "2099-01-01", "--verbose")
+        self.assertIn("EXTRACT", out)
+        self.assertTrue(self.out_file.exists())
+
     def test_output_newer_is_skipped(self) -> None:
         self._run()
         # Output at least as new as source -> skip.

--- a/tests/test_extract_staleness.py
+++ b/tests/test_extract_staleness.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+# extract-jsonl.py has a hyphen, so import it by file path.
+_SPEC = importlib.util.spec_from_file_location(
+    "extract_jsonl",
+    Path(__file__).resolve().parent.parent / "scripts" / "extract-jsonl.py",
+)
+extract_jsonl = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(extract_jsonl)  # type: ignore[union-attr]
+
+
+class ExtractStalenessTest(unittest.TestCase):
+    """The extractor must be idempotent based on output-file staleness.
+
+    Regression guard: after the first run, a session whose output is missing or
+    whose source is newer than its output must be (re)extracted, without the
+    caller having to pass the right --since. A previous version keyed staleness
+    off a wallclock manifest, so a session that landed after the first run (or
+    whose output was deleted) was silently treated as already-done and never
+    re-extracted (real case: session 2d83ed0d reported missing downstream).
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.history = root / ".claude"
+        self.output = root / "out"
+        self.project = "-Users-x-app"
+        self.source = self.history / "projects" / self.project / "sess1.jsonl"
+        self.source.parent.mkdir(parents=True)
+        self.source.write_text(
+            '{"type":"user","timestamp":"2026-06-01T10:00:00Z","cwd":"/Users/x/app",'
+            '"sessionId":"sess1","message":{"role":"user","content":"hello"}}\n'
+            '{"type":"assistant","timestamp":"2026-06-01T10:00:05Z","sessionId":"sess1",'
+            '"message":{"role":"assistant","content":[{"type":"text","text":"hi there"}]}}\n'
+        )
+        self.out_file = self.output / self.project / "sess1.json"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _run(self, *extra: str) -> str:
+        buf = io.StringIO()
+        argv = [
+            "--history-path", str(self.history),
+            "--output-dir", str(self.output),
+            *extra,
+        ]
+        with contextlib.redirect_stdout(buf):
+            rc = extract_jsonl.main(argv)
+        self.assertEqual(rc, 0)
+        return buf.getvalue()
+
+    def _set_mtimes(self, source_mtime: float, output_mtime: float) -> None:
+        os.utime(self.source, (source_mtime, source_mtime))
+        os.utime(self.out_file, (output_mtime, output_mtime))
+
+    def test_first_run_extracts(self) -> None:
+        self._run()
+        self.assertTrue(self.out_file.exists())
+        data = json.loads(self.out_file.read_text())
+        self.assertEqual(data["session_id"], "sess1")
+
+    def test_missing_output_is_reextracted(self) -> None:
+        # The reported bug: output gone but source unchanged -> must re-extract.
+        self._run()
+        self.out_file.unlink()
+        self._run()
+        self.assertTrue(self.out_file.exists())
+
+    def test_source_newer_is_reextracted(self) -> None:
+        self._run()
+        # Source strictly newer than its output -> re-extract.
+        self._set_mtimes(source_mtime=2000, output_mtime=1000)
+        out = self._run("--verbose")
+        self.assertIn("EXTRACT", out)
+        self.assertNotIn("SKIP(unchanged)", out)
+
+    def test_output_newer_is_skipped(self) -> None:
+        self._run()
+        # Output at least as new as source -> skip.
+        self._set_mtimes(source_mtime=1000, output_mtime=2000)
+        out = self._run("--verbose")
+        self.assertIn("SKIP(unchanged)", out)
+        self.assertNotIn("EXTRACT ", out)
+
+
+if __name__ == "__main__":
+    sys.exit(unittest.main())

--- a/tests/test_manifest_delta.py
+++ b/tests/test_manifest_delta.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import manifest  # noqa: E402
+
+
+class ManifestDeltaRelativeKeyTest(unittest.TestCase):
+    """cmd_delta must recognize sources stored under relative keys.
+
+    Real vaults key many sources relative to the ingest root (e.g.
+    "-Users-x-github/abc.jsonl" under ~/.claude/projects/). canonical()
+    resolves those against the CWD, so before the fix every already-ingested
+    file with a relative key was misreported as NEW.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        root = Path(self.tmp.name)
+        self.vault = root / "vault"
+        self.vault.mkdir()
+        # A scanned source living under an ingest root, tracked relatively.
+        self.projects = root / "projects"
+        self.source = self.projects / "-Users-yician-github" / "abc123.jsonl"
+        self.source.parent.mkdir(parents=True)
+        self.source.write_text("{}\n")
+        self.scan = str(self.projects / "**" / "*.jsonl")
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write_manifest(self, sources: dict) -> None:
+        m = {"version": 1, "sources": sources, "projects": {}, "stats": {}}
+        (self.vault / ".manifest.json").write_text(json.dumps(m, indent=2))
+
+    def _delta(self) -> str:
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc = manifest.main(["delta", str(self.vault), "--scan", self.scan])
+        self.assertEqual(rc, 0)
+        return buf.getvalue()
+
+    def test_relative_key_older_ingest_is_modified_not_new(self) -> None:
+        # File mtime = now, ingested long ago -> modified via suffix match.
+        self._write_manifest(
+            {"-Users-yician-github/abc123.jsonl": {"ingested_at": "2020-01-01T00:00:00Z"}}
+        )
+        out = self._delta()
+        self.assertIn("# 0 new, 1 modified, 1 known", out)
+        self.assertNotIn("NEW\t", out)
+        self.assertIn("MOD\t", out)
+
+    def test_relative_key_recent_ingest_is_unchanged(self) -> None:
+        # File mtime older than the ingest timestamp -> neither new nor modified.
+        old = 946684800  # 2000-01-01
+        os.utime(self.source, (old, old))
+        self._write_manifest(
+            {"-Users-yician-github/abc123.jsonl": {"ingested_at": "2020-01-01T00:00:00Z"}}
+        )
+        out = self._delta()
+        self.assertIn("# 0 new, 0 modified, 1 known", out)
+        self.assertNotIn("NEW\t", out)
+        self.assertNotIn("MOD\t", out)
+
+    def test_absolute_key_still_matches(self) -> None:
+        # Absolute keys must keep working exactly as before.
+        old = 946684800
+        os.utime(self.source, (old, old))
+        self._write_manifest(
+            {str(self.source): {"ingested_at": "2020-01-01T00:00:00Z"}}
+        )
+        out = self._delta()
+        self.assertIn("# 0 new, 0 modified, 1 known", out)
+        self.assertNotIn("NEW\t", out)
+
+    def test_unknown_file_is_new(self) -> None:
+        # A scanned file matched by neither an absolute nor a relative key.
+        self._write_manifest(
+            {"-Users-yician-github/other.jsonl": {"ingested_at": "2020-01-01T00:00:00Z"}}
+        )
+        out = self._delta()
+        self.assertIn("# 1 new, 0 modified, 1 known", out)
+        self.assertIn("NEW\t", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_manifest_delta.py
+++ b/tests/test_manifest_delta.py
@@ -92,5 +92,61 @@ class ManifestDeltaRelativeKeyTest(unittest.TestCase):
         self.assertIn("NEW\t", out)
 
 
+class ManifestNormalizeRelativeKeyTest(unittest.TestCase):
+    """cmd_normalize must not corrupt relative source keys.
+
+    canonical() resolves a relative key against the CWD, so canonicalizing one
+    would rewrite it to a bogus absolute path and persist the damage. normalize
+    only dedups/canonicalizes absolute keys; relative keys must survive as-is.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.vault = Path(self.tmp.name) / "vault"
+        self.vault.mkdir()
+        self.manifest = self.vault / ".manifest.json"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _write_manifest(self, sources: dict) -> None:
+        m = {"version": 1, "sources": sources, "projects": {}, "stats": {}}
+        self.manifest.write_text(json.dumps(m, indent=2))
+
+    def _keys_after_normalize(self, cwd: str) -> list:
+        prev = os.getcwd()
+        os.chdir(cwd)
+        try:
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                rc = manifest.main(["normalize", str(self.vault)])
+            self.assertEqual(rc, 0)
+        finally:
+            os.chdir(prev)
+        return list(json.loads(self.manifest.read_text())["sources"].keys())
+
+    def test_relative_key_preserved_regardless_of_cwd(self) -> None:
+        relkey = "-Users-yician-github/abc.jsonl"
+        self._write_manifest({relkey: {"ingested_at": "2020-01-01T00:00:00Z"}})
+        # Run from an unrelated CWD; the relative key must not be abspath-rewritten.
+        keys = self._keys_after_normalize(self.tmp.name)
+        self.assertEqual(keys, [relkey])
+
+    def test_absolute_keys_still_dedup_and_canonicalize(self) -> None:
+        # Two spellings of the same absolute path must merge into one canonical key.
+        abs_dir = str(Path(self.tmp.name) / "sessions")
+        os.makedirs(abs_dir)
+        canon = os.path.join(abs_dir, "x.jsonl")
+        messy = os.path.join(abs_dir, "sub", "..", "x.jsonl")
+        self._write_manifest(
+            {
+                canon: {"ingested_at": "2020-01-01T00:00:00Z"},
+                messy: {"ingested_at": "2021-01-01T00:00:00Z"},
+            }
+        )
+        keys = self._keys_after_normalize(self.tmp.name)
+        self.assertEqual(keys, [canon])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two silent delta-detection bugs in the ingest helper scripts. Both break incremental "process only what's new" detection and both fail silently — no error, just a wrong result.

## Bug 1 — `manifest.py delta` treats relative manifest keys as absolute

`cmd_delta` builds `known = {canonical(k): v for k, v in sources}`, canonicalizing every manifest key through `os.path.abspath`. When a vault stores source keys **relative** to an ingest root (e.g. `-Users-name-project/<uuid>.jsonl` under `~/.claude/projects/`), `os.path.abspath` resolves them against the current working directory, producing a path that never matches the scanned file.

**Effect:** every already-ingested source is reported as NEW — incremental detection is fully defeated and a re-run re-ingests the entire history.

**Fix (`fix(manifest): match relative source keys in delta scan`):** basename-indexed suffix fallback — when a scanned absolute path has no exact canonical match, look it up by basename and confirm the relative key is a path suffix (O(1) avg). Absolute keys keep their exact prior behavior.

**Follow-up (`fix(manifest): stop normalize from corrupting relative source keys`):** `cmd_normalize` didn't just mis-compare relative keys — it rewrote them (`os.path.abspath` → CWD-based path) and wrote the corrupted key back to the manifest. Now relative keys are preserved untouched (normalize only dedups/canonicalizes absolute keys) and a warning is emitted.

## Bug 2 — `extract-jsonl.py` keys staleness on a manifest wallclock, not the output file

`needs_extraction` decides re-extraction from `.extract-manifest.json`'s `extracted_at` timestamp rather than the actual output file. A session whose output is missing — or that landed on disk after the first extract pass — is treated as already-done and never (re)extracted, so downstream ingest silently sees it as missing. `--since` additionally acted as a hard gate that hid never-extracted older sessions.

**Fix (`fix(extract): key incremental staleness on output file, not manifest wallclock`):** make the check idempotent on the output file — (re)extract when the output is missing or the source is newer than it; remove the `.extract-manifest.json` mechanism (nothing else read it). `--since` demoted to merely narrowing the scan range.

**Follow-up (`fix(extract): check missing output before the --since gate`):** the first fix still ran the `--since` gate before the missing-output check, so "old source + missing output + `--since`" was still skipped, contradicting the fix's own docstring. Reordered so a missing output always (re)extracts regardless of `--since`.

## Tests

Adds `tests/test_manifest_delta.py` and `tests/test_extract_staleness.py` (stdlib `unittest`, 11 tests) covering: relative-key → not-new, absolute-key unchanged behavior, normalize preserving relative keys, missing-output re-extraction (incl. the `--since` interaction), and source-newer re-extraction. All 11 pass on this branch.

> Note: the repo's other test modules (`test_ast_extractor`, `test_batch`, `test_cache`, `test_graph_analysis`, `test_graphrag`) require `pytest`, which was not installed in the environment used here, so a full `unittest discover` reports those as import errors — unrelated to this change. The two added modules use only the stdlib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
