### PR TITLE
fix: remove dangling skill mirror symlinks

### DIFF
--- a/.agents/skills/data-ingest
+++ b/.agents/skills/data-ingest
@@ -1,1 +1,0 @@
-../../.skills/data-ingest

--- a/.agents/skills/ingest-url
+++ b/.agents/skills/ingest-url
@@ -1,1 +1,0 @@
-../../.skills/ingest-url

--- a/.agents/skills/obsidian-wiki-ingest
+++ b/.agents/skills/obsidian-wiki-ingest
@@ -1,1 +1,0 @@
-../../.skills/obsidian-wiki-ingest

--- a/.claude/skills/data-ingest
+++ b/.claude/skills/data-ingest
@@ -1,1 +1,0 @@
-../../.skills/data-ingest

--- a/.claude/skills/ingest-url
+++ b/.claude/skills/ingest-url
@@ -1,1 +1,0 @@
-../../.skills/ingest-url

--- a/.claude/skills/obsidian-wiki-ingest
+++ b/.claude/skills/obsidian-wiki-ingest
@@ -1,1 +1,0 @@
-../../.skills/obsidian-wiki-ingest

--- a/.cursor/skills/data-ingest
+++ b/.cursor/skills/data-ingest
@@ -1,1 +1,0 @@
-../../.skills/data-ingest

--- a/.cursor/skills/ingest-url
+++ b/.cursor/skills/ingest-url
@@ -1,1 +1,0 @@
-../../.skills/ingest-url

--- a/.cursor/skills/obsidian-wiki-ingest
+++ b/.cursor/skills/obsidian-wiki-ingest
@@ -1,1 +1,0 @@
-../../.skills/obsidian-wiki-ingest

--- a/.kiro/skills/data-ingest
+++ b/.kiro/skills/data-ingest
@@ -1,1 +1,0 @@
-../../.skills/data-ingest

--- a/.kiro/skills/ingest-url
+++ b/.kiro/skills/ingest-url
@@ -1,1 +1,0 @@
-../../.skills/ingest-url

--- a/.kiro/skills/obsidian-wiki-ingest
+++ b/.kiro/skills/obsidian-wiki-ingest
@@ -1,1 +1,0 @@
-../../.skills/obsidian-wiki-ingest

--- a/.pi/skills/data-ingest
+++ b/.pi/skills/data-ingest
@@ -1,1 +1,0 @@
-../../.skills/data-ingest

--- a/.pi/skills/ingest-url
+++ b/.pi/skills/ingest-url
@@ -1,1 +1,0 @@
-../../.skills/ingest-url

--- a/.pi/skills/obsidian-wiki-ingest
+++ b/.pi/skills/obsidian-wiki-ingest
@@ -1,1 +1,0 @@
-../../.skills/obsidian-wiki-ingest

--- a/.windsurf/skills/data-ingest
+++ b/.windsurf/skills/data-ingest
@@ -1,1 +1,0 @@
-../../.skills/data-ingest

--- a/.windsurf/skills/ingest-url
+++ b/.windsurf/skills/ingest-url
@@ -1,1 +1,0 @@
-../../.skills/ingest-url

--- a/.windsurf/skills/obsidian-wiki-ingest
+++ b/.windsurf/skills/obsidian-wiki-ingest
@@ -1,1 +1,0 @@
-../../.skills/obsidian-wiki-ingest


### PR DESCRIPTION
## Problem

`data-ingest`, `ingest-url`, and `obsidian-wiki-ingest` were merged into `wiki-ingest`, but their agent mirror symlinks remained in the repository. On a fresh checkout, those 18 mirror entries point at missing `.skills/` directories and show up as dangling symlinks.

## Fix

- Remove the stale symlinks for those three retired skills from all six committed mirror directories: `.claude`, `.cursor`, `.windsurf`, `.kiro`, `.agents`, and `.pi`.
- Keep the change scoped to the broken mirror entries; setup/install behavior is unchanged.

Closes #125.

## Tests

- `find . -type l ! -exec test -e {} \; -print | grep -v '.git/' || true` -> no output
- `HOME=$(mktemp -d ...) HERMES_HOME= bash setup.sh < /dev/null` twice, then `git diff --exit-code`
- `UV_CACHE_DIR="$PWD/../.uv-cache" uv run --with pytest python -m pytest` -> 165 passed
- `git diff --check`