### PR TITLE
docs: add missing skills to the AGENTS.md routing table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,9 @@ Skills live in `.skills/<name>/SKILL.md`. Match the user's intent to the right s
 | "/impl-validator" / "check this implementation" / "validate what you did" / "is this correct?" | `impl-validator` |
 | "/wiki-switch NAME" / "switch to my work wiki" / "switch vault" / "change wiki" / "list my wikis" / "show my vaults" / "create a new vault config" | `wiki-switch` |
 | "/wiki-digest" / "what did I learn this week" / "weekly digest" / "knowledge summary" / "what's new in my wiki" / "summarize my recent learning" / "monthly review" | `wiki-digest` |
+| "/wiki-context-pack" / "make a context pack" / "context slice for X" / "pack the wiki for my agent" / "bounded context for Y" | `wiki-context-pack` |
+| "/wiki-stage-commit" / "review staged pages" / "commit staged writes" / "promote staged pages" / "what's waiting in staging" | `wiki-stage-commit` |
+| "restyle Obsidian" / "adjust the vault layout" / "CSS snippet" / "tune tabs/sidebars/graph panes" | `obsidian-layout-adjustment` |
 
 ## Cross-Project Usage
 


### PR DESCRIPTION
## Summary

Three skills exist in `.skills/` but were missing from the Skill Routing table in `AGENTS.md` (symlinked as `CLAUDE.md`/`GEMINI.md`). Agents dispatch skills through this table, so an unrouted skill is effectively invisible.

This adds the three missing rows, with trigger phrases taken from each skill's own `description` frontmatter:

| Skill | Notes |
|---|---|
| `wiki-context-pack` | `/wiki-context-pack`, "make a context pack", "bounded context for Y" |
| `wiki-stage-commit` | `/wiki-stage-commit`, "review staged pages", "promote staged pages" |
| `obsidian-layout-adjustment` | added in #128 but never routed — "restyle Obsidian", "CSS snippet" |

## Verification

```bash
for s in $(ls .skills); do grep -q "$s" AGENTS.md || echo "missing: $s"; done
# (no output — all 36 skills routed)
```

Docs-only change; no skill content touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015e5m1CuEE5DTQcFFmeCgRu