### PR TITLE
fix(lint): add approved confidence trust ledger

### DIFF
--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -361,12 +361,16 @@ lifecycle_changed: 2024-03-15  # ISO date of last state transition
 
 ### Confidence formula
 
-```
-base_confidence = source_count_score * 0.5 + source_quality_score * 0.5
+The formula is a **manual base score**, not a deterministic URL classifier:
 
-source_count_score   = min(distinct_source_ids / 3, 1.0)
-source_quality_score = avg(quality score per distinct source_id)
 ```
+base_confidence = lineage_count_score * 0.5 + source_quality_score * 0.5
+
+lineage_count_score  = min(independent_evidence_lineages / 3, 1.0)
+source_quality_score = avg(reviewed quality score per independent lineage)
+```
+
+After calculating the raw score, assess whether the evidence covers the page's material claims. Partial coverage may justify keeping or lowering the score; unsupported material claims require source/claim repair before any confidence change. Avoid small score churn without meaningful epistemic change.
 
 **Source-quality scores** (use the highest-matching bucket):
 
@@ -376,23 +380,23 @@ source_quality_score = avg(quality score per distinct source_id)
 | `official` | 0.9 | `*.gov`, vendor docs |
 | `documentation` | 0.85 | well-maintained third-party docs |
 | `book` | 0.8 | books, technical references |
-| `repository` | 0.75 | GitHub READMEs, codebases |
+| `repository` | 0.75 | content-addressed repository/code evidence |
 | `blog` | 0.55 | personal blogs |
-| `session_transcript` | 0.5 | conversation history |
-| `forum` | 0.4 | Stack Overflow, HN, Reddit |
-| `unknown` | 0.4 | catch-all |
-| `llm_generated` | 0.3 | LLM self-reflections |
+| `session_transcript` | 0.5 | conversation history or completed operation |
+| `forum` | 0.4 | Stack Overflow, HN, Reddit, issue-grade reports |
+| `unknown` | 0.4 | catch-all/current config |
+| `llm_generated` | 0.3 | LLM synthesis or unvalidated memory seed |
 
-**A `source_id`** is a stable per-source identifier — prevents counting three copies of the same blog as three distinct sources:
+**An independent evidence lineage** is an origin that can corroborate a claim independently. Canonical source IDs remain useful for identity, but identity alone does not prove independence. Collapse dependent evidence before counting:
 
-| Source type | source_id rule |
-|---|---|
-| Academic paper | DOI > arXiv ID > `<author>-<year>-<slug>` |
-| GitHub repo | `github.com/<owner>/<repo>` |
-| Documentation site | `<canonical-host>/<product>` |
-| Blog post | `<host>/<author>` |
-| Session transcript | `<agent>/<session-id>` |
-| Other | `<canonical-url>` |
+- files, releases, and commits from one repository → one repository lineage;
+- retry/review/fix tasks in one workstream → one task lineage;
+- parent/child Kanban records → one task lineage;
+- byte-identical memories across profiles → one memory lineage;
+- a snapshot plus the mutable source it captures → one lineage;
+- aliases or metadata references resolving to one origin → one lineage.
+
+The deterministic `wiki-lint` path validates `_meta/trust-ledger.json`; it does not recompute confidence from source strings. New or materially changed pages are marked for manual review. Refresh the ledger only after explicit human approval.
 
 **Per-skill defaults** (ingest skills compute this automatically):
 

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -174,7 +174,9 @@ Enforces the confidence + lifecycle frontmatter schema (see `llm-wiki/SKILL.md`,
 
 Two modes:
 - **`--check`** (default, read-only) — reports errors and warnings
-- **`--fix`** — may rewrite `base_confidence` only when drift is detected (Rule 12e); never rewrites `lifecycle`
+- **`--consolidate`** — may apply separately approved structural maintenance, but **never rewrites `base_confidence`**
+
+Confidence is a semantic judgment. A deterministic tool cannot infer independent evidence lineages or whole-page claim coverage from source strings alone. Confidence automation therefore validates an explicitly approved manual trust ledger; it never substitutes URL counting for review.
 
 #### Rule 12a — `lifecycle` enum validation
 
@@ -208,11 +210,50 @@ Staleness is never stored — it is computed at read time: `is_stale = (today �
 
 **How to fix:** n/a — flag for human resolution
 
-#### Rule 12e — Confidence drift
+#### Rule 12e — Confidence review integrity
 
-**How to check:** For pages that have both `base_confidence:` and `sources:` in frontmatter, recompute `base_confidence` using the formula in `llm-wiki/SKILL.md`. If the stored value differs from the recomputed value by more than 0.05, flag it as drift.
+**How to check:** Run the deterministic ledger validator first:
 
-**How to fix (`--fix` only):** Rewrite the `base_confidence` field to the recomputed value. This is the **only rule** that mutates frontmatter automatically.
+```bash
+obsidian-wiki trust-check "$OBSIDIAN_VAULT_PATH" --json --pretty
+```
+
+The approved ledger lives at `_meta/trust-ledger.json`. Each entry records the human-reviewed score plus a SHA-256 fingerprint of material page content and evidence metadata. The fingerprint excludes volatile bookkeeping (`updated`, `base_confidence`, and lifecycle transition fields), so timestamp-only edits do not reopen review.
+
+Interpret results as follows:
+
+- `reviewed` — current material fingerprint and stored score both match the approved review; do **not** recompute from source strings.
+- `stale` — body, summary, sources, provenance, tags, or relationships changed; perform a new manual lineage + claim-coverage review.
+- `unreviewed` — page has no approved ledger entry; manual review is required.
+- `score_mismatches` — material content still matches, but stored `base_confidence` differs from the approved value; fail the lint.
+- `errors` — malformed/missing ledger data; fail the lint.
+
+For a separately approved full-vault review, record the accepted state explicitly:
+
+```bash
+obsidian-wiki trust-record "$OBSIDIAN_VAULT_PATH" \
+  --all --reviewed-at "<ISO-8601 timestamp>" --approved --json --pretty
+```
+
+After a separately approved review of only specific stale/unreviewed pages, update only those entries:
+
+```bash
+obsidian-wiki trust-record "$OBSIDIAN_VAULT_PATH" \
+  --page "concepts/example.md" --page "skills/example.md" \
+  --reviewed-at "<ISO-8601 timestamp>" --approved --json --pretty
+```
+
+`--approved` means a human approved every score being recorded. `--all` is valid only after a full-vault review; use repeatable `--page` for partial reviews so unrelated stale pages remain open. Never run `trust-record` merely to silence warnings.
+
+**Manual recomputation protocol for stale/unreviewed pages:**
+
+1. Decompose the page into material claims and map each claim to evidence.
+2. Collapse dependent evidence into independent lineages: files/commits from one repository, retries in one task chain, snapshots plus their captured source, duplicate memories, and parent/child tasks each count once.
+3. Assign reviewed quality per independent lineage using `llm-wiki` buckets.
+4. Compute the raw base score, then assess whole-page claim coverage. The formula is a starting point, not an automatic target.
+5. Classify the result as `raise`, `keep`, `lower`, or `repair first`; require approval before changing `base_confidence` or refreshing the ledger.
+
+**How to fix:** There is no automatic confidence fix. Apply only an explicitly approved exact patch, verify its scope, then refresh only the reviewed ledger state. `--consolidate` must never rewrite `base_confidence`.
 
 #### Migration timeline
 
@@ -234,7 +275,8 @@ Add to the Wiki Health Report:
 - `synthesis/old-analysis.md` — STALE (last updated 2025-10-01, 182 days ago) lifecycle=verified ⚠️ HIGH PRIORITY
 - `concepts/outdated.md` — STALE (last updated 2025-11-15, 137 days ago) lifecycle=draft
 - `entities/tool-v1.md` — `superseded_by: [[entities/tool-v2]]` but lifecycle=draft (expected archived)
-- `concepts/drift-example.md` — base_confidence drift: stored=0.80, recomputed=0.59 (delta=0.21)
+- `concepts/drift-example.md` — confidence review stale: material fingerprint changed; manual lineage + coverage review required
+- `entities/mismatch.md` — confidence mismatch: stored=0.80, approved=0.59
 ```
 
 Append to the `LINT` log entry:

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -215,8 +215,13 @@ Staleness is never stored — it is computed at read time: `is_stale = (today �
 **How to check:** Run the deterministic ledger validator first:
 
 ```bash
-obsidian-wiki trust-check "$OBSIDIAN_VAULT_PATH" --json --pretty
+obsidian-wiki trust-check "$OBSIDIAN_VAULT_PATH" --strict --json --pretty
 ```
+
+Use `--strict` for CI and scheduled gates: stale, unreviewed, or missing-page
+warnings then return nonzero. Without `--strict`, `trust-check` remains a
+read-only reporting command and returns nonzero only for hard ledger errors or
+score mismatches.
 
 The approved ledger lives at `_meta/trust-ledger.json`. Each entry records the human-reviewed score plus a SHA-256 fingerprint of material page content and evidence metadata. The fingerprint excludes volatile bookkeeping (`updated`, `base_confidence`, and lifecycle transition fields), so timestamp-only edits do not reopen review.
 
@@ -243,7 +248,12 @@ obsidian-wiki trust-record "$OBSIDIAN_VAULT_PATH" \
   --reviewed-at "<ISO-8601 timestamp>" --approved --json --pretty
 ```
 
-`--approved` means a human approved every score being recorded. `--all` is valid only after a full-vault review; use repeatable `--page` for partial reviews so unrelated stale pages remain open. Never run `trust-record` merely to silence warnings.
+`--approved` means a human approved every score being recorded. It is a workflow
+assertion, not a cryptographic signature: keep `_meta/trust-ledger.json` under
+version control and require human diff review before merging ledger changes.
+`--all` is valid only after a full-vault review; use repeatable `--page` for
+partial reviews so unrelated stale pages remain open. Never run `trust-record`
+merely to silence warnings.
 
 **Manual recomputation protocol for stale/unreviewed pages:**
 
@@ -255,13 +265,13 @@ obsidian-wiki trust-record "$OBSIDIAN_VAULT_PATH" \
 
 **How to fix:** There is no automatic confidence fix. Apply only an explicitly approved exact patch, verify its scope, then refresh only the reviewed ledger state. `--consolidate` must never rewrite `base_confidence`.
 
-#### Migration timeline
+#### Current enforcement
 
-| Phase | When | Behavior on missing fields |
-|---|---|---|
-| Phase 1: Soft launch | Initial PR | Warning only — missing `base_confidence` or `lifecycle` on any page |
-| Phase 2: New pages enforced | +2 weeks | Error for newly created pages missing the fields; existing pages still warn even if `updated` is bumped during routine maintenance |
-| Phase 3: Full enforcement | +6 weeks, gated on a backfill script shipping in a separate PR | Error for all pages |
+Full enforcement is active. Every non-reserved content page must contain a
+finite `base_confidence` in `[0.0, 1.0]` and a documented lifecycle value.
+Missing or malformed trust fields, malformed ledger data, and a missing required
+ledger are hard errors. New pages with valid trust fields but no approved ledger
+entry are `unreviewed`; material changes to approved pages are `stale`.
 
 #### Output additions
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ obsidian-wiki info              # show install paths, version, and config
 obsidian-wiki doctor            # health-check config, vault shape, and installed skills
 obsidian-wiki query "rate limiting"  # query the configured vault from the terminal
 obsidian-wiki lint              # lint the configured vault for broken links / metadata gaps
-obsidian-wiki trust-check       # validate confidence against approved manual review fingerprints
-obsidian-wiki trust-record --all --reviewed-at <ISO> --approved  # record a human-approved full review
+obsidian-wiki trust-check --strict  # CI/scheduled gate for approved manual review fingerprints
+obsidian-wiki trust-record --all --reviewed-at <ISO-with-timezone> --approved  # record a human-approved full review
 obsidian-wiki setup --project . # also drop project-local skills + AGENTS.md into the current repo
 obsidian-wiki setup --copy      # copy skill files instead of symlinking
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ obsidian-wiki info              # show install paths, version, and config
 obsidian-wiki doctor            # health-check config, vault shape, and installed skills
 obsidian-wiki query "rate limiting"  # query the configured vault from the terminal
 obsidian-wiki lint              # lint the configured vault for broken links / metadata gaps
+obsidian-wiki trust-check       # validate confidence against approved manual review fingerprints
+obsidian-wiki trust-record --all --reviewed-at <ISO> --approved  # record a human-approved full review
 obsidian-wiki setup --project . # also drop project-local skills + AGENTS.md into the current repo
 obsidian-wiki setup --copy      # copy skill files instead of symlinking
 ```

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -752,7 +752,7 @@ def cmd_lint(args: argparse.Namespace) -> int:
         print(f"error: vault not found: {vault}", file=sys.stderr)
         return 1
 
-    report = lint_vault(vault)
+    report = lint_vault(vault, require_trust_ledger=True)
     if args.json:
         if args.pretty:
             print(json.dumps(report, indent=2))
@@ -760,6 +760,74 @@ def cmd_lint(args: argparse.Namespace) -> int:
             print(json.dumps(report))
     else:
         _print_lint(report)
+    if report["status"] == "fail" or (args.strict and report["status"] == "warn"):
+        return 1
+    return 0
+
+
+def _resolve_command_vault(vault_arg: str | None) -> Path | None:
+    resolved = vault_arg or _read_config_value("OBSIDIAN_VAULT_PATH")
+    if not resolved:
+        print("error: vault not configured; pass a path or run obsidian-wiki setup", file=sys.stderr)
+        return None
+    vault = Path(resolved).expanduser().resolve()
+    if not vault.is_dir():
+        print(f"error: vault not found: {vault}", file=sys.stderr)
+        return None
+    return vault
+
+
+def cmd_trust_record(args: argparse.Namespace) -> int:
+    from obsidian_wiki.trust import (
+        TRUST_LEDGER_RELATIVE_PATH,
+        build_trust_ledger,
+        update_trust_ledger,
+        write_trust_ledger,
+    )
+
+    vault = _resolve_command_vault(args.vault)
+    if vault is None:
+        return 1
+    path = vault / TRUST_LEDGER_RELATIVE_PATH
+    if args.all:
+        ledger = build_trust_ledger(vault, reviewed_at=args.reviewed_at)
+        recorded_pages = len(ledger["pages"])
+    else:
+        ledger = update_trust_ledger(
+            vault,
+            path,
+            reviewed_at=args.reviewed_at,
+            page_paths=args.page,
+        )
+        recorded_pages = len(set(args.page))
+    write_trust_ledger(path, ledger)
+    result = {
+        "status": "recorded",
+        "ledger_path": str(path),
+        "recorded_pages": recorded_pages,
+        "reviewed_at": args.reviewed_at,
+        "method": ledger["method"],
+    }
+    if args.json:
+        print(json.dumps(result, indent=2 if args.pretty else None))
+    else:
+        print(f"recorded {result['recorded_pages']} reviewed page(s) in {path}")
+    return 0
+
+
+def cmd_trust_check(args: argparse.Namespace) -> int:
+    from obsidian_wiki.trust import check_trust_ledger
+
+    vault = _resolve_command_vault(args.vault)
+    if vault is None:
+        return 1
+    report = check_trust_ledger(vault)
+    if args.json:
+        print(json.dumps(report, indent=2 if args.pretty else None))
+    else:
+        print(f"obsidian-wiki trust-check: {report['status']}")
+        for name, count in report["counts"].items():
+            print(f"{name}: {count}")
     if report["status"] == "fail" or (args.strict and report["status"] == "warn"):
         return 1
     return 0
@@ -951,6 +1019,40 @@ def build_parser() -> argparse.ArgumentParser:
     lt.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
     lt.add_argument("--strict", action="store_true", help="exit non-zero on warnings as well as failures")
     lt.set_defaults(func=cmd_lint)
+
+    tr = sub.add_parser(
+        "trust-record",
+        help="record explicitly approved manual confidence reviews in the vault trust ledger",
+    )
+    tr.add_argument("vault", nargs="?", help="path to the Obsidian vault (defaults to configured OBSIDIAN_VAULT_PATH)")
+    selection = tr.add_mutually_exclusive_group(required=True)
+    selection.add_argument("--all", action="store_true", help="record every current trust-schema page")
+    selection.add_argument(
+        "--page",
+        action="append",
+        metavar="VAULT_RELATIVE_PATH",
+        help="record only this explicitly reviewed page (repeatable)",
+    )
+    tr.add_argument("--reviewed-at", required=True, help="ISO timestamp for the approved review")
+    tr.add_argument(
+        "--approved",
+        action="store_true",
+        required=True,
+        help="confirm a human approved every confidence value being recorded",
+    )
+    tr.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    tr.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
+    tr.set_defaults(func=cmd_trust_record)
+
+    tc = sub.add_parser(
+        "trust-check",
+        help="validate confidence values and material fingerprints against the manual trust ledger",
+    )
+    tc.add_argument("vault", nargs="?", help="path to the Obsidian vault (defaults to configured OBSIDIAN_VAULT_PATH)")
+    tc.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    tc.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
+    tc.add_argument("--strict", action="store_true", help="exit non-zero on warnings as well as failures")
+    tc.set_defaults(func=cmd_trust_check)
 
     qq = sub.add_parser(
         "query",

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -789,18 +789,22 @@ def cmd_trust_record(args: argparse.Namespace) -> int:
     if vault is None:
         return 1
     path = vault / TRUST_LEDGER_RELATIVE_PATH
-    if args.all:
-        ledger = build_trust_ledger(vault, reviewed_at=args.reviewed_at)
-        recorded_pages = len(ledger["pages"])
-    else:
-        ledger = update_trust_ledger(
-            vault,
-            path,
-            reviewed_at=args.reviewed_at,
-            page_paths=args.page,
-        )
-        recorded_pages = len(set(args.page))
-    write_trust_ledger(path, ledger)
+    try:
+        if args.all:
+            ledger = build_trust_ledger(vault, reviewed_at=args.reviewed_at)
+            recorded_pages = len(ledger["pages"])
+        else:
+            ledger = update_trust_ledger(
+                vault,
+                path,
+                reviewed_at=args.reviewed_at,
+                page_paths=args.page,
+            )
+            recorded_pages = len(set(args.page))
+        write_trust_ledger(path, ledger, vault=vault)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     result = {
         "status": "recorded",
         "ledger_path": str(path),

--- a/obsidian_wiki/lint.py
+++ b/obsidian_wiki/lint.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import re
-from collections import Counter, defaultdict
+from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
 from obsidian_wiki.trust import TRUST_LEDGER_RELATIVE_PATH, check_trust_ledger
 
-SKIP_DIRS = frozenset("_raw _archived _staging _archives _bootstrap .obsidian".split())
+SKIP_DIRS = frozenset("_raw _archived _staging _archives _bootstrap .obsidian .git".split())
 REQUIRED_FRONTMATTER = (
     "title",
     "category",
@@ -29,8 +29,10 @@ _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 _FIELD_RE = re.compile(r"^([A-Za-z_][\w-]*):", re.MULTILINE)
 _WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]")
 _MD_LINK_RE = re.compile(r"\[.*?\]\(([^)]+\.md[^)]*)\)")
-_RELATIONSHIP_TYPE_RE = re.compile(r"^\s*-\s*type:\s*['\"]?([^'\"#]+?)['\"]?\s*$")
-_RELATIONSHIP_TARGET_RE = re.compile(r"^\s*target:\s*['\"]?([^'\"#]+?)['\"]?\s*$")
+_RELATIONSHIP_LIST_FIELD_RE = re.compile(
+    r"^\s*-\s*(type|target):\s*(.*?)\s*$"
+)
+_RELATIONSHIP_FIELD_RE = re.compile(r"^\s+(type|target):\s*(.*?)\s*$")
 
 
 def _slug(text: str) -> str:
@@ -73,28 +75,45 @@ def _parse_frontmatter_values(frontmatter: str) -> dict[str, str]:
     return values
 
 
+def _relationship_scalar(raw: str) -> str:
+    value = raw.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        return value[1:-1].strip()
+    return value.split(" #", 1)[0].strip()
+
+
 def _parse_relationships(frontmatter: str) -> list[dict[str, str]]:
     relationships: list[dict[str, str]] = []
     current: dict[str, str] | None = None
     in_relationships = False
     for line in frontmatter.splitlines():
-        if line == "relationships:":
+        if line.startswith("relationships:") and not line.startswith((" ", "\t")):
             in_relationships = True
+            inline = line.split(":", 1)[1].strip()
+            if inline in {"[]", "null", "~"}:
+                return []
+            if inline:
+                relationships.append({"parse_error": "inline_relationships_not_supported"})
+                return relationships
             continue
         if in_relationships and line and not line.startswith((" ", "\t")):
             break
         if not in_relationships:
             continue
-        type_match = _RELATIONSHIP_TYPE_RE.match(line)
-        if type_match:
-            if current:
+        item_match = _RELATIONSHIP_LIST_FIELD_RE.match(line)
+        if item_match:
+            if current is not None:
                 relationships.append(current)
-            current = {"type": type_match.group(1).strip()}
+            current = {item_match.group(1): _relationship_scalar(item_match.group(2))}
             continue
-        target_match = _RELATIONSHIP_TARGET_RE.match(line)
-        if target_match and current is not None:
-            current["target"] = target_match.group(1).strip()
-    if current:
+        field_match = _RELATIONSHIP_FIELD_RE.match(line)
+        if field_match and current is not None:
+            key = field_match.group(1)
+            if key in current:
+                current["parse_error"] = f"duplicate_relationship_{key}"
+            else:
+                current[key] = _relationship_scalar(field_match.group(2))
+    if current is not None:
         relationships.append(current)
     return relationships
 
@@ -113,6 +132,7 @@ def _parse_page(path: Path, vault: Path) -> dict[str, Any]:
     frontmatter = front_match.group(1) if front_match else ""
     fields = set(_FIELD_RE.findall(frontmatter))
     values = _parse_frontmatter_values(frontmatter)
+    relative = path.relative_to(vault)
 
     links: list[str] = []
     for raw in _WIKILINK_RE.findall(text):
@@ -125,8 +145,8 @@ def _parse_page(path: Path, vault: Path) -> dict[str, Any]:
             links.append(target)
 
     return {
-        "path": str(path.relative_to(vault)),
-        "node_id": _normalise_node_id(str(path.relative_to(vault).with_suffix(""))),
+        "path": relative.as_posix(),
+        "node_id": _normalise_node_id(relative.with_suffix("").as_posix()),
         "slug": _slug(path.stem),
         "title": values.get("title", "").strip() or path.stem,
         "summary": values.get("summary", "").strip(),
@@ -136,9 +156,12 @@ def _parse_page(path: Path, vault: Path) -> dict[str, Any]:
     }
 
 
-def lint_vault(vault: Path, *, require_trust_ledger: bool = False) -> dict[str, Any]:
+def lint_vault(vault: Path, *, require_trust_ledger: bool = True) -> dict[str, Any]:
     pages = [_parse_page(path, vault) for path in _iter_pages(vault)]
-    by_slug = {page["slug"]: page for page in pages}
+    slug_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for page in pages:
+        slug_index[page["slug"]].append(page)
+    by_slug = {slug: matches[0] for slug, matches in slug_index.items()}
     by_node_id = {page["node_id"]: page for page in pages}
     incoming: dict[str, int] = defaultdict(int)
 
@@ -188,6 +211,15 @@ def lint_vault(vault: Path, *, require_trust_ledger: bool = False) -> dict[str, 
     typed_relationship_issues: list[dict[str, Any]] = []
     for page in pages:
         for index, relationship in enumerate(page["relationships"]):
+            if "parse_error" in relationship:
+                typed_relationship_issues.append(
+                    {
+                        "page": page["path"],
+                        "index": index,
+                        "issue": relationship["parse_error"],
+                    }
+                )
+                continue
             relation_type = relationship.get("type", "")
             target_raw = relationship.get("target", "")
             if relation_type not in ALLOWED_RELATIONSHIP_TYPES:
@@ -201,9 +233,21 @@ def lint_vault(vault: Path, *, require_trust_ledger: bool = False) -> dict[str, 
                 )
                 continue
             target = _normalise_node_id(target_raw)
-            resolved = by_node_id.get(target)
-            if resolved is None and "/" not in target:
-                resolved = by_slug.get(target)
+            if "/" in target:
+                resolved = by_node_id.get(target)
+            else:
+                matches = slug_index.get(target, [])
+                if len(matches) > 1:
+                    typed_relationship_issues.append(
+                        {
+                            "page": page["path"],
+                            "index": index,
+                            "issue": "ambiguous_target",
+                            "target": target,
+                        }
+                    )
+                    continue
+                resolved = matches[0] if matches else None
             if resolved is None:
                 typed_relationship_issues.append(
                     {

--- a/obsidian_wiki/lint.py
+++ b/obsidian_wiki/lint.py
@@ -32,6 +32,7 @@ _MD_LINK_RE = re.compile(r"\[.*?\]\(([^)]+\.md[^)]*)\)")
 _RELATIONSHIP_LIST_FIELD_RE = re.compile(
     r"^\s*-\s*(type|target):\s*(.*?)\s*$"
 )
+_RELATIONSHIP_ITEM_START_RE = re.compile(r"^\s*-\s*(?:#.*)?$")
 _RELATIONSHIP_FIELD_RE = re.compile(r"^\s+(type|target):\s*(.*?)\s*$")
 
 
@@ -106,6 +107,11 @@ def _parse_relationships(frontmatter: str) -> list[dict[str, str]]:
                 relationships.append(current)
             current = {item_match.group(1): _relationship_scalar(item_match.group(2))}
             continue
+        if _RELATIONSHIP_ITEM_START_RE.match(line):
+            if current is not None:
+                relationships.append(current)
+            current = {}
+            continue
         field_match = _RELATIONSHIP_FIELD_RE.match(line)
         if field_match and current is not None:
             key = field_match.group(1)
@@ -113,6 +119,12 @@ def _parse_relationships(frontmatter: str) -> list[dict[str, str]]:
                 current["parse_error"] = f"duplicate_relationship_{key}"
             else:
                 current[key] = _relationship_scalar(field_match.group(2))
+            continue
+        if line.strip() and not line.lstrip().startswith("#"):
+            if current is None:
+                current = {"parse_error": "malformed_relationship_entry"}
+            else:
+                current.setdefault("parse_error", "malformed_relationship_entry")
     if current is not None:
         relationships.append(current)
     return relationships
@@ -159,10 +171,11 @@ def _parse_page(path: Path, vault: Path) -> dict[str, Any]:
 def lint_vault(vault: Path, *, require_trust_ledger: bool = True) -> dict[str, Any]:
     pages = [_parse_page(path, vault) for path in _iter_pages(vault)]
     slug_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    node_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
     for page in pages:
         slug_index[page["slug"]].append(page)
+        node_index[page["node_id"]].append(page)
     by_slug = {slug: matches[0] for slug, matches in slug_index.items()}
-    by_node_id = {page["node_id"]: page for page in pages}
     incoming: dict[str, int] = defaultdict(int)
 
     broken_links: list[dict[str, str]] = []
@@ -233,21 +246,18 @@ def lint_vault(vault: Path, *, require_trust_ledger: bool = True) -> dict[str, A
                 )
                 continue
             target = _normalise_node_id(target_raw)
-            if "/" in target:
-                resolved = by_node_id.get(target)
-            else:
-                matches = slug_index.get(target, [])
-                if len(matches) > 1:
-                    typed_relationship_issues.append(
-                        {
-                            "page": page["path"],
-                            "index": index,
-                            "issue": "ambiguous_target",
-                            "target": target,
-                        }
-                    )
-                    continue
-                resolved = matches[0] if matches else None
+            matches = node_index.get(target, []) if "/" in target else slug_index.get(target, [])
+            if len(matches) > 1:
+                typed_relationship_issues.append(
+                    {
+                        "page": page["path"],
+                        "index": index,
+                        "issue": "ambiguous_target",
+                        "target": target,
+                    }
+                )
+                continue
+            resolved = matches[0] if matches else None
             if resolved is None:
                 typed_relationship_issues.append(
                     {

--- a/obsidian_wiki/lint.py
+++ b/obsidian_wiki/lint.py
@@ -7,14 +7,30 @@ from collections import Counter, defaultdict
 from pathlib import Path
 from typing import Any
 
-SKIP_DIRS = frozenset("_raw _archived _staging _archives .obsidian".split())
-REQUIRED_FRONTMATTER = ("title", "category", "tags", "sources", "created", "updated")
+from obsidian_wiki.trust import TRUST_LEDGER_RELATIVE_PATH, check_trust_ledger
+
+SKIP_DIRS = frozenset("_raw _archived _staging _archives _bootstrap .obsidian".split())
+REQUIRED_FRONTMATTER = (
+    "title",
+    "category",
+    "tags",
+    "sources",
+    "created",
+    "updated",
+    "base_confidence",
+    "lifecycle",
+)
 RESERVED_PAGE_STEMS = frozenset({"index", "log", "hot", "_insights"})
+ALLOWED_RELATIONSHIP_TYPES = frozenset(
+    {"extends", "implements", "contradicts", "derived_from", "uses", "replaces", "related_to"}
+)
 
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---", re.DOTALL)
 _FIELD_RE = re.compile(r"^([A-Za-z_][\w-]*):", re.MULTILINE)
 _WIKILINK_RE = re.compile(r"\[\[([^\]|#]+?)(?:[|#][^\]]*?)?\]\]")
 _MD_LINK_RE = re.compile(r"\[.*?\]\(([^)]+\.md[^)]*)\)")
+_RELATIONSHIP_TYPE_RE = re.compile(r"^\s*-\s*type:\s*['\"]?([^'\"#]+?)['\"]?\s*$")
+_RELATIONSHIP_TARGET_RE = re.compile(r"^\s*target:\s*['\"]?([^'\"#]+?)['\"]?\s*$")
 
 
 def _slug(text: str) -> str:
@@ -57,6 +73,40 @@ def _parse_frontmatter_values(frontmatter: str) -> dict[str, str]:
     return values
 
 
+def _parse_relationships(frontmatter: str) -> list[dict[str, str]]:
+    relationships: list[dict[str, str]] = []
+    current: dict[str, str] | None = None
+    in_relationships = False
+    for line in frontmatter.splitlines():
+        if line == "relationships:":
+            in_relationships = True
+            continue
+        if in_relationships and line and not line.startswith((" ", "\t")):
+            break
+        if not in_relationships:
+            continue
+        type_match = _RELATIONSHIP_TYPE_RE.match(line)
+        if type_match:
+            if current:
+                relationships.append(current)
+            current = {"type": type_match.group(1).strip()}
+            continue
+        target_match = _RELATIONSHIP_TARGET_RE.match(line)
+        if target_match and current is not None:
+            current["target"] = target_match.group(1).strip()
+    if current:
+        relationships.append(current)
+    return relationships
+
+
+def _normalise_node_id(raw: str) -> str:
+    target = raw.strip().removeprefix("[[").removesuffix("]]")
+    target = target.split("|", 1)[0].split("#", 1)[0].strip()
+    if target.lower().endswith(".md"):
+        target = target[:-3]
+    return "/".join(_slug(part) for part in target.strip("/").split("/") if part)
+
+
 def _parse_page(path: Path, vault: Path) -> dict[str, Any]:
     text = path.read_text(encoding="utf-8", errors="replace")
     front_match = _FRONTMATTER_RE.match(text)
@@ -76,17 +126,20 @@ def _parse_page(path: Path, vault: Path) -> dict[str, Any]:
 
     return {
         "path": str(path.relative_to(vault)),
+        "node_id": _normalise_node_id(str(path.relative_to(vault).with_suffix(""))),
         "slug": _slug(path.stem),
         "title": values.get("title", "").strip() or path.stem,
         "summary": values.get("summary", "").strip(),
         "fields": fields,
         "links": links,
+        "relationships": _parse_relationships(frontmatter),
     }
 
 
-def lint_vault(vault: Path) -> dict[str, Any]:
+def lint_vault(vault: Path, *, require_trust_ledger: bool = False) -> dict[str, Any]:
     pages = [_parse_page(path, vault) for path in _iter_pages(vault)]
     by_slug = {page["slug"]: page for page in pages}
+    by_node_id = {page["node_id"]: page for page in pages}
     incoming: dict[str, int] = defaultdict(int)
 
     broken_links: list[dict[str, str]] = []
@@ -101,6 +154,8 @@ def lint_vault(vault: Path) -> dict[str, Any]:
 
     missing_frontmatter = []
     for page in pages:
+        if page["slug"] in RESERVED_PAGE_STEMS:
+            continue
         missing = [field for field in REQUIRED_FRONTMATTER if field not in page["fields"]]
         if missing:
             missing_frontmatter.append({"page": page["path"], "missing": missing})
@@ -118,7 +173,8 @@ def lint_vault(vault: Path) -> dict[str, Any]:
     missing_summaries = [
         page["path"]
         for page in pages
-        if "summary" not in page["fields"] or not page["summary"]
+        if page["slug"] not in RESERVED_PAGE_STEMS
+        and ("summary" not in page["fields"] or not page["summary"])
     ]
 
     orphan_pages = []
@@ -129,18 +185,83 @@ def lint_vault(vault: Path) -> dict[str, Any]:
         if outgoing == 0 and incoming.get(page["slug"], 0) == 0:
             orphan_pages.append(page["path"])
 
+    typed_relationship_issues: list[dict[str, Any]] = []
+    for page in pages:
+        for index, relationship in enumerate(page["relationships"]):
+            relation_type = relationship.get("type", "")
+            target_raw = relationship.get("target", "")
+            if relation_type not in ALLOWED_RELATIONSHIP_TYPES:
+                typed_relationship_issues.append(
+                    {
+                        "page": page["path"],
+                        "index": index,
+                        "issue": "invalid_type",
+                        "type": relation_type,
+                    }
+                )
+                continue
+            target = _normalise_node_id(target_raw)
+            resolved = by_node_id.get(target)
+            if resolved is None and "/" not in target:
+                resolved = by_slug.get(target)
+            if resolved is None:
+                typed_relationship_issues.append(
+                    {
+                        "page": page["path"],
+                        "index": index,
+                        "issue": "missing_target",
+                        "target": target,
+                    }
+                )
+            elif resolved["node_id"] == page["node_id"]:
+                typed_relationship_issues.append(
+                    {
+                        "page": page["path"],
+                        "index": index,
+                        "issue": "self_reference",
+                        "target": target,
+                    }
+                )
+
+    ledger_path = vault / TRUST_LEDGER_RELATIVE_PATH
+    trust_report = (
+        check_trust_ledger(vault, ledger_path)
+        if ledger_path.is_file() or require_trust_ledger
+        else None
+    )
+
     findings = {
         "broken_links": broken_links,
         "missing_frontmatter": missing_frontmatter,
         "duplicate_titles": duplicate_titles,
         "missing_summaries": sorted(missing_summaries),
         "orphan_pages": sorted(orphan_pages),
+        "typed_relationship_issues": typed_relationship_issues,
+        "confidence_review_stale": trust_report["stale"] if trust_report else [],
+        "confidence_unreviewed": trust_report["unreviewed"] if trust_report else [],
+        "confidence_mismatches": trust_report["score_mismatches"] if trust_report else [],
+        "confidence_ledger_errors": trust_report["errors"] if trust_report else [],
     }
     counts = {name: len(items) for name, items in findings.items()}
 
-    if counts["broken_links"] or counts["missing_frontmatter"]:
+    if (
+        counts["broken_links"]
+        or counts["missing_frontmatter"]
+        or counts["confidence_mismatches"]
+        or counts["confidence_ledger_errors"]
+    ):
         status = "fail"
-    elif any(counts[name] for name in ("duplicate_titles", "missing_summaries", "orphan_pages")):
+    elif any(
+        counts[name]
+        for name in (
+            "duplicate_titles",
+            "missing_summaries",
+            "orphan_pages",
+            "typed_relationship_issues",
+            "confidence_review_stale",
+            "confidence_unreviewed",
+        )
+    ):
         status = "warn"
     else:
         status = "pass"
@@ -151,6 +272,7 @@ def lint_vault(vault: Path) -> dict[str, Any]:
             "pages": len(pages),
             "link_count": sum(len(page["links"]) for page in pages),
             "findings": counts,
+            "trust": trust_report["counts"] if trust_report else {"ledger": "not_configured"},
         },
         "findings": findings,
     }

--- a/obsidian_wiki/trust.py
+++ b/obsidian_wiki/trust.py
@@ -28,7 +28,7 @@ TRUST_SKIP_DIRS = frozenset(
 )
 TRUST_RESERVED_STEMS = frozenset({"index", "log", "hot", "_insights"})
 ALLOWED_LIFECYCLES = frozenset({"draft", "reviewed", "verified", "disputed", "archived"})
-_REQUIRED_TRUST_KEYS = ("base_confidence", "lifecycle")
+_REQUIRED_TRUST_KEYS = ("base_confidence", "lifecycle", "updated")
 _VOLATILE_CONFIDENCE_KEYS = (
     "updated",
     "base_confidence",
@@ -55,6 +55,16 @@ def _validate_reviewed_at(value: Any) -> str:
         raise ValueError("reviewed_at must be an ISO-8601 timestamp with timezone") from exc
     if parsed.tzinfo is None or parsed.utcoffset() is None:
         raise ValueError("reviewed_at must be an ISO-8601 timestamp with timezone")
+    return candidate
+
+
+def _validate_updated(value: str) -> str:
+    candidate = value.strip()
+    try:
+        # Page metadata intentionally permits either an ISO date or an ISO date-time.
+        datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("updated is not an ISO-8601 date or timestamp") from exc
     return candidate
 
 
@@ -123,6 +133,9 @@ def _trust_metadata(path: Path) -> dict[str, Any]:
         scalar = _frontmatter_scalar(raw)
         if not scalar or scalar in {">", ">-", "|", "|-"} or children:
             raise ValueError(f"{key} must be a scalar")
+
+    updated = _frontmatter_scalar(records["updated"][0][0])
+    _validate_updated(updated)
 
     confidence_raw = _frontmatter_scalar(records["base_confidence"][0][0])
     try:

--- a/obsidian_wiki/trust.py
+++ b/obsidian_wiki/trust.py
@@ -11,8 +11,13 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+import os
 import re
-from pathlib import Path
+import secrets
+import stat
+import tempfile
+from datetime import datetime
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 TRUST_LEDGER_RELATIVE_PATH = Path("_meta/trust-ledger.json")
@@ -22,29 +27,122 @@ TRUST_SKIP_DIRS = frozenset(
     "_raw _archived _staging _archives _bootstrap .obsidian .git".split()
 )
 TRUST_RESERVED_STEMS = frozenset({"index", "log", "hot", "_insights"})
-_VOLATILE_CONFIDENCE_KEYS = frozenset(
-    {
-        "updated",
-        "base_confidence",
-        "lifecycle",
-        "lifecycle_changed",
-        "lifecycle_reason",
-        "superseded_by",
-    }
+ALLOWED_LIFECYCLES = frozenset({"draft", "reviewed", "verified", "disputed", "archived"})
+_REQUIRED_TRUST_KEYS = ("base_confidence", "lifecycle")
+_VOLATILE_CONFIDENCE_KEYS = (
+    "updated",
+    "base_confidence",
+    "lifecycle",
+    "lifecycle_changed",
+    "lifecycle_reason",
+    "superseded_by",
 )
 _FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---(?:\n|$)", re.DOTALL)
 _TOP_LEVEL_FIELD_RE = re.compile(r"^([A-Za-z_][\w-]*):")
-_CONFIDENCE_RE = re.compile(r"^base_confidence:\s*([^#\n]+)", re.MULTILINE)
-_LIFECYCLE_RE = re.compile(r"^lifecycle:\s*([^#\n]+)", re.MULTILINE)
 
 
 def _normalise_text(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
+def _validate_reviewed_at(value: Any) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError("reviewed_at must be an ISO-8601 timestamp with timezone")
+    candidate = value.strip()
+    try:
+        parsed = datetime.fromisoformat(candidate.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("reviewed_at must be an ISO-8601 timestamp with timezone") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("reviewed_at must be an ISO-8601 timestamp with timezone")
+    return candidate
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"non-standard JSON number: {value}")
+
+
+def _reject_duplicate_json_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
 def _frontmatter(text: str) -> str:
     match = _FRONTMATTER_RE.match(_normalise_text(text))
     return match.group(1) if match else ""
+
+
+def _frontmatter_scalar(raw: str) -> str:
+    value = raw.strip().split(" #", 1)[0].strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {"'", '"'}:
+        value = value[1:-1].strip()
+    return value
+
+
+def _trust_metadata(path: Path) -> dict[str, Any]:
+    """Parse and validate trust-sensitive frontmatter without YAML ambiguity."""
+    try:
+        text = _normalise_text(path.read_text(encoding="utf-8"))
+    except UnicodeError as exc:
+        raise ValueError("page is not valid UTF-8") from exc
+    frontmatter = _frontmatter(text)
+    if not frontmatter:
+        raise ValueError("missing frontmatter")
+
+    records: dict[str, list[tuple[str, list[str]]]] = {}
+    current: tuple[str, list[str]] | None = None
+    for line in frontmatter.splitlines():
+        field = _TOP_LEVEL_FIELD_RE.match(line)
+        if field:
+            key = field.group(1)
+            raw = line.split(":", 1)[1].strip()
+            children: list[str] = []
+            records.setdefault(key, []).append((raw, children))
+            current = (key, children)
+            continue
+        if line.startswith((" ", "\t")) and current is not None:
+            current[1].append(line)
+
+    for key in _VOLATILE_CONFIDENCE_KEYS:
+        entries = records.get(key, [])
+        if len(entries) > 1:
+            raise ValueError(f"duplicate top-level field: {key}")
+    for key in _REQUIRED_TRUST_KEYS:
+        if key not in records:
+            raise ValueError(f"missing {key}")
+
+    for key in _VOLATILE_CONFIDENCE_KEYS:
+        entries = records.get(key, [])
+        if not entries:
+            continue
+        raw, children = entries[0]
+        scalar = _frontmatter_scalar(raw)
+        if not scalar or scalar in {">", ">-", "|", "|-"} or children:
+            raise ValueError(f"{key} must be a scalar")
+
+    confidence_raw = _frontmatter_scalar(records["base_confidence"][0][0])
+    try:
+        confidence = float(confidence_raw)
+    except ValueError as exc:
+        raise ValueError("base_confidence is not numeric") from exc
+    if not math.isfinite(confidence):
+        raise ValueError("base_confidence is not finite")
+    if not 0.0 <= confidence <= 1.0:
+        raise ValueError("base_confidence is outside [0.0, 1.0]")
+
+    lifecycle = _frontmatter_scalar(records["lifecycle"][0][0])
+    if lifecycle not in ALLOWED_LIFECYCLES:
+        raise ValueError(f"invalid lifecycle: {lifecycle}")
+    return {
+        "text": text,
+        "frontmatter": frontmatter,
+        "confidence": confidence,
+        "lifecycle": lifecycle,
+    }
 
 
 def _strip_volatile_confidence_fields(frontmatter: str) -> str:
@@ -61,33 +159,23 @@ def _strip_volatile_confidence_fields(frontmatter: str) -> str:
 
 
 def page_fingerprint(path: Path) -> str:
-    """Hash material claims and evidence, excluding volatile review bookkeeping."""
-    text = _normalise_text(path.read_text(encoding="utf-8", errors="replace"))
+    """Hash material claims and evidence, excluding validated volatile bookkeeping."""
+    metadata = _trust_metadata(path)
+    text = metadata["text"]
     match = _FRONTMATTER_RE.match(text)
-    if not match:
-        material = text.strip() + "\n"
-    else:
-        stable_frontmatter = _strip_volatile_confidence_fields(match.group(1))
-        body = text[match.end() :].strip()
-        material = f"---\n{stable_frontmatter}\n---\n{body}\n"
+    assert match is not None
+    stable_frontmatter = _strip_volatile_confidence_fields(metadata["frontmatter"])
+    body = text[match.end() :].strip()
+    material = f"---\n{stable_frontmatter}\n---\n{body}\n"
     return "sha256:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
 def _parse_confidence(path: Path) -> float:
-    match = _CONFIDENCE_RE.search(_frontmatter(path.read_text(encoding="utf-8", errors="replace")))
-    if not match:
-        raise ValueError("missing base_confidence")
-    try:
-        value = float(match.group(1).strip().strip("'\""))
-    except ValueError as exc:
-        raise ValueError("base_confidence is not numeric") from exc
-    if not 0.0 <= value <= 1.0:
-        raise ValueError("base_confidence is outside [0.0, 1.0]")
-    return value
+    return float(_trust_metadata(path)["confidence"])
 
 
 def iter_trust_pages(vault: Path) -> list[Path]:
-    """Return content pages carrying the confidence/lifecycle trust schema."""
+    """Return every non-reserved content page that must participate in trust review."""
     pages: list[Path] = []
     for path in vault.rglob("*.md"):
         rel = path.relative_to(vault)
@@ -95,17 +183,16 @@ def iter_trust_pages(vault: Path) -> list[Path]:
             continue
         if path.stem in TRUST_RESERVED_STEMS:
             continue
-        frontmatter = _frontmatter(path.read_text(encoding="utf-8", errors="replace"))
-        if _CONFIDENCE_RE.search(frontmatter) and _LIFECYCLE_RE.search(frontmatter):
-            pages.append(path)
-    return sorted(pages, key=lambda item: str(item.relative_to(vault)))
+        pages.append(path)
+    return sorted(pages, key=lambda item: item.relative_to(vault).as_posix())
 
 
 def build_trust_ledger(vault: Path, *, reviewed_at: str) -> dict[str, Any]:
     """Capture explicitly approved confidence values and material fingerprints."""
+    reviewed_at = _validate_reviewed_at(reviewed_at)
     pages: dict[str, dict[str, Any]] = {}
     for path in iter_trust_pages(vault):
-        rel = str(path.relative_to(vault))
+        rel = path.relative_to(vault).as_posix()
         pages[rel] = _review_entry(path, reviewed_at)
     return {
         "schema_version": TRUST_LEDGER_SCHEMA_VERSION,
@@ -123,6 +210,37 @@ def _review_entry(path: Path, reviewed_at: str) -> dict[str, Any]:
     }
 
 
+def _validate_ledger_entry(entry: Any) -> tuple[str, float, str]:
+    if not isinstance(entry, dict):
+        raise ValueError("invalid_ledger_entry")
+    fingerprint = entry.get("material_fingerprint")
+    reviewed_confidence = entry.get("reviewed_confidence")
+    if (
+        not isinstance(fingerprint, str)
+        or re.fullmatch(r"sha256:[0-9a-f]{64}", fingerprint) is None
+    ):
+        raise ValueError("invalid_ledger_entry")
+    if not isinstance(reviewed_confidence, (int, float)) or isinstance(reviewed_confidence, bool):
+        raise ValueError("invalid_ledger_entry")
+    reviewed_value = float(reviewed_confidence)
+    if not math.isfinite(reviewed_value) or not 0.0 <= reviewed_value <= 1.0:
+        raise ValueError("invalid_ledger_entry")
+    try:
+        reviewed_at = _validate_reviewed_at(entry.get("reviewed_at"))
+    except ValueError as exc:
+        raise ValueError("invalid_ledger_entry") from exc
+    return fingerprint, reviewed_value, reviewed_at
+
+
+def _validate_ledger_page_path(raw: Any) -> str:
+    if not isinstance(raw, str) or not raw or "\\" in raw:
+        raise ValueError("invalid_ledger_page_path")
+    path = PurePosixPath(raw)
+    if path.is_absolute() or ".." in path.parts or path.as_posix() != raw:
+        raise ValueError("invalid_ledger_page_path")
+    return raw
+
+
 def update_trust_ledger(
     vault: Path,
     ledger_path: Path,
@@ -131,17 +249,29 @@ def update_trust_ledger(
     page_paths: list[str],
 ) -> dict[str, Any]:
     """Update only explicitly reviewed pages while preserving every other entry."""
+    reviewed_at = _validate_reviewed_at(reviewed_at)
     if ledger_path.is_file():
         try:
-            ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError) as exc:
+            ledger = json.loads(
+                ledger_path.read_text(encoding="utf-8"),
+                parse_constant=_reject_json_constant,
+                object_pairs_hook=_reject_duplicate_json_keys,
+            )
+        except (OSError, UnicodeError, ValueError) as exc:
             raise RuntimeError(f"cannot update unreadable trust ledger: {exc}") from exc
         if not isinstance(ledger, dict):
             raise RuntimeError("cannot update trust ledger: top level must be an object")
-        if ledger.get("schema_version") != TRUST_LEDGER_SCHEMA_VERSION:
+        if type(ledger.get("schema_version")) is not int or ledger.get("schema_version") != TRUST_LEDGER_SCHEMA_VERSION:
             raise RuntimeError("cannot update unsupported trust ledger schema")
         if ledger.get("method") != TRUST_REVIEW_METHOD or not isinstance(ledger.get("pages"), dict):
             raise RuntimeError("cannot update malformed trust ledger")
+        try:
+            _validate_reviewed_at(ledger.get("reviewed_at"))
+            for rel, entry in ledger["pages"].items():
+                _validate_ledger_page_path(rel)
+                _validate_ledger_entry(entry)
+        except ValueError as exc:
+            raise RuntimeError("cannot update malformed trust ledger") from exc
     else:
         ledger = {
             "schema_version": TRUST_LEDGER_SCHEMA_VERSION,
@@ -150,7 +280,7 @@ def update_trust_ledger(
             "pages": {},
         }
 
-    current = {str(path.relative_to(vault)): path for path in iter_trust_pages(vault)}
+    current = {path.relative_to(vault).as_posix(): path for path in iter_trust_pages(vault)}
     selected: list[str] = []
     for raw in page_paths:
         candidate = Path(raw)
@@ -167,13 +297,105 @@ def update_trust_ledger(
     return ledger
 
 
-def write_trust_ledger(path: Path, ledger: dict[str, Any]) -> None:
-    """Write a ledger atomically with stable ordering."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = json.dumps(ledger, indent=2, sort_keys=True) + "\n"
-    temporary = path.with_suffix(path.suffix + ".tmp")
-    temporary.write_text(payload, encoding="utf-8")
-    temporary.replace(path)
+def write_trust_ledger(
+    path: Path,
+    ledger: dict[str, Any],
+    *,
+    vault: Path | None = None,
+) -> None:
+    """Write a ledger atomically without following vault-internal symlinks."""
+    vault_root = (vault or path.parent.parent).expanduser().resolve(strict=True)
+    expected = vault_root / TRUST_LEDGER_RELATIVE_PATH
+    requested = path.expanduser().absolute()
+    if requested.resolve(strict=False) != expected:
+        raise RuntimeError("trust ledger destination resolves outside the resolved vault")
+
+    parent = expected.parent
+    if parent.exists() and parent.is_symlink():
+        raise RuntimeError("trust ledger parent must not be a symlink")
+    parent.mkdir(parents=True, exist_ok=True)
+    if parent.resolve(strict=True) != vault_root / TRUST_LEDGER_RELATIVE_PATH.parent:
+        raise RuntimeError("trust ledger parent resolves outside the resolved vault")
+    if expected.is_symlink():
+        raise RuntimeError("trust ledger destination must not be a symlink")
+
+    try:
+        payload = json.dumps(ledger, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(f"trust ledger is not valid JSON data: {exc}") from exc
+
+    if os.name == "posix":
+        directory_flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0)
+        try:
+            directory_fd = os.open(parent, directory_flags)
+        except OSError as exc:
+            raise RuntimeError(f"cannot securely open trust ledger directory: {exc}") from exc
+        temporary_name = f".trust-ledger-{secrets.token_hex(16)}.tmp"
+        temporary_created = False
+        try:
+            try:
+                destination_stat = os.stat(
+                    expected.name,
+                    dir_fd=directory_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                destination_stat = None
+            if destination_stat is not None and stat.S_ISLNK(destination_stat.st_mode):
+                raise RuntimeError("trust ledger destination must not be a symlink")
+
+            descriptor = os.open(
+                temporary_name,
+                os.O_WRONLY
+                | os.O_CREAT
+                | os.O_EXCL
+                | getattr(os, "O_NOFOLLOW", 0),
+                0o600,
+                dir_fd=directory_fd,
+            )
+            temporary_created = True
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(
+                temporary_name,
+                expected.name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+            )
+            temporary_created = False
+            os.fsync(directory_fd)
+        except OSError as exc:
+            raise RuntimeError(f"cannot securely write trust ledger: {exc}") from exc
+        finally:
+            if temporary_created:
+                try:
+                    os.unlink(temporary_name, dir_fd=directory_fd)
+                except FileNotFoundError:
+                    pass
+            os.close(directory_fd)
+        return
+
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            dir=parent,
+            prefix=".trust-ledger-",
+            suffix=".tmp",
+            text=True,
+        )
+    except OSError as exc:
+        raise RuntimeError(f"cannot create trust ledger temporary file: {exc}") from exc
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        temporary.replace(expected)
+    except OSError as exc:
+        temporary.unlink(missing_ok=True)
+        raise RuntimeError(f"cannot write trust ledger: {exc}") from exc
 
 
 def _empty_report(ledger_path: Path) -> dict[str, Any]:
@@ -195,18 +417,22 @@ def check_trust_ledger(vault: Path, ledger_path: Path | None = None) -> dict[str
     path = ledger_path or vault / TRUST_LEDGER_RELATIVE_PATH
     report = _empty_report(path)
     try:
-        ledger = json.loads(path.read_text(encoding="utf-8"))
+        ledger = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=_reject_json_constant,
+            object_pairs_hook=_reject_duplicate_json_keys,
+        )
     except FileNotFoundError:
         report["errors"].append({"issue": "ledger_missing", "path": str(path)})
         return _finalise_report(report)
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeError, ValueError) as exc:
         report["errors"].append({"issue": "ledger_unreadable", "detail": str(exc)})
         return _finalise_report(report)
 
     if not isinstance(ledger, dict):
         report["errors"].append({"issue": "ledger_must_be_an_object"})
         return _finalise_report(report)
-    if ledger.get("schema_version") != TRUST_LEDGER_SCHEMA_VERSION:
+    if type(ledger.get("schema_version")) is not int or ledger.get("schema_version") != TRUST_LEDGER_SCHEMA_VERSION:
         report["errors"].append(
             {
                 "issue": "unsupported_schema_version",
@@ -220,44 +446,44 @@ def check_trust_ledger(vault: Path, ledger_path: Path | None = None) -> dict[str
             {"issue": "unsupported_review_method", "found": ledger.get("method")}
         )
         return _finalise_report(report)
+    try:
+        _validate_reviewed_at(ledger.get("reviewed_at"))
+    except ValueError:
+        report["errors"].append({"issue": "invalid_reviewed_at"})
+        return _finalise_report(report)
     entries = ledger.get("pages")
     if not isinstance(entries, dict):
         report["errors"].append({"issue": "pages_must_be_an_object"})
         return _finalise_report(report)
 
+    validated_entries: dict[str, tuple[str, float, str]] = {}
+    for raw_rel, entry in entries.items():
+        try:
+            rel = _validate_ledger_page_path(raw_rel)
+            validated_entries[rel] = _validate_ledger_entry(entry)
+        except ValueError as exc:
+            report["errors"].append(
+                {"page": raw_rel, "issue": str(exc)}
+            )
+    if report["errors"]:
+        return _finalise_report(report)
+
     current: dict[str, Path] = {
-        str(page.relative_to(vault)): page for page in iter_trust_pages(vault)
+        page.relative_to(vault).as_posix(): page for page in iter_trust_pages(vault)
     }
     for rel, page in current.items():
-        if rel not in entries:
-            report["unreviewed"].append({"page": rel, "reason": "not_in_manual_ledger"})
-            continue
-        entry = entries[rel]
-        if not isinstance(entry, dict):
-            report["errors"].append({"page": rel, "issue": "invalid_ledger_entry"})
-            continue
-        fingerprint = entry.get("material_fingerprint")
-        reviewed_confidence = entry.get("reviewed_confidence")
-        reviewed_value = (
-            float(reviewed_confidence)
-            if isinstance(reviewed_confidence, (int, float))
-            and not isinstance(reviewed_confidence, bool)
-            else math.nan
-        )
-        valid_confidence = math.isfinite(reviewed_value) and 0.0 <= reviewed_value <= 1.0
-        valid_fingerprint = isinstance(fingerprint, str) and bool(
-            re.fullmatch(r"sha256:[0-9a-f]{64}", fingerprint)
-        )
-        if not valid_fingerprint or not valid_confidence:
-            report["errors"].append({"page": rel, "issue": "invalid_ledger_entry"})
-            continue
-        if page_fingerprint(page) != fingerprint:
-            report["stale"].append({"page": rel, "reason": "material_fingerprint_changed"})
-            continue
         try:
-            stored_confidence = _parse_confidence(page)
+            page_metadata = _trust_metadata(page)
+            stored_confidence = float(page_metadata["confidence"])
         except ValueError as exc:
             report["errors"].append({"page": rel, "issue": str(exc)})
+            continue
+        if rel not in validated_entries:
+            report["unreviewed"].append({"page": rel, "reason": "not_in_manual_ledger"})
+            continue
+        fingerprint, reviewed_value, reviewed_at = validated_entries[rel]
+        if page_fingerprint(page) != fingerprint:
+            report["stale"].append({"page": rel, "reason": "material_fingerprint_changed"})
             continue
         if abs(stored_confidence - reviewed_value) > 1e-9:
             report["score_mismatches"].append(
@@ -272,7 +498,7 @@ def check_trust_ledger(vault: Path, ledger_path: Path | None = None) -> dict[str
             {
                 "page": rel,
                 "reviewed_confidence": stored_confidence,
-                "reviewed_at": entry.get("reviewed_at", ledger.get("reviewed_at", "")),
+                "reviewed_at": reviewed_at,
             }
         )
 

--- a/obsidian_wiki/trust.py
+++ b/obsidian_wiki/trust.py
@@ -1,0 +1,293 @@
+"""Manual trust-review ledger for confidence linting.
+
+Confidence depends on semantic judgments that source-string heuristics cannot make:
+independent evidence lineages must be collapsed and material claim coverage must be
+reviewed.  This module therefore validates an approved review ledger instead of
+pretending to recompute confidence from URLs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+TRUST_LEDGER_RELATIVE_PATH = Path("_meta/trust-ledger.json")
+TRUST_LEDGER_SCHEMA_VERSION = 1
+TRUST_REVIEW_METHOD = "manual-lineage-and-claim-coverage-v1"
+TRUST_SKIP_DIRS = frozenset(
+    "_raw _archived _staging _archives _bootstrap .obsidian .git".split()
+)
+TRUST_RESERVED_STEMS = frozenset({"index", "log", "hot", "_insights"})
+_VOLATILE_CONFIDENCE_KEYS = frozenset(
+    {
+        "updated",
+        "base_confidence",
+        "lifecycle",
+        "lifecycle_changed",
+        "lifecycle_reason",
+        "superseded_by",
+    }
+)
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---(?:\n|$)", re.DOTALL)
+_TOP_LEVEL_FIELD_RE = re.compile(r"^([A-Za-z_][\w-]*):")
+_CONFIDENCE_RE = re.compile(r"^base_confidence:\s*([^#\n]+)", re.MULTILINE)
+_LIFECYCLE_RE = re.compile(r"^lifecycle:\s*([^#\n]+)", re.MULTILINE)
+
+
+def _normalise_text(text: str) -> str:
+    return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _frontmatter(text: str) -> str:
+    match = _FRONTMATTER_RE.match(_normalise_text(text))
+    return match.group(1) if match else ""
+
+
+def _strip_volatile_confidence_fields(frontmatter: str) -> str:
+    """Remove confidence/lifecycle bookkeeping while retaining material metadata."""
+    kept: list[str] = []
+    skipping = False
+    for line in frontmatter.splitlines():
+        field = _TOP_LEVEL_FIELD_RE.match(line)
+        if field:
+            skipping = field.group(1) in _VOLATILE_CONFIDENCE_KEYS
+        if not skipping:
+            kept.append(line.rstrip())
+    return "\n".join(kept).strip()
+
+
+def page_fingerprint(path: Path) -> str:
+    """Hash material claims and evidence, excluding volatile review bookkeeping."""
+    text = _normalise_text(path.read_text(encoding="utf-8", errors="replace"))
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        material = text.strip() + "\n"
+    else:
+        stable_frontmatter = _strip_volatile_confidence_fields(match.group(1))
+        body = text[match.end() :].strip()
+        material = f"---\n{stable_frontmatter}\n---\n{body}\n"
+    return "sha256:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _parse_confidence(path: Path) -> float:
+    match = _CONFIDENCE_RE.search(_frontmatter(path.read_text(encoding="utf-8", errors="replace")))
+    if not match:
+        raise ValueError("missing base_confidence")
+    try:
+        value = float(match.group(1).strip().strip("'\""))
+    except ValueError as exc:
+        raise ValueError("base_confidence is not numeric") from exc
+    if not 0.0 <= value <= 1.0:
+        raise ValueError("base_confidence is outside [0.0, 1.0]")
+    return value
+
+
+def iter_trust_pages(vault: Path) -> list[Path]:
+    """Return content pages carrying the confidence/lifecycle trust schema."""
+    pages: list[Path] = []
+    for path in vault.rglob("*.md"):
+        rel = path.relative_to(vault)
+        if any(part in TRUST_SKIP_DIRS for part in rel.parts):
+            continue
+        if path.stem in TRUST_RESERVED_STEMS:
+            continue
+        frontmatter = _frontmatter(path.read_text(encoding="utf-8", errors="replace"))
+        if _CONFIDENCE_RE.search(frontmatter) and _LIFECYCLE_RE.search(frontmatter):
+            pages.append(path)
+    return sorted(pages, key=lambda item: str(item.relative_to(vault)))
+
+
+def build_trust_ledger(vault: Path, *, reviewed_at: str) -> dict[str, Any]:
+    """Capture explicitly approved confidence values and material fingerprints."""
+    pages: dict[str, dict[str, Any]] = {}
+    for path in iter_trust_pages(vault):
+        rel = str(path.relative_to(vault))
+        pages[rel] = _review_entry(path, reviewed_at)
+    return {
+        "schema_version": TRUST_LEDGER_SCHEMA_VERSION,
+        "method": TRUST_REVIEW_METHOD,
+        "reviewed_at": reviewed_at,
+        "pages": pages,
+    }
+
+
+def _review_entry(path: Path, reviewed_at: str) -> dict[str, Any]:
+    return {
+        "reviewed_confidence": _parse_confidence(path),
+        "material_fingerprint": page_fingerprint(path),
+        "reviewed_at": reviewed_at,
+    }
+
+
+def update_trust_ledger(
+    vault: Path,
+    ledger_path: Path,
+    *,
+    reviewed_at: str,
+    page_paths: list[str],
+) -> dict[str, Any]:
+    """Update only explicitly reviewed pages while preserving every other entry."""
+    if ledger_path.is_file():
+        try:
+            ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise RuntimeError(f"cannot update unreadable trust ledger: {exc}") from exc
+        if not isinstance(ledger, dict):
+            raise RuntimeError("cannot update trust ledger: top level must be an object")
+        if ledger.get("schema_version") != TRUST_LEDGER_SCHEMA_VERSION:
+            raise RuntimeError("cannot update unsupported trust ledger schema")
+        if ledger.get("method") != TRUST_REVIEW_METHOD or not isinstance(ledger.get("pages"), dict):
+            raise RuntimeError("cannot update malformed trust ledger")
+    else:
+        ledger = {
+            "schema_version": TRUST_LEDGER_SCHEMA_VERSION,
+            "method": TRUST_REVIEW_METHOD,
+            "reviewed_at": reviewed_at,
+            "pages": {},
+        }
+
+    current = {str(path.relative_to(vault)): path for path in iter_trust_pages(vault)}
+    selected: list[str] = []
+    for raw in page_paths:
+        candidate = Path(raw)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            raise RuntimeError(f"trust page must be a safe vault-relative path: {raw}")
+        rel = candidate.as_posix().removeprefix("./")
+        page = current.get(rel)
+        if page is None:
+            raise RuntimeError(f"trust page is missing or lacks the trust schema: {raw}")
+        if rel not in selected:
+            selected.append(rel)
+            ledger["pages"][rel] = _review_entry(page, reviewed_at)
+    ledger["reviewed_at"] = reviewed_at
+    return ledger
+
+
+def write_trust_ledger(path: Path, ledger: dict[str, Any]) -> None:
+    """Write a ledger atomically with stable ordering."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(ledger, indent=2, sort_keys=True) + "\n"
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(payload, encoding="utf-8")
+    temporary.replace(path)
+
+
+def _empty_report(ledger_path: Path) -> dict[str, Any]:
+    return {
+        "status": "pass",
+        "ledger_path": str(ledger_path),
+        "reviewed": [],
+        "stale": [],
+        "unreviewed": [],
+        "score_mismatches": [],
+        "missing_pages": [],
+        "errors": [],
+        "counts": {},
+    }
+
+
+def check_trust_ledger(vault: Path, ledger_path: Path | None = None) -> dict[str, Any]:
+    """Validate current pages against an approved manual review ledger."""
+    path = ledger_path or vault / TRUST_LEDGER_RELATIVE_PATH
+    report = _empty_report(path)
+    try:
+        ledger = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        report["errors"].append({"issue": "ledger_missing", "path": str(path)})
+        return _finalise_report(report)
+    except (OSError, json.JSONDecodeError) as exc:
+        report["errors"].append({"issue": "ledger_unreadable", "detail": str(exc)})
+        return _finalise_report(report)
+
+    if not isinstance(ledger, dict):
+        report["errors"].append({"issue": "ledger_must_be_an_object"})
+        return _finalise_report(report)
+    if ledger.get("schema_version") != TRUST_LEDGER_SCHEMA_VERSION:
+        report["errors"].append(
+            {
+                "issue": "unsupported_schema_version",
+                "found": ledger.get("schema_version"),
+                "expected": TRUST_LEDGER_SCHEMA_VERSION,
+            }
+        )
+        return _finalise_report(report)
+    if ledger.get("method") != TRUST_REVIEW_METHOD:
+        report["errors"].append(
+            {"issue": "unsupported_review_method", "found": ledger.get("method")}
+        )
+        return _finalise_report(report)
+    entries = ledger.get("pages")
+    if not isinstance(entries, dict):
+        report["errors"].append({"issue": "pages_must_be_an_object"})
+        return _finalise_report(report)
+
+    current: dict[str, Path] = {
+        str(page.relative_to(vault)): page for page in iter_trust_pages(vault)
+    }
+    for rel, page in current.items():
+        if rel not in entries:
+            report["unreviewed"].append({"page": rel, "reason": "not_in_manual_ledger"})
+            continue
+        entry = entries[rel]
+        if not isinstance(entry, dict):
+            report["errors"].append({"page": rel, "issue": "invalid_ledger_entry"})
+            continue
+        fingerprint = entry.get("material_fingerprint")
+        reviewed_confidence = entry.get("reviewed_confidence")
+        reviewed_value = (
+            float(reviewed_confidence)
+            if isinstance(reviewed_confidence, (int, float))
+            and not isinstance(reviewed_confidence, bool)
+            else math.nan
+        )
+        valid_confidence = math.isfinite(reviewed_value) and 0.0 <= reviewed_value <= 1.0
+        valid_fingerprint = isinstance(fingerprint, str) and bool(
+            re.fullmatch(r"sha256:[0-9a-f]{64}", fingerprint)
+        )
+        if not valid_fingerprint or not valid_confidence:
+            report["errors"].append({"page": rel, "issue": "invalid_ledger_entry"})
+            continue
+        if page_fingerprint(page) != fingerprint:
+            report["stale"].append({"page": rel, "reason": "material_fingerprint_changed"})
+            continue
+        try:
+            stored_confidence = _parse_confidence(page)
+        except ValueError as exc:
+            report["errors"].append({"page": rel, "issue": str(exc)})
+            continue
+        if abs(stored_confidence - reviewed_value) > 1e-9:
+            report["score_mismatches"].append(
+                {
+                    "page": rel,
+                    "stored": stored_confidence,
+                    "reviewed": reviewed_value,
+                }
+            )
+            continue
+        report["reviewed"].append(
+            {
+                "page": rel,
+                "reviewed_confidence": stored_confidence,
+                "reviewed_at": entry.get("reviewed_at", ledger.get("reviewed_at", "")),
+            }
+        )
+
+    for rel in sorted(set(entries) - set(current)):
+        report["missing_pages"].append({"page": rel, "reason": "reviewed_page_missing"})
+    return _finalise_report(report)
+
+
+def _finalise_report(report: dict[str, Any]) -> dict[str, Any]:
+    keys = ("reviewed", "stale", "unreviewed", "score_mismatches", "missing_pages", "errors")
+    report["counts"] = {key: len(report[key]) for key in keys}
+    if report["errors"] or report["score_mismatches"]:
+        report["status"] = "fail"
+    elif report["stale"] or report["unreviewed"] or report["missing_pages"]:
+        report["status"] = "warn"
+    else:
+        report["status"] = "pass"
+    return report

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -70,6 +70,8 @@ def test_lint_vault_passes_clean_graph(tmp_path: Path) -> None:
     _page(vault, "hot.md", links=["alpha"])
     _page(vault, "concepts/alpha.md", links=["beta"])
     _page(vault, "concepts/beta.md", links=["alpha"])
+    ledger = build_trust_ledger(vault, reviewed_at="2026-07-12T17:38:39+07:00")
+    write_trust_ledger(vault / "_meta" / "trust-ledger.json", ledger, vault=vault)
 
     report = lint_vault(vault)
 
@@ -94,6 +96,8 @@ def test_lint_vault_warns_on_duplicates_missing_summaries_and_orphans(tmp_path: 
     vault = tmp_path / "vault"
     _page(vault, "concepts/alpha.md", title="Same Title", summary=None)
     _page(vault, "references/beta.md", title="Same Title")
+    ledger = build_trust_ledger(vault, reviewed_at="2026-07-12T17:38:39+07:00")
+    write_trust_ledger(vault / "_meta" / "trust-ledger.json", ledger, vault=vault)
 
     report = lint_vault(vault)
 

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -9,6 +9,7 @@ import sys
 from pathlib import Path
 
 from obsidian_wiki.lint import lint_vault
+from obsidian_wiki.trust import build_trust_ledger, write_trust_ledger
 
 
 def _page(
@@ -37,6 +38,8 @@ def _page(
                 f"sources: {sources}",
                 f"created: {created}",
                 f"updated: {updated}",
+                "base_confidence: 0.80",
+                "lifecycle: reviewed",
             ]
         )
         if summary is not None:
@@ -108,6 +111,8 @@ def test_lint_cli_uses_configured_vault_and_strict_mode(tmp_path: Path) -> None:
     config_dir = home / ".obsidian-wiki"
     config_dir.mkdir(parents=True, exist_ok=True)
     (config_dir / "config").write_text(f'OBSIDIAN_VAULT_PATH="{vault}"\n', encoding="utf-8")
+    ledger = build_trust_ledger(vault, reviewed_at="2026-07-12T17:38:39+07:00")
+    write_trust_ledger(vault / "_meta" / "trust-ledger.json", ledger)
 
     proc = _run(home, "lint", "--json", "--strict")
 

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -1,0 +1,349 @@
+"""Regression tests for manually reviewed confidence and relationship linting."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from obsidian_wiki.lint import lint_vault
+from obsidian_wiki.trust import build_trust_ledger, check_trust_ledger, write_trust_ledger
+
+
+def _page(
+    vault: Path,
+    relpath: str,
+    *,
+    confidence: float = 0.80,
+    updated: str = "2026-07-12T17:38:39+07:00",
+    body: str = "Reviewed material claim.",
+    relationships: list[tuple[str, str]] | None = None,
+) -> Path:
+    path = vault / relpath
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "---",
+        f"title: {path.stem}",
+        f"category: {path.parts[-2] if len(path.parts) > 1 else 'concepts'}",
+        "tags: [test]",
+        "sources:",
+        "  - github.com/example/repo@0123456789abcdef0123456789abcdef01234567",
+        "created: 2026-07-01",
+        f"updated: {updated}",
+        f"base_confidence: {confidence:.2f}",
+        "lifecycle: reviewed",
+    ]
+    if relationships:
+        lines.append("relationships:")
+        for relation_type, target in relationships:
+            lines.extend([f"  - type: {relation_type}", f'    target: "[[{target}]]"'])
+    lines.extend(["---", f"# {path.stem}", "", body, ""])
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _write_ledger(vault: Path) -> Path:
+    ledger = build_trust_ledger(vault, reviewed_at="2026-07-12T17:38:39+07:00")
+    path = vault / "_meta" / "trust-ledger.json"
+    write_trust_ledger(path, ledger)
+    return path
+
+
+def _run_cli(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, "-m", "obsidian_wiki.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_reviewed_ledger_is_authoritative_instead_of_reclassifying_sources(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", confidence=0.53)
+    _page(vault, "skills/beta.md", confidence=0.80)
+    ledger_path = _write_ledger(vault)
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "pass"
+    assert report["counts"] == {
+        "reviewed": 2,
+        "stale": 0,
+        "unreviewed": 0,
+        "score_mismatches": 0,
+        "missing_pages": 0,
+        "errors": 0,
+    }
+    assert {item["page"] for item in report["reviewed"]} == {
+        "concepts/alpha.md",
+        "skills/beta.md",
+    }
+
+
+def test_claim_change_invalidates_review_but_updated_timestamp_does_not(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md", confidence=0.53)
+    ledger_path = _write_ledger(vault)
+
+    page.write_text(page.read_text().replace("updated: 2026-07-12T17:38:39+07:00", "updated: 2026-07-13T09:00:00+07:00"))
+    assert check_trust_ledger(vault, ledger_path)["counts"]["reviewed"] == 1
+
+    page.write_text(page.read_text().replace("Reviewed material claim.", "Changed material claim."))
+    report = check_trust_ledger(vault, ledger_path)
+    assert report["status"] == "warn"
+    assert report["stale"] == [{"page": "concepts/alpha.md", "reason": "material_fingerprint_changed"}]
+
+
+def test_confidence_change_is_reported_as_score_mismatch_not_stale_review(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md", confidence=0.53)
+    ledger_path = _write_ledger(vault)
+
+    page.write_text(page.read_text().replace("base_confidence: 0.53", "base_confidence: 0.88"))
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["stale"] == []
+    assert report["score_mismatches"] == [
+        {"page": "concepts/alpha.md", "stored": 0.88, "reviewed": 0.53}
+    ]
+
+
+def test_new_page_requires_manual_review_instead_of_formula_guess(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    _page(vault, "concepts/new.md", confidence=0.95)
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "warn"
+    assert report["unreviewed"] == [{"page": "concepts/new.md", "reason": "not_in_manual_ledger"}]
+
+
+def test_non_object_ledger_fails_cleanly(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = vault / "_meta" / "trust-ledger.json"
+    ledger_path.parent.mkdir(parents=True)
+    ledger_path.write_text("[]\n")
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [{"issue": "ledger_must_be_an_object"}]
+
+
+def test_out_of_range_reviewed_confidence_is_invalid_ledger_data(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    ledger = json.loads(ledger_path.read_text())
+    ledger["pages"]["concepts/alpha.md"]["reviewed_confidence"] = 2.0
+    ledger_path.write_text(json.dumps(ledger))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [{"page": "concepts/alpha.md", "issue": "invalid_ledger_entry"}]
+
+
+def test_non_object_page_entry_is_invalid_not_unreviewed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    ledger = json.loads(ledger_path.read_text())
+    ledger["pages"]["concepts/alpha.md"] = []
+    ledger_path.write_text(json.dumps(ledger))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["unreviewed"] == []
+    assert report["errors"] == [{"page": "concepts/alpha.md", "issue": "invalid_ledger_entry"}]
+
+
+def test_lint_vault_surfaces_manual_trust_status_without_formula_drift(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", confidence=0.53, relationships=[("related_to", "skills/beta")])
+    _page(vault, "skills/beta.md", confidence=0.80, relationships=[("related_to", "concepts/alpha")])
+    _write_ledger(vault)
+
+    report = lint_vault(vault)
+
+    assert report["findings"]["confidence_review_stale"] == []
+    assert report["findings"]["confidence_unreviewed"] == []
+    assert report["findings"]["confidence_mismatches"] == []
+    assert report["findings"]["typed_relationship_issues"] == []
+    assert report["stats"]["trust"]["reviewed"] == 2
+
+
+def test_typed_relationship_resolver_uses_exact_vault_paths(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "projects/demo/alpha.md", relationships=[("implements", "projects/demo/beta")])
+    _page(vault, "projects/demo/beta.md", relationships=[("related_to", "projects/demo/alpha")])
+    _page(vault, "concepts/broken.md", relationships=[("related_to", "skills/missing")])
+
+    report = lint_vault(vault)
+
+    assert report["findings"]["typed_relationship_issues"] == [
+        {
+            "page": "concepts/broken.md",
+            "index": 0,
+            "issue": "missing_target",
+            "target": "skills/missing",
+        }
+    ]
+
+
+def test_lint_excludes_bootstrap_scaffolding_from_page_health(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", relationships=[("related_to", "concepts/beta")])
+    _page(vault, "concepts/beta.md", relationships=[("related_to", "concepts/alpha")])
+    bootstrap = vault / "_bootstrap" / "README.md"
+    bootstrap.parent.mkdir(parents=True)
+    bootstrap.write_text("# Setup instructions\n")
+
+    report = lint_vault(vault)
+
+    serialized = json.dumps(report)
+    assert "_bootstrap/README.md" not in serialized
+
+
+def test_lint_flags_content_page_missing_trust_schema(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(
+        "\n".join(
+            line
+            for line in page.read_text().splitlines()
+            if not line.startswith(("base_confidence:", "lifecycle:"))
+        )
+        + "\n"
+    )
+
+    report = lint_vault(vault)
+
+    assert report["status"] == "fail"
+    assert report["findings"]["missing_frontmatter"] == [
+        {"page": "concepts/alpha.md", "missing": ["base_confidence", "lifecycle"]}
+    ]
+
+
+def test_required_trust_ledger_fails_closed_when_missing(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+
+    report = lint_vault(vault, require_trust_ledger=True)
+
+    assert report["status"] == "fail"
+    assert report["findings"]["confidence_ledger_errors"] == [
+        {"issue": "ledger_missing", "path": str(vault / "_meta" / "trust-ledger.json")}
+    ]
+
+
+def test_trust_record_cli_requires_explicit_approval(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+
+    proc = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--all",
+        "--reviewed-at",
+        "2026-07-12T17:38:39+07:00",
+        "--json",
+    )
+
+    assert proc.returncode == 2
+    assert "--approved" in proc.stderr
+    assert not (vault / "_meta" / "trust-ledger.json").exists()
+
+
+def test_trust_record_and_check_cli_round_trip(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", confidence=0.53)
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--all",
+        "--reviewed-at",
+        "2026-07-12T17:38:39+07:00",
+        "--approved",
+        "--json",
+    )
+    check = _run_cli(home, "trust-check", str(vault), "--json")
+
+    assert record.returncode == 0, record.stderr
+    assert json.loads(record.stdout)["recorded_pages"] == 1
+    assert check.returncode == 0, check.stderr
+    payload = json.loads(check.stdout)
+    assert payload["status"] == "pass"
+    assert payload["counts"]["reviewed"] == 1
+
+
+def test_partial_trust_record_does_not_approve_other_stale_pages(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    alpha = _page(vault, "concepts/alpha.md", confidence=0.53)
+    beta = _page(vault, "skills/beta.md", confidence=0.80)
+    _write_ledger(vault)
+    alpha.write_text(alpha.read_text().replace("Reviewed material claim.", "Reviewed alpha change."))
+    beta.write_text(beta.read_text().replace("Reviewed material claim.", "Unreviewed beta change."))
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--page",
+        "concepts/alpha.md",
+        "--reviewed-at",
+        "2026-07-13T09:00:00+07:00",
+        "--approved",
+        "--json",
+    )
+    check = _run_cli(home, "trust-check", str(vault), "--json")
+
+    assert record.returncode == 0, record.stderr
+    assert json.loads(record.stdout)["recorded_pages"] == 1
+    payload = json.loads(check.stdout)
+    assert payload["counts"]["reviewed"] == 1
+    assert payload["stale"] == [
+        {"page": "skills/beta.md", "reason": "material_fingerprint_changed"}
+    ]
+
+
+def test_partial_trust_record_reports_malformed_ledger_without_traceback(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = vault / "_meta" / "trust-ledger.json"
+    ledger_path.parent.mkdir(parents=True)
+    ledger_path.write_text("[]\n")
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--page",
+        "concepts/alpha.md",
+        "--reviewed-at",
+        "2026-07-13T09:00:00+07:00",
+        "--approved",
+        "--json",
+    )
+
+    assert record.returncode == 1
+    assert "error: cannot update trust ledger" in record.stderr
+    assert "Traceback" not in record.stderr
+    assert ledger_path.read_text() == "[]\n"

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -171,6 +171,39 @@ def test_invalid_lifecycle_fails_closed(tmp_path: Path) -> None:
     ]
 
 
+def test_mismatched_scalar_quotes_fail_closed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    page.write_text(page.read_text().replace("lifecycle: reviewed", 'lifecycle: "reviewed\''))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [
+        {"page": "concepts/alpha.md", "issue": 'invalid lifecycle: "reviewed\''}
+    ]
+
+
+def test_invalid_updated_timestamp_fails_before_fingerprint_match(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    page.write_text(
+        page.read_text().replace(
+            "updated: 2026-07-12T17:38:39+07:00",
+            "updated: definitely-not-a-timestamp",
+        )
+    )
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [
+        {"page": "concepts/alpha.md", "issue": "updated is not an ISO-8601 date or timestamp"}
+    ]
+
+
 def test_inline_comments_on_scalar_trust_fields_remain_valid(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     page = _page(vault, "concepts/alpha.md")
@@ -529,6 +562,50 @@ def test_target_first_relationship_order_is_parsed_and_validated(tmp_path: Path)
     ]
 
 
+def test_dash_only_relationship_item_is_parsed_and_validated(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(
+        page.read_text().replace(
+            "lifecycle: reviewed",
+            'lifecycle: reviewed\nrelationships:\n  -\n    target: "[[skills/missing]]"\n    type: related_to',
+        )
+    )
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["typed_relationship_issues"] == [
+        {
+            "page": "concepts/alpha.md",
+            "index": 0,
+            "issue": "missing_target",
+            "target": "skills/missing",
+        }
+    ]
+
+
+def test_unknown_relationship_field_fails_closed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    _page(vault, "skills/beta.md")
+    page.write_text(
+        page.read_text().replace(
+            "lifecycle: reviewed",
+            'lifecycle: reviewed\nrelationships:\n  - target: "[[skills/beta]]"\n    type: related_to\n    weight: 5',
+        )
+    )
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["typed_relationship_issues"] == [
+        {
+            "page": "concepts/alpha.md",
+            "index": 0,
+            "issue": "malformed_relationship_entry",
+        }
+    ]
+
+
 def test_basename_only_relationship_is_rejected_when_ambiguous(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     _page(vault, "concepts/alpha.md", relationships=[("related_to", "beta")])
@@ -543,6 +620,24 @@ def test_basename_only_relationship_is_rejected_when_ambiguous(tmp_path: Path) -
             "index": 0,
             "issue": "ambiguous_target",
             "target": "beta",
+        }
+    ]
+
+
+def test_qualified_relationship_is_ambiguous_when_normalized_paths_collide(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", relationships=[("related_to", "skills/foo-bar")])
+    _page(vault, "skills/Foo Bar.md")
+    _page(vault, "skills/foo-bar.md")
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["typed_relationship_issues"] == [
+        {
+            "page": "concepts/alpha.md",
+            "index": 0,
+            "issue": "ambiguous_target",
+            "target": "skills/foo-bar",
         }
     ]
 

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -99,12 +99,100 @@ def test_claim_change_invalidates_review_but_updated_timestamp_does_not(tmp_path
     assert report["stale"] == [{"page": "concepts/alpha.md", "reason": "material_fingerprint_changed"}]
 
 
-def test_confidence_change_is_reported_as_score_mismatch_not_stale_review(tmp_path: Path) -> None:
+def test_material_change_marks_review_stale(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     page = _page(vault, "concepts/alpha.md", confidence=0.53)
     ledger_path = _write_ledger(vault)
+    page.write_text(page.read_text().replace("Reviewed material claim.", "Changed material claim."))
 
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "warn"
+    assert report["stale"] == [
+        {"page": "concepts/alpha.md", "reason": "material_fingerprint_changed"}
+    ]
+
+
+def test_duplicate_confidence_field_fails_instead_of_bypassing_fingerprint(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md", confidence=0.53)
+    ledger_path = _write_ledger(vault)
+    page.write_text(page.read_text().replace("lifecycle: reviewed", "base_confidence: 0.99\nlifecycle: reviewed"))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [
+        {"page": "concepts/alpha.md", "issue": "duplicate top-level field: base_confidence"}
+    ]
+
+
+def test_volatile_field_with_nested_content_fails_closed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    page.write_text(page.read_text().replace("updated: 2026-07-12T17:38:39+07:00", "updated: 2026-07-12T17:38:39+07:00\n  hidden: material"))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [
+        {"page": "concepts/alpha.md", "issue": "updated must be a scalar"}
+    ]
+
+
+def test_invalid_confidence_is_checked_before_stale_short_circuit(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    changed = page.read_text().replace("Reviewed material claim.", "Changed material claim.")
+    page.write_text(changed.replace("base_confidence: 0.80", "base_confidence: nan"))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["stale"] == []
+    assert report["errors"] == [
+        {"page": "concepts/alpha.md", "issue": "base_confidence is not finite"}
+    ]
+
+
+def test_invalid_lifecycle_fails_closed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    page.write_text(page.read_text().replace("lifecycle: reviewed", "lifecycle: totally-invalid"))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [
+        {"page": "concepts/alpha.md", "issue": "invalid lifecycle: totally-invalid"}
+    ]
+
+
+def test_inline_comments_on_scalar_trust_fields_remain_valid(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(
+        page.read_text()
+        .replace("base_confidence: 0.80", "base_confidence: 0.80 # reviewed score")
+        .replace("lifecycle: reviewed", "lifecycle: reviewed # human-reviewed")
+    )
+
+    ledger_path = _write_ledger(vault)
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "pass"
+    assert report["counts"]["reviewed"] == 1
+
+
+def test_score_only_change_is_a_failing_mismatch_not_stale(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md", confidence=0.53)
+    ledger_path = _write_ledger(vault)
     page.write_text(page.read_text().replace("base_confidence: 0.53", "base_confidence: 0.88"))
+
     report = check_trust_ledger(vault, ledger_path)
 
     assert report["status"] == "fail"
@@ -126,6 +214,49 @@ def test_new_page_requires_manual_review_instead_of_formula_guess(tmp_path: Path
     assert report["unreviewed"] == [{"page": "concepts/new.md", "reason": "not_in_manual_ledger"}]
 
 
+def test_standalone_trust_check_fails_for_page_missing_trust_fields(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(
+        "\n".join(
+            line
+            for line in page.read_text().splitlines()
+            if not line.startswith(("base_confidence:", "lifecycle:"))
+        )
+        + "\n"
+    )
+    ledger_path = vault / "_meta" / "trust-ledger.json"
+    write_trust_ledger(
+        ledger_path,
+        {
+            "schema_version": 1,
+            "method": "manual-lineage-and-claim-coverage-v1",
+            "reviewed_at": "2026-07-12T17:38:39+07:00",
+            "pages": {},
+        },
+        vault=vault,
+    )
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [
+        {"page": "concepts/alpha.md", "issue": "missing base_confidence"}
+    ]
+
+
+def test_lint_vault_requires_trust_ledger_by_default(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+
+    report = lint_vault(vault)
+
+    assert report["status"] == "fail"
+    assert report["findings"]["confidence_ledger_errors"] == [
+        {"issue": "ledger_missing", "path": str(vault / "_meta" / "trust-ledger.json")}
+    ]
+
+
 def test_non_object_ledger_fails_cleanly(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     _page(vault, "concepts/alpha.md")
@@ -139,12 +270,186 @@ def test_non_object_ledger_fails_cleanly(tmp_path: Path) -> None:
     assert report["errors"] == [{"issue": "ledger_must_be_an_object"}]
 
 
+def test_duplicate_json_keys_are_rejected(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    text = ledger_path.read_text()
+    ledger_path.write_text(text.replace('"schema_version": 1', '"schema_version": 1, "schema_version": 1'))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"][0]["issue"] == "ledger_unreadable"
+    assert "duplicate JSON key" in report["errors"][0]["detail"]
+
+
+def test_boolean_schema_version_fails_closed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    ledger = json.loads(ledger_path.read_text())
+    ledger["schema_version"] = True
+    ledger_path.write_text(json.dumps(ledger))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"][0]["issue"] == "unsupported_schema_version"
+
+
+def test_invalid_utf8_ledger_returns_structured_failure(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = vault / "_meta" / "trust-ledger.json"
+    ledger_path.parent.mkdir(parents=True)
+    ledger_path.write_bytes(b"\xff\xfe")
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"][0]["issue"] == "ledger_unreadable"
+
+
+def test_invalid_review_timestamp_is_rejected_by_record_cli(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--all",
+        "--reviewed-at",
+        "not-an-iso-timestamp",
+        "--approved",
+        "--json",
+    )
+
+    assert record.returncode == 1
+    assert "reviewed_at must be an ISO-8601 timestamp with timezone" in record.stderr
+    assert "Traceback" not in record.stderr
+    assert not (vault / "_meta" / "trust-ledger.json").exists()
+
+
+def test_invalid_ledger_review_timestamp_fails_closed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    ledger = json.loads(ledger_path.read_text())
+    ledger["reviewed_at"] = "yesterday"
+    ledger_path.write_text(json.dumps(ledger))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [{"issue": "invalid_reviewed_at"}]
+
+
+def test_trust_writer_rejects_symlinked_meta_directory(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    outside = tmp_path / "outside"
+    vault.mkdir()
+    outside.mkdir()
+    (vault / "_meta").symlink_to(outside, target_is_directory=True)
+    ledger = {"schema_version": 1, "method": "manual-lineage-and-claim-coverage-v1", "pages": {}}
+
+    try:
+        write_trust_ledger(vault / "_meta" / "trust-ledger.json", ledger, vault=vault)
+    except RuntimeError as exc:
+        assert "outside the resolved vault" in str(exc) or "symlink" in str(exc)
+    else:
+        raise AssertionError("symlinked _meta directory was accepted")
+
+    assert not (outside / "trust-ledger.json").exists()
+
+
+def test_trust_writer_never_follows_predictable_temp_symlink(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    meta = vault / "_meta"
+    meta.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("sentinel\n")
+    (meta / "trust-ledger.json.tmp").symlink_to(outside)
+    ledger = {"schema_version": 1, "method": "manual-lineage-and-claim-coverage-v1", "pages": {}}
+
+    write_trust_ledger(meta / "trust-ledger.json", ledger, vault=vault)
+
+    assert outside.read_text() == "sentinel\n"
+    assert json.loads((meta / "trust-ledger.json").read_text())["schema_version"] == 1
+
+
+def test_trust_writer_rejects_symlinked_ledger_destination(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    meta = vault / "_meta"
+    meta.mkdir(parents=True)
+    outside = tmp_path / "outside.txt"
+    outside.write_text("sentinel\n")
+    destination = meta / "trust-ledger.json"
+    destination.symlink_to(outside)
+    ledger = {"schema_version": 1, "method": "manual-lineage-and-claim-coverage-v1", "pages": {}}
+
+    try:
+        write_trust_ledger(destination, ledger, vault=vault)
+    except RuntimeError as exc:
+        assert "outside the resolved vault" in str(exc) or "symlink" in str(exc)
+    else:
+        raise AssertionError("symlinked ledger destination was accepted")
+
+    assert outside.read_text() == "sentinel\n"
+
+
 def test_out_of_range_reviewed_confidence_is_invalid_ledger_data(tmp_path: Path) -> None:
     vault = tmp_path / "vault"
     _page(vault, "concepts/alpha.md")
     ledger_path = _write_ledger(vault)
     ledger = json.loads(ledger_path.read_text())
     ledger["pages"]["concepts/alpha.md"]["reviewed_confidence"] = 2.0
+    ledger_path.write_text(json.dumps(ledger))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [{"page": "concepts/alpha.md", "issue": "invalid_ledger_entry"}]
+
+
+def test_boolean_reviewed_confidence_is_invalid_ledger_data(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    ledger = json.loads(ledger_path.read_text())
+    ledger["pages"]["concepts/alpha.md"]["reviewed_confidence"] = True
+    ledger_path.write_text(json.dumps(ledger))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [{"page": "concepts/alpha.md", "issue": "invalid_ledger_entry"}]
+
+
+def test_non_standard_json_number_is_unreadable_not_approved(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    ledger = json.loads(ledger_path.read_text())
+    ledger["pages"]["concepts/alpha.md"]["reviewed_confidence"] = float("nan")
+    ledger_path.write_text(json.dumps(ledger))
+
+    report = check_trust_ledger(vault, ledger_path)
+
+    assert report["status"] == "fail"
+    assert report["errors"][0]["issue"] == "ledger_unreadable"
+
+
+def test_malformed_fingerprint_and_entry_timestamp_fail_closed(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    ledger = json.loads(ledger_path.read_text())
+    entry = ledger["pages"]["concepts/alpha.md"]
+    entry["material_fingerprint"] = "garbage"
+    entry["reviewed_at"] = "yesterday"
     ledger_path.write_text(json.dumps(ledger))
 
     report = check_trust_ledger(vault, ledger_path)
@@ -189,7 +494,7 @@ def test_typed_relationship_resolver_uses_exact_vault_paths(tmp_path: Path) -> N
     _page(vault, "projects/demo/beta.md", relationships=[("related_to", "projects/demo/alpha")])
     _page(vault, "concepts/broken.md", relationships=[("related_to", "skills/missing")])
 
-    report = lint_vault(vault)
+    report = lint_vault(vault, require_trust_ledger=False)
 
     assert report["findings"]["typed_relationship_issues"] == [
         {
@@ -199,6 +504,57 @@ def test_typed_relationship_resolver_uses_exact_vault_paths(tmp_path: Path) -> N
             "target": "skills/missing",
         }
     ]
+
+
+def test_target_first_relationship_order_is_parsed_and_validated(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    _page(vault, "skills/beta.md")
+    page.write_text(
+        page.read_text().replace(
+            "lifecycle: reviewed",
+            'lifecycle: reviewed\nrelationships:\n  - target: "[[skills/missing]]"\n    type: related_to',
+        )
+    )
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["typed_relationship_issues"] == [
+        {
+            "page": "concepts/alpha.md",
+            "index": 0,
+            "issue": "missing_target",
+            "target": "skills/missing",
+        }
+    ]
+
+
+def test_basename_only_relationship_is_rejected_when_ambiguous(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", relationships=[("related_to", "beta")])
+    _page(vault, "skills/beta.md")
+    _page(vault, "projects/demo/beta.md")
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["typed_relationship_issues"] == [
+        {
+            "page": "concepts/alpha.md",
+            "index": 0,
+            "issue": "ambiguous_target",
+            "target": "beta",
+        }
+    ]
+
+
+def test_empty_inline_relationship_list_is_valid(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("lifecycle: reviewed", "lifecycle: reviewed\nrelationships: []"))
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["typed_relationship_issues"] == []
 
 
 def test_lint_excludes_bootstrap_scaffolding_from_page_health(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- replace source-string confidence recomputation with a human-approved trust ledger
- fingerprint material page content and evidence while excluding validated volatile confidence/lifecycle bookkeeping
- make CLI and direct `lint_vault()` calls fail closed when the trust ledger is missing or malformed
- distinguish stale pages, unreviewed pages, and score mismatches
- support approval-gated full and partial trust recording without clearing unrelated stale entries
- validate exact typed-relationship targets independent of YAML key order and reject ambiguous basenames
- exclude reserved/bootstrap/VCS scaffolding from content-health findings
- update `wiki-lint`, `llm-wiki`, and README guidance to forbid automatic confidence rewrites

## Why

Independent evidence lineages and whole-page claim coverage are semantic judgments. Counting source strings overstates confidence when multiple records come from the same repository, task chain, snapshot origin, or conversation. A deterministic classifier should validate an approved review, not pretend to reproduce that judgment from URLs.

## Safety model

- `trust-record` requires both `--approved` and an explicit `--all` or repeatable `--page` selection.
- Partial recording updates only selected pages and preserves unrelated stale entries.
- All non-reserved content pages participate in trust coverage, including pages missing required trust fields.
- Ledger JSON rejects duplicate keys, non-object roots/entries, non-standard numbers, booleans, invalid paths, invalid timestamps, malformed fingerprints, and unsupported schema/method values.
- Frontmatter rejects duplicate trust keys, nested data under excluded volatile keys, invalid confidence/lifecycle values, malformed `updated` dates/timestamps, and malformed UTF-8.
- Material changes become stale; score-only changes become failing mismatches.
- Ledger writes reject symlinked parents/destinations and use random exclusive temporary files; POSIX writes use directory file descriptors and `O_NOFOLLOW`.
- `lint_vault()` requires the ledger by default; `trust-check --strict` is documented for CI and scheduled gates.
- `--approved` is explicitly documented as a workflow assertion rather than a cryptographic signature; ledger diffs remain version-controlled and human-reviewed.
- Automatic confidence changes and automatic `trust-record` execution are explicitly prohibited.

## Test plan

- [x] `python3 -m pytest -q` — 208 passed, 11 subtests passed
- [x] targeted Ruff checks for trust/lint implementation and tests
- [x] `python3 -m compileall -q obsidian_wiki tests`
- [x] `git diff --check`
- [x] wheel build includes `obsidian_wiki/trust.py` and `obsidian_wiki/lint.py`
- [x] adversarial tests: symlinked `_meta`/destination/temp, duplicate/nested frontmatter, duplicate JSON keys, NaN/boolean/out-of-range scores, malformed `updated`/review timestamps, fingerprints, paths and UTF-8, missing trust fields, target-first and dash-only relationships, unknown relationship fields, ambiguous basenames, and normalized qualified-path collisions
- [x] live 44-page vault: 44 reviewed, 0 stale/unreviewed/mismatch/errors
- [x] live deterministic lint: all finding counts 0
- [x] fresh independent read-only adversarial review: passed, 0 security concerns, 0 logic errors

## Compatibility

Trust enforcement is now fail closed by default for both CLI and direct `lint_vault()` callers. Callers performing isolated structural checks without an approved ledger must opt out explicitly with `require_trust_ledger=False`.
