### PR TITLE
docs(wiki-ingest): fix Step 7 manifest schema drift from cache.py (#135)

### DIFF
--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -428,17 +428,14 @@ After writing pages, check that wikilinks work in both directions. If page A lin
 **`.manifest.json`** — For each source file ingested, add or update its entry:
 ```json
 {
-  "ingested_at": "TIMESTAMP",
-  "size_bytes": FILE_SIZE,
-  "modified_at": FILE_MTIME,
   "content_hash": "sha256:<64-char-hex>",
+  "last_ingested": "TIMESTAMP",
+  "pages_produced": ["list/of/pages.md"],
   "source_type": "document",  // or "image" for png/jpg/webp/gif and image-only PDFs; "data" for chat/log/CSV/JSON sources
-  "project": "project-name-or-null",
-  "pages_created": ["list/of/pages.md"],
-  "pages_updated": ["list/of/pages.md"]
+  "project": "project-name-or-null"
 }
 ```
-`content_hash` is the SHA-256 of the file contents at ingest time. Always write it — it's the primary skip signal on subsequent runs.
+`content_hash`, `last_ingested`, and `pages_produced` are the three fields `cache.py` reads and writes (`cache-check` / `cache-update`) — the field names must match exactly or incremental-skip detection breaks. `content_hash` is the SHA-256 of the file contents at ingest time; it's the primary skip signal on subsequent runs, so always write it. `source_type` and `project` are advisory metadata for your own bookkeeping — the cache layer doesn't read them.
 
 Also update `stats.total_sources_ingested` and `stats.total_pages`.
 


### PR DESCRIPTION
Fixes #135. Thanks @gujialind for the detailed report — the field-by-field table and the tag-pinned evidence made this a quick fix.

## What was wrong

Step 7 of `.skills/wiki-ingest/SKILL.md` documented manifest fields that `obsidian_wiki/cache.py` never reads:

- `ingested_at` → the code writes `last_ingested`
- `pages_created` → the code writes `pages_produced`
- `pages_updated`, `size_bytes`, `modified_at` → no writer in code or CLI

An agent following the doc wrote the wrong keys. On the next run `cache-check` compared against `content_hash`/`last_ingested`/`pages_produced`, found the entry incomplete, and re-ingested the source — the skip signal was dead.

## The fix

I aligned the docs to the code, since `tests/test_cache.py` already pins the code as correct:

- Renamed `ingested_at` → `last_ingested` and `pages_created` → `pages_produced`.
- Dropped `pages_updated`, `size_bytes`, and `modified_at` (nothing persists them).
- Marked `source_type` and `project` as advisory metadata the cache layer ignores.

Docs-only change; no code behavior moves. Left the `pages_updated=N pages_created=M` wording in the `log.md` line format alone, since that's the human-readable activity log, not the manifest schema.
