### PR TITLE
feat(skills): snapshot vault before destructive writes

### DIFF
--- a/.skills/cross-linker/SKILL.md
+++ b/.skills/cross-linker/SKILL.md
@@ -97,13 +97,40 @@ Only act on **EXTRACTED** and **INFERRED** candidates. Include the confidence la
 
 ## Step 4: Apply Links
 
-**Pre-write snapshot** — before the first file write, check `git -C "$OBSIDIAN_VAULT_PATH" rev-parse --is-inside-work-tree`. If the vault is not a git repo, skip this step silently — no nagging, no suggesting `git init`. If it is, snapshot it:
+**Pre-write snapshot** — before the first file write, check whether the vault itself is the root of a Git repository. Merely being a subdirectory of a larger repository does not qualify: running `git add -A` there could capture unrelated files. If the vault is not a standalone Git repository, skip this step silently — no nagging, no suggesting `git init`.
 
 ```bash
-git -C "$OBSIDIAN_VAULT_PATH" add -A && git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-cross-linker snapshot" --quiet
+VAULT_REAL_PATH=$(cd "$OBSIDIAN_VAULT_PATH" && pwd -P)
+VAULT_GIT_ROOT=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse --show-toplevel 2>/dev/null || true)
+SNAPSHOT_SHA=""
+
+if [ -n "$VAULT_GIT_ROOT" ] && [ "$VAULT_GIT_ROOT" = "$VAULT_REAL_PATH" ]; then
+  if git -C "$OBSIDIAN_VAULT_PATH" diff --quiet \
+    && git -C "$OBSIDIAN_VAULT_PATH" diff --cached --quiet \
+    && [ -z "$(git -C "$OBSIDIAN_VAULT_PATH" ls-files --others --exclude-standard)" ]; then
+    SNAPSHOT_SHA=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse HEAD)
+  else
+    if ! git -C "$OBSIDIAN_VAULT_PATH" add -A; then
+      echo "Pre-write snapshot failed; abort the skill without writing any vault files." >&2
+      exit 1
+    fi
+    if ! git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-cross-linker snapshot" --quiet; then
+      echo "Pre-write snapshot failed; abort the skill without writing any vault files." >&2
+      exit 1
+    fi
+    SNAPSHOT_SHA=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse HEAD)
+  fi
+fi
 ```
 
-A "nothing to commit" result is fine — the vault was already clean. If a snapshot commit was made, mention it in your final report so the user knows the run can be undone with `git -C "$OBSIDIAN_VAULT_PATH" revert` (or `reset`).
+The clean-repository branch deliberately avoids calling `git commit`, so "nothing to commit" is not treated as an error. If `git add` or `git commit` fails, stop before editing the vault; never continue without the promised snapshot.
+
+If `SNAPSHOT_SHA` is non-empty and the skill writes files, include the SHA in the final report. To discard the entire run, after confirming there are no later changes worth keeping, the user can run:
+
+```bash
+git -C "$OBSIDIAN_VAULT_PATH" reset --hard "$SNAPSHOT_SHA"
+git -C "$OBSIDIAN_VAULT_PATH" clean -fd
+```
 
 For each page with missing links:
 

--- a/.skills/cross-linker/SKILL.md
+++ b/.skills/cross-linker/SKILL.md
@@ -97,6 +97,14 @@ Only act on **EXTRACTED** and **INFERRED** candidates. Include the confidence la
 
 ## Step 4: Apply Links
 
+**Pre-write snapshot** — before the first file write, check `git -C "$OBSIDIAN_VAULT_PATH" rev-parse --is-inside-work-tree`. If the vault is not a git repo, skip this step silently — no nagging, no suggesting `git init`. If it is, snapshot it:
+
+```bash
+git -C "$OBSIDIAN_VAULT_PATH" add -A && git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-cross-linker snapshot" --quiet
+```
+
+A "nothing to commit" result is fine — the vault was already clean. If a snapshot commit was made, mention it in your final report so the user knows the run can be undone with `git -C "$OBSIDIAN_VAULT_PATH" revert` (or `reset`).
+
 For each page with missing links:
 
 ### 4a: Inline linking (preferred)

--- a/.skills/wiki-dedup/SKILL.md
+++ b/.skills/wiki-dedup/SKILL.md
@@ -145,13 +145,40 @@ In **Audit mode**, stop here and ask: "Run `--merge` to interactively merge the 
 
 ## Step 5: Merge
 
-**Pre-write snapshot** — before the first file write, check `git -C "$OBSIDIAN_VAULT_PATH" rev-parse --is-inside-work-tree`. If the vault is not a git repo, skip this step silently — no nagging, no suggesting `git init`. If it is, snapshot it:
+**Pre-write snapshot** — before the first file write, check whether the vault itself is the root of a Git repository. Merely being a subdirectory of a larger repository does not qualify: running `git add -A` there could capture unrelated files. If the vault is not a standalone Git repository, skip this step silently — no nagging, no suggesting `git init`.
 
 ```bash
-git -C "$OBSIDIAN_VAULT_PATH" add -A && git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-wiki-dedup snapshot" --quiet
+VAULT_REAL_PATH=$(cd "$OBSIDIAN_VAULT_PATH" && pwd -P)
+VAULT_GIT_ROOT=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse --show-toplevel 2>/dev/null || true)
+SNAPSHOT_SHA=""
+
+if [ -n "$VAULT_GIT_ROOT" ] && [ "$VAULT_GIT_ROOT" = "$VAULT_REAL_PATH" ]; then
+  if git -C "$OBSIDIAN_VAULT_PATH" diff --quiet \
+    && git -C "$OBSIDIAN_VAULT_PATH" diff --cached --quiet \
+    && [ -z "$(git -C "$OBSIDIAN_VAULT_PATH" ls-files --others --exclude-standard)" ]; then
+    SNAPSHOT_SHA=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse HEAD)
+  else
+    if ! git -C "$OBSIDIAN_VAULT_PATH" add -A; then
+      echo "Pre-write snapshot failed; abort the skill without writing any vault files." >&2
+      exit 1
+    fi
+    if ! git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-wiki-dedup snapshot" --quiet; then
+      echo "Pre-write snapshot failed; abort the skill without writing any vault files." >&2
+      exit 1
+    fi
+    SNAPSHOT_SHA=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse HEAD)
+  fi
+fi
 ```
 
-A "nothing to commit" result is fine — the vault was already clean. If a snapshot commit was made, mention it in your final report so the user knows the run can be undone with `git -C "$OBSIDIAN_VAULT_PATH" revert` (or `reset`).
+The clean-repository branch deliberately avoids calling `git commit`, so "nothing to commit" is not treated as an error. If `git add` or `git commit` fails, stop before editing the vault; never continue without the promised snapshot.
+
+If `SNAPSHOT_SHA` is non-empty and the skill writes files, include the SHA in the final report. To discard the entire run, after confirming there are no later changes worth keeping, the user can run:
+
+```bash
+git -C "$OBSIDIAN_VAULT_PATH" reset --hard "$SNAPSHOT_SHA"
+git -C "$OBSIDIAN_VAULT_PATH" clean -fd
+```
 
 For each `merge` verdict pair (in merge or auto-merge mode):
 

--- a/.skills/wiki-dedup/SKILL.md
+++ b/.skills/wiki-dedup/SKILL.md
@@ -145,6 +145,14 @@ In **Audit mode**, stop here and ask: "Run `--merge` to interactively merge the 
 
 ## Step 5: Merge
 
+**Pre-write snapshot** — before the first file write, check `git -C "$OBSIDIAN_VAULT_PATH" rev-parse --is-inside-work-tree`. If the vault is not a git repo, skip this step silently — no nagging, no suggesting `git init`. If it is, snapshot it:
+
+```bash
+git -C "$OBSIDIAN_VAULT_PATH" add -A && git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-wiki-dedup snapshot" --quiet
+```
+
+A "nothing to commit" result is fine — the vault was already clean. If a snapshot commit was made, mention it in your final report so the user knows the run can be undone with `git -C "$OBSIDIAN_VAULT_PATH" revert` (or `reset`).
+
 For each `merge` verdict pair (in merge or auto-merge mode):
 
 In **merge mode**: show the pair and verdict, then ask: "Merge `[Page A]` into `[Page B]`? (yes/skip/review)". Skip on anything other than yes.

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -438,13 +438,40 @@ Triggered by `wiki-lint --consolidate`. Switches from report-only to **act-and-r
 
 ### Consolidation actions (in order, after confirmation)
 
-**Pre-write snapshot** — before the first file write, check `git -C "$OBSIDIAN_VAULT_PATH" rev-parse --is-inside-work-tree`. If the vault is not a git repo, skip this step silently — no nagging, no suggesting `git init`. If it is, snapshot it:
+**Pre-write snapshot** — before the first file write, check whether the vault itself is the root of a Git repository. Merely being a subdirectory of a larger repository does not qualify: running `git add -A` there could capture unrelated files. If the vault is not a standalone Git repository, skip this step silently — no nagging, no suggesting `git init`.
 
 ```bash
-git -C "$OBSIDIAN_VAULT_PATH" add -A && git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-wiki-lint snapshot" --quiet
+VAULT_REAL_PATH=$(cd "$OBSIDIAN_VAULT_PATH" && pwd -P)
+VAULT_GIT_ROOT=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse --show-toplevel 2>/dev/null || true)
+SNAPSHOT_SHA=""
+
+if [ -n "$VAULT_GIT_ROOT" ] && [ "$VAULT_GIT_ROOT" = "$VAULT_REAL_PATH" ]; then
+  if git -C "$OBSIDIAN_VAULT_PATH" diff --quiet \
+    && git -C "$OBSIDIAN_VAULT_PATH" diff --cached --quiet \
+    && [ -z "$(git -C "$OBSIDIAN_VAULT_PATH" ls-files --others --exclude-standard)" ]; then
+    SNAPSHOT_SHA=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse HEAD)
+  else
+    if ! git -C "$OBSIDIAN_VAULT_PATH" add -A; then
+      echo "Pre-write snapshot failed; abort the skill without writing any vault files." >&2
+      exit 1
+    fi
+    if ! git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-wiki-lint snapshot" --quiet; then
+      echo "Pre-write snapshot failed; abort the skill without writing any vault files." >&2
+      exit 1
+    fi
+    SNAPSHOT_SHA=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse HEAD)
+  fi
+fi
 ```
 
-A "nothing to commit" result is fine — the vault was already clean. If a snapshot commit was made, mention it in your final report so the user knows the run can be undone with `git -C "$OBSIDIAN_VAULT_PATH" revert` (or `reset`).
+The clean-repository branch deliberately avoids calling `git commit`, so "nothing to commit" is not treated as an error. If `git add` or `git commit` fails, stop before editing the vault; never continue without the promised snapshot.
+
+If `SNAPSHOT_SHA` is non-empty and the skill writes files, include the SHA in the final report. To discard the entire run, after confirming there are no later changes worth keeping, the user can run:
+
+```bash
+git -C "$OBSIDIAN_VAULT_PATH" reset --hard "$SNAPSHOT_SHA"
+git -C "$OBSIDIAN_VAULT_PATH" clean -fd
+```
 
 #### Action 1: Fix broken wikilinks
 

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -438,6 +438,14 @@ Triggered by `wiki-lint --consolidate`. Switches from report-only to **act-and-r
 
 ### Consolidation actions (in order, after confirmation)
 
+**Pre-write snapshot** — before the first file write, check `git -C "$OBSIDIAN_VAULT_PATH" rev-parse --is-inside-work-tree`. If the vault is not a git repo, skip this step silently — no nagging, no suggesting `git init`. If it is, snapshot it:
+
+```bash
+git -C "$OBSIDIAN_VAULT_PATH" add -A && git -C "$OBSIDIAN_VAULT_PATH" commit -m "pre-wiki-lint snapshot" --quiet
+```
+
+A "nothing to commit" result is fine — the vault was already clean. If a snapshot commit was made, mention it in your final report so the user knows the run can be undone with `git -C "$OBSIDIAN_VAULT_PATH" revert` (or `reset`).
+
 #### Action 1: Fix broken wikilinks
 
 For each broken `[[Target]]` found in Check 2:

--- a/tests/test_pre_write_snapshot_docs.py
+++ b/tests/test_pre_write_snapshot_docs.py
@@ -1,0 +1,40 @@
+"""Contract tests for destructive-skill pre-write snapshots."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_PATHS = (
+    ".skills/cross-linker/SKILL.md",
+    ".skills/wiki-dedup/SKILL.md",
+    ".skills/wiki-lint/SKILL.md",
+)
+
+
+def _skill_texts() -> list[tuple[str, str]]:
+    return [
+        (path, (ROOT / path).read_text(encoding="utf-8"))
+        for path in SKILL_PATHS
+    ]
+
+
+def test_snapshot_only_runs_for_standalone_vault_repositories() -> None:
+    for path, text in _skill_texts():
+        assert "rev-parse --show-toplevel" in text, path
+        assert '"$VAULT_GIT_ROOT" = "$VAULT_REAL_PATH"' in text, path
+
+
+def test_snapshot_distinguishes_clean_repository_from_commit_failure() -> None:
+    for path, text in _skill_texts():
+        assert "diff --quiet" in text, path
+        assert "diff --cached --quiet" in text, path
+        assert "ls-files --others --exclude-standard" in text, path
+        assert 'if ! git -C "$OBSIDIAN_VAULT_PATH" add -A; then' in text, path
+        assert "abort the skill without writing any vault files" in text, path
+
+
+def test_snapshot_records_an_actionable_rollback_point() -> None:
+    for path, text in _skill_texts():
+        assert 'SNAPSHOT_SHA=$(git -C "$OBSIDIAN_VAULT_PATH" rev-parse HEAD)' in text, path
+        assert 'reset --hard "$SNAPSHOT_SHA"' in text, path
+        assert "clean -fd" in text, path


### PR DESCRIPTION
## Summary

- snapshot Git-backed vaults before `cross-linker`, `wiki-dedup`, and `wiki-lint --consolidate` perform destructive writes
- require the vault itself to be the repository root so `git add -A` cannot capture unrelated parent-repository changes
- distinguish a clean repository from a failed snapshot and abort before vault writes when staging or committing fails
- record an actionable snapshot SHA and document complete rollback commands
- add contract tests covering all three skills

## Why

These skills can rewrite many vault pages in one run. A pre-write commit provides a cheap rollback point, but the initial implementation treated any directory inside a Git worktree as a standalone vault repository. From a nested vault, `git add -A` can stage sibling files outside the vault. It also treated an empty commit's non-zero exit ambiguously and did not provide a complete rollback command.

This version scopes the snapshot to standalone vault repositories and fails closed when the promised snapshot cannot be created.

## Validation

- `216 passed, 11 subtests passed`
- shell syntax checked for all three embedded snapshot blocks
- exercised clean, dirty, nested, non-Git, commit-failure, and rollback scenarios for every affected skill

Tracks the fork issue: [mike840609/obsidian-wiki#4](https://github.com/mike840609/obsidian-wiki/issues/4)

Closes mike840609/obsidian-wiki#4
