### PR TITLE
fix(cache): resolve vault-relative manifest keys in cache-check (#136)

### DIFF
--- a/obsidian_wiki/cache.py
+++ b/obsidian_wiki/cache.py
@@ -109,7 +109,11 @@ def check_sources(vault: Path, source_paths: list[Path]) -> CheckResult:
             result["missing"].append(key)
             continue
         current_hash = compute_hash(path)
-        entry = sources.get(key) or sources.get(os.path.abspath(key))
+        entry = (
+            sources.get(key)
+            or sources.get(os.path.abspath(key))
+            or sources.get(os.path.relpath(path, vault))
+        )
         if entry is None:
             result["new"].append(key)
         elif entry.get("content_hash") != current_hash:
@@ -117,10 +121,17 @@ def check_sources(vault: Path, source_paths: list[Path]) -> CheckResult:
         else:
             result["unchanged"].append(key)
 
-    # Report manifest keys that no longer exist on disk (not in source_paths scan)
-    checked = {str(p) for p in source_paths} | {os.path.abspath(p) for p in source_paths}
+    # Report manifest keys that no longer exist on disk (not in source_paths scan).
+    # Manifest keys may be stored absolute or vault-relative, so match each passed
+    # path in all three forms and resolve relative keys against the vault root.
+    checked: set[str] = set()
+    for p in source_paths:
+        checked.add(str(p))
+        checked.add(os.path.abspath(p))
+        checked.add(os.path.relpath(p, vault))
     for key in sources:
-        if key not in checked and not Path(key).exists():
+        resolved = Path(key) if os.path.isabs(key) else (vault / key)
+        if key not in checked and not resolved.exists():
             result["missing"].append(key)
 
     return result

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -119,6 +119,50 @@ class TestCheckSources:
         result = check_sources(vault, [src_file])
         assert str(src_file) in result["unchanged"]
 
+    def _write_relative_manifest(self, vault, rel_key, content_hash):
+        """Write a manifest whose source key is stored vault-relative."""
+        _manifest_path(vault).write_text(
+            json.dumps(
+                {"sources": {rel_key: {"content_hash": content_hash, "last_ingested": "2026-07-14"}}}
+            ),
+            encoding="utf-8",
+        )
+
+    def test_relative_manifest_key_unchanged_for_abs_path(self, vault):
+        # Manifest stores a vault-relative key; caller passes the absolute path.
+        src = vault / "_raw" / "articles" / "foo.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("body", encoding="utf-8")
+        self._write_relative_manifest(vault, "_raw/articles/foo.md", sha256_file(src))
+        result = check_sources(vault, [src])
+        assert str(src) in result["unchanged"]
+        assert result["new"] == []
+        assert result["missing"] == []
+
+    def test_relative_manifest_key_not_falsely_missing(self, vault):
+        # A relative key whose file exists under the vault must not be flagged missing,
+        # even when CWD != vault root.
+        src = vault / "_raw" / "articles" / "foo.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("body", encoding="utf-8")
+        self._write_relative_manifest(vault, "_raw/articles/foo.md", sha256_file(src))
+        result = check_sources(vault, [])
+        assert "_raw/articles/foo.md" not in result["missing"]
+
+    def test_relative_manifest_key_modified(self, vault):
+        src = vault / "_raw" / "articles" / "foo.md"
+        src.parent.mkdir(parents=True)
+        src.write_text("body", encoding="utf-8")
+        self._write_relative_manifest(vault, "_raw/articles/foo.md", "stale-hash")
+        result = check_sources(vault, [src])
+        assert str(src) in result["modified"]
+
+    def test_relative_manifest_key_genuinely_missing(self, vault):
+        # A relative key with no file on disk is still reported missing.
+        self._write_relative_manifest(vault, "_raw/articles/gone.md", "abc")
+        result = check_sources(vault, [])
+        assert "_raw/articles/gone.md" in result["missing"]
+
 
 # ---------------------------------------------------------------------------
 # update_source / manifest


### PR DESCRIPTION
Fixes #136. Thanks @gujialind — the root-cause breakdown pointing at the two lines and the CWD-vs-vault detail made this fast to fix and test.

## What was broken

`cache.py`'s docstring promises `<abs-or-rel-path>` manifest keys, but `check_sources` didn't honor the relative form:

- **Lookup** matched an entry only by the passed key or its abspath. A manifest storing `_raw/articles/foo.md` never matched an absolute path the CLI naturally passes, so the source came back `new`.
- **Missing detection** used `Path(key).exists()`, which resolves a relative key against CWD. When CWD wasn't the vault root, the file read as gone and every relative key landed in `missing`.

Either way, incremental-skip broke for anyone using the documented relative keys.

## The fix

- Lookup now also tries `os.path.relpath(path, vault)`, so an absolute path matches a vault-relative key.
- Missing detection resolves relative keys against the vault root (`vault / key`) instead of CWD, and the "already checked" set now includes each path's relative form too.

Absolute keys behave exactly as before.

## Test gap closed

Every prior `test_cache.py` case used absolute keys (`str(src_file)` on a `tmp_path`), so the relative path never ran in CI. Added four cases covering a vault-relative key: `unchanged` when passed an absolute path, not falsely `missing`, `modified` on a hash change, and still `missing` when the file is genuinely gone.

I reran the issue's CLI reproduction against this branch — both the absolute-path and relative-path calls now report `unchanged`. Full suite green (29 passed).
