### PR TITLE
fix(skills): replace hardcoded grep examples with rg

### DIFF
--- a/.skills/memory-bridge/SKILL.md
+++ b/.skills/memory-bridge/SKILL.md
@@ -87,7 +87,7 @@ Read frontmatter for the listed pages (grep for `^(title|category|tags|updated):
 
 Within the filtered page set, run:
 ```
-grep -l "<topic>" <pages in tool set>
+rg -l "<topic>" <pages in tool set>
 ```
 Then grep section headers (`^##`) around matches to give context without full reads. Present results as a ranked list with the matching excerpt.
 

--- a/.skills/wiki-agent/SKILL.md
+++ b/.skills/wiki-agent/SKILL.md
@@ -131,20 +131,20 @@ Open each selected session file and extract only the content relevant to the que
 
 **Claude** (JSONL conversation):
 - Each line: `{role, content, timestamp, ...}`
-- Search with: `grep -i "<query terms>" <session.jsonl>` to find the relevant lines
+- Search with: `rg -i "<query terms>" <session.jsonl>` to find the relevant lines
 - Extract: the surrounding conversation window (10 lines before + 20 lines after each hit)
 - Special signal: tool calls (Read/Write/Bash/Edit) reveal what was actually done — extract these even without keyword matches if they're in the relevant window
 
 **Codex** (rollout JSONL):
 - Each line: `{type: "session_meta|turn_context|event_msg|response_item", ...}`
 - Filter to `type: "event_msg"` (user turns) and `type: "response_item"` (model output)
-- Search with: `grep -i "<query terms>" <rollout.jsonl>`
+- Search with: `rg -i "<query terms>" <rollout.jsonl>`
 - Extract: matching turns + their parent context (the `turn_context` preceding the match)
 - Skip: `session_meta` events (operational metadata, not knowledge)
 
 **Hermes** (memory files + session JSONL):
 - For memory files: read the full file (they're short — typically <500 words each)
-- For session JSONL: `grep -i "<query terms>"` + surrounding window
+- For session JSONL: `rg -i "<query terms>"` + surrounding window
 - Memory files with title matches → read fully; others → grep only
 
 **OpenClaw** (MEMORY.md + daily notes + session JSONL):
@@ -160,7 +160,7 @@ Open each selected session file and extract only the content relevant to the que
 **Pi** (structured JSONL with tree layout):
 - Each line is a tree entry: `{type, id, parentId, timestamp, message?, ...}`
 - Build the active branch: map entries by `id`, find leaf (last entry with no children), walk `parentId` to root
-- Search with: `grep -i "<query terms>" <session.jsonl>` to find matching entries
+- Search with: `rg -i "<query terms>" <session.jsonl>` to find matching entries
 - Extract: the matching entries + their ancestors on the active branch (follow parent chain)
 - Special signal: `toolCall` blocks inside assistant messages reveal what was actually done — extract these even without keyword matches if they're in the relevant window
 - Prefer `compaction` and `branch_summary` entries when available — they're pre-synthesized summaries

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -496,7 +496,7 @@ ${QMD_CLI:-qmd} get "qmd://$QMD_WIKI_COLLECTION/projects/<project>/<category>/<p
 If the exact `qmd://` path is uncertain, use:
 
 ```bash
-${QMD_CLI:-qmd} ls "$QMD_WIKI_COLLECTION" | grep "<page-slug>"
+${QMD_CLI:-qmd} ls "$QMD_WIKI_COLLECTION" | rg "<page-slug>"
 ```
 
 Record QMD refresh in the final report as one of:

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -338,8 +338,8 @@ Identify high-value synthesis opportunities the wiki is missing — concept pair
 - Pick 10-15 frequently linked concepts from `concepts/` and `entities/`
 - For each pair, run a quick grep to count pages that link to both:
   ```bash
-  grep -rl "\[\[ConceptA\]\]" "$OBSIDIAN_VAULT_PATH" --include="*.md" > /tmp/a.txt
-  grep -rl "\[\[ConceptB\]\]" "$OBSIDIAN_VAULT_PATH" --include="*.md" > /tmp/b.txt
+  rg -l --glob '*.md' "\[\[ConceptA\]\]" "$OBSIDIAN_VAULT_PATH" > /tmp/a.txt
+  rg -l --glob '*.md' "\[\[ConceptB\]\]" "$OBSIDIAN_VAULT_PATH" > /tmp/b.txt
   comm -12 <(sort /tmp/a.txt) <(sort /tmp/b.txt) | wc -l
   ```
 - Flag pairs with co-occurrence ≥ 3 that have no existing synthesis page

--- a/.skills/wiki-synthesize/SKILL.md
+++ b/.skills/wiki-synthesize/SKILL.md
@@ -35,7 +35,7 @@ Build a co-occurrence matrix: for every pair of concept/entity pages (A, B), cou
 You don't need to be exhaustive — aim for the top 20-30 pairs by co-occurrence score. Use Grep to find backlinks efficiently:
 
 ```bash
-grep -rl "\[\[ConceptA\]\]" "$OBSIDIAN_VAULT_PATH" --include="*.md"
+rg -l --glob '*.md' "\[\[ConceptA\]\]" "$OBSIDIAN_VAULT_PATH"
 ```
 
 Run this for your top candidate concepts and intersect the result sets.

--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -223,7 +223,7 @@ ${QMD_CLI:-qmd} get "qmd://$QMD_WIKI_COLLECTION/projects/<project-name>/<page>.m
 If the exact `qmd://` path is uncertain, use:
 
 ```bash
-${QMD_CLI:-qmd} ls "$QMD_WIKI_COLLECTION" | grep "<project-name>"
+${QMD_CLI:-qmd} ls "$QMD_WIKI_COLLECTION" | rg "<project-name>"
 ```
 
 Record QMD refresh in the final report as one of:


### PR DESCRIPTION
## Summary
- #129 added a "prefer ripgrep" policy to `llm-wiki/SKILL.md`, but six other skill files still hardcoded literal `grep` commands in their instruction examples, silently bypassing that policy.
- Swaps those literal examples to `rg`, with correct flag mapping (`--include="*.md"` → `--glob '*.md'`; `-r` dropped since `rg` recurses by default).
- Files touched: `wiki-agent`, `wiki-update`, `wiki-ingest`, `wiki-lint`, `wiki-synthesize`, `memory-bridge`.
- Left untouched intentionally: `llm-wiki/SKILL.md`'s `grep -q` config-resolution check (zero-dependency by design) and `claude-history-ingest/SKILL.md`'s mention of `grep -v` (an anti-pattern warning, not an instruction).

## Behavior note
`rg` respects `.gitignore` and skips hidden files by default; plain `grep -r` doesn't. This only matters for the two directory-wide backlink scans in `wiki-lint`/`wiki-synthesize` (`wiki-agent`'s single-file search, the piped `qmd ls` filters, and `memory-bridge`'s explicit-file-list search never traverse a directory, so it doesn't apply to them).

**Concrete effect on this vault:** the standard vault `.gitignore` includes `.trash/`. Before this change, `grep -r` would count wikilink backlinks from pages sitting in Obsidian's trash toward co-occurrence scores; after this change, `rg` silently excludes them. That's a real, not just hypothetical, behavior difference for anyone with deleted pages still in `.trash/` — it's arguably the more correct behavior for synthesis-gap detection (deleted pages shouldn't count), but it is a change, and reviewers should decide if that's the intended semantics. Aside from `.trash/`, a typical vault's `.gitignore` only covers Obsidian internals (`.obsidian/workspace.json`, etc.), not content pages, so the two commands scan the same `.md` file set otherwise.

## Test plan
- [x] Ran the old `grep -rl ... --include="*.md"` vs new `rg -l --glob '*.md'` against real vault data — identical file match sets
- [x] Ran `grep -i` vs `rg -i` on a real session `.jsonl` file — byte-identical output
- [x] Ran the piped `cmd | grep "substr"` vs `cmd | rg "substr"` pattern — identical filtered output