### PR TITLE
docs: advisory README translation drift check with backfill script

### DIFF
--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -29,11 +29,14 @@ jobs:
 
       - name: Require README translations to change together
         env:
+          EVENT_NAME: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
-          if [[ "$BASE_SHA" =~ ^0+$ ]]; then
-            git diff-tree --root --no-commit-id --name-only -r "$HEAD_SHA"
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            git diff --name-only "$BASE_SHA...$HEAD_SHA"
+          elif [[ "$BASE_SHA" =~ ^0+$ ]]; then
+            git ls-tree -r --name-only "$HEAD_SHA"
           else
             git diff --name-only "$BASE_SHA" "$HEAD_SHA"
           fi | python tools/check_readme_sync.py

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -1,0 +1,39 @@
+name: README sync
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  readmes-change-together:
+    name: readmes-change-together
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Test README sync checker
+        run: python -m unittest discover -s tests -p 'test_readme_sync.py' -v
+
+      - name: Require README translations to change together
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          if [[ "$BASE_SHA" =~ ^0+$ ]]; then
+            git diff-tree --root --no-commit-id --name-only -r "$HEAD_SHA"
+          else
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA"
+          fi | python tools/check_readme_sync.py

--- a/.github/workflows/readme-sync.yml
+++ b/.github/workflows/readme-sync.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 jobs:
-  readmes-change-together:
-    name: readmes-change-together
+  readme-translation-drift:
+    name: readme-translation-drift (advisory)
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -27,16 +27,6 @@ jobs:
       - name: Test README sync checker
         run: python -m unittest discover -s tests -p 'test_readme_sync.py' -v
 
-      - name: Require README translations to change together
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Report README translation drift (never blocks merge)
         run: |
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            git diff --name-only "$BASE_SHA...$HEAD_SHA"
-          elif [[ "$BASE_SHA" =~ ^0+$ ]]; then
-            git ls-tree -r --name-only "$HEAD_SHA"
-          else
-            git diff --name-only "$BASE_SHA" "$HEAD_SHA"
-          fi | python tools/check_readme_sync.py
+          python tools/check_readme_sync.py || echo "::warning file=README_TW.md::README_TW.md is behind README.md. Run 'python tools/check_readme_sync.py' locally, then translate and backfill the pending changes."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 A **skill-based framework** for building and maintaining an Obsidian knowledge base. No scripts or dependencies — everything is markdown instructions that you execute directly.
 
+## README Translation Parity
+
+`README.md` and `README_TW.md` are one documentation surface. Changing either file requires changing the other in the same change set. Keep headings, examples, links, and user-facing behavior aligned between the two translations. The `readmes-change-together` CI job enforces that both files change together; reviewers assess translation quality.
+
 ## Configuration
 
 Resolve config using the Config Resolution Protocol in `llm-wiki/SKILL.md`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ A **skill-based framework** for building and maintaining an Obsidian knowledge b
 
 ## README Translation Parity
 
-`README.md` and `README_TW.md` are one documentation surface. Changing either file requires changing the other in the same change set. Keep headings, examples, links, and user-facing behavior aligned between the two translations. The `readmes-change-together` CI job enforces that both files change together; reviewers assess translation quality.
+`README.md` and `README_TW.md` are one documentation surface. Keep headings, examples, links, and user-facing behavior aligned between the two translations. The check is advisory and never blocks a PR: the `readme-translation-drift` CI job only reports drift. Run `python tools/check_readme_sync.py` to list commits that changed `README.md` without a later `README_TW.md` update, along with the pending English diff — then translate and backfill those changes into `README_TW.md`. Reviewers assess translation quality.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -569,6 +569,10 @@ Both skills follow the same Karpathy pattern as everything else. If a concept pa
 
 This is early. The skills work, but there's room to make the brain smarter: better cross-referencing, sharper deduplication, bigger vaults, new ingest sources. If you've been chewing on this problem or have a workflow that could be a skill, PRs are welcome.
 
+### Keeping both READMEs in sync
+
+`README.md` is the English documentation and `README_TW.md` is its Traditional Chinese translation; together they are one documentation surface. Any PR that changes either file must update both in the same PR. Keep headings, examples, links, and user-facing behavior structurally and semantically aligned. The `readmes-change-together` CI job enforces that both files change together, while reviewers assess translation quality.
+
 ### Adding a new skill
 
 1. Create a folder in `.skills/your-skill-name/`

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ This is early. The skills work, but there's room to make the brain smarter: bett
 
 ### Keeping both READMEs in sync
 
-`README.md` is the English documentation and `README_TW.md` is its Traditional Chinese translation; together they are one documentation surface. Any PR that changes either file must update both in the same PR. Keep headings, examples, links, and user-facing behavior structurally and semantically aligned. The `readmes-change-together` CI job enforces that both files change together, while reviewers assess translation quality.
+`README.md` is the English documentation and `README_TW.md` is its Traditional Chinese translation; together they are one documentation surface. Keep headings, examples, links, and user-facing behavior structurally and semantically aligned. Syncing is advisory, not a merge gate: the `readme-translation-drift` CI job only reports when the translation falls behind. To catch up, run `python tools/check_readme_sync.py` — it lists the commits that changed `README.md` without a later `README_TW.md` update plus the pending English diff — then translate and backfill those changes into `README_TW.md`. Reviewers assess translation quality.
 
 ### Adding a new skill
 

--- a/README_TW.md
+++ b/README_TW.md
@@ -566,6 +566,10 @@ claude
 
 這還很早期。skills 已可用，但還有很多地方能讓這個大腦更聰明：更好的 cross-referencing、更精準的 deduplication、更大的 vaults、新的 ingest sources。如果你也一直在思考這個問題，或有某個 workflow 可以變成 skill，歡迎 PR。
 
+### 保持兩份 README 同步
+
+`README.md` 是英文文件，`README_TW.md` 是其繁體中文翻譯；兩者共同構成同一份文件介面。任何變更其中一個檔案的 PR，都必須在同一個 PR 中更新另一個檔案。兩份翻譯的標題、範例、連結與面向使用者的行為，應在結構與語意上保持一致。`readmes-change-together` CI job 會強制兩個檔案一起變更，而 reviewers 則負責評估翻譯品質。
+
 ### 新增 skill
 
 1. 在 `.skills/your-skill-name/` 建立資料夾

--- a/README_TW.md
+++ b/README_TW.md
@@ -568,7 +568,7 @@ claude
 
 ### 保持兩份 README 同步
 
-`README.md` 是英文文件，`README_TW.md` 是其繁體中文翻譯；兩者共同構成同一份文件介面。任何變更其中一個檔案的 PR，都必須在同一個 PR 中更新另一個檔案。兩份翻譯的標題、範例、連結與面向使用者的行為，應在結構與語意上保持一致。`readmes-change-together` CI job 會強制兩個檔案一起變更，而 reviewers 則負責評估翻譯品質。
+`README.md` 是英文文件，`README_TW.md` 是其繁體中文翻譯；兩者共同構成同一份文件介面。兩份翻譯的標題、範例、連結與面向使用者的行為，應在結構與語意上保持一致。同步是建議性的，不會擋下合併：`readme-translation-drift` CI job 只會在翻譯落後時提出回報。要補齊時，執行 `python tools/check_readme_sync.py` — 它會列出動到 `README.md` 但之後沒有更新 `README_TW.md` 的 commits，以及尚未翻譯的英文 diff — 接著將這些變更翻譯並補進 `README_TW.md`。翻譯品質由 reviewers 評估。
 
 ### 新增 skill
 

--- a/tests/test_readme_sync.py
+++ b/tests/test_readme_sync.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CHECKER = ROOT / "tools" / "check_readme_sync.py"
+
+
+class ReadmeSyncTest(unittest.TestCase):
+    def run_checker(self, changed_input: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(CHECKER)],
+            cwd=ROOT,
+            input=changed_input,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_unrelated_file_only_passes(self) -> None:
+        result = self.run_checker("obsidian_wiki/cli.py\n")
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_both_readmes_changed_passes(self) -> None:
+        result = self.run_checker("README.md\nREADME_TW.md\nAGENTS.md\n")
+
+        self.assertEqual(result.returncode, 0)
+
+    def test_english_readme_only_fails_with_specific_message(self) -> None:
+        result = self.run_checker("README.md\n")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(
+            result.stderr,
+            "README sync check failed: README.md changed without README_TW.md. "
+            "Update both files in the same change set.\n",
+        )
+
+    def test_traditional_chinese_readme_only_fails_with_specific_message(self) -> None:
+        result = self.run_checker("README_TW.md\n")
+
+        self.assertEqual(result.returncode, 1)
+        self.assertEqual(
+            result.stderr,
+            "README sync check failed: README_TW.md changed without README.md. "
+            "Update both files in the same change set.\n",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_readme_sync.py
+++ b/tests/test_readme_sync.py
@@ -51,6 +51,14 @@ class ReadmeSyncTest(unittest.TestCase):
             "Update both files in the same change set.\n",
         )
 
+    def test_readme_sync_policy_is_documented(self) -> None:
+        for path in (ROOT / "AGENTS.md", ROOT / "README.md", ROOT / "README_TW.md"):
+            with self.subTest(path=path.name):
+                contents = path.read_text(encoding="utf-8")
+                self.assertIn("README.md", contents)
+                self.assertIn("README_TW.md", contents)
+                self.assertIn("readmes-change-together", contents)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_readme_sync.py
+++ b/tests/test_readme_sync.py
@@ -8,6 +8,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECKER = ROOT / "tools" / "check_readme_sync.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "readme-sync.yml"
 
 
 class ReadmeSyncTest(unittest.TestCase):
@@ -58,6 +59,24 @@ class ReadmeSyncTest(unittest.TestCase):
                 self.assertIn("README.md", contents)
                 self.assertIn("README_TW.md", contents)
                 self.assertIn("readmes-change-together", contents)
+
+    def test_pull_requests_compare_changes_from_the_merge_base(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'if [[ "$EVENT_NAME" == "pull_request" ]]; then\n'
+            '            git diff --name-only "$BASE_SHA...$HEAD_SHA"',
+            workflow,
+        )
+
+    def test_all_zero_pushes_emit_the_complete_tip_tree(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            'elif [[ "$BASE_SHA" =~ ^0+$ ]]; then\n'
+            '            git ls-tree -r --name-only "$HEAD_SHA"',
+            workflow,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_readme_sync.py
+++ b/tests/test_readme_sync.py
@@ -3,80 +3,83 @@ from __future__ import annotations
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
 CHECKER = ROOT / "tools" / "check_readme_sync.py"
-WORKFLOW = ROOT / ".github" / "workflows" / "readme-sync.yml"
 
 
-class ReadmeSyncTest(unittest.TestCase):
-    def run_checker(self, changed_input: str) -> subprocess.CompletedProcess[str]:
+class ReadmeDriftTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.repo = Path(self._tmp.name)
+        self.git("init", "-q")
+        self.git("config", "user.email", "test@example.com")
+        self.git("config", "user.name", "Test")
+
+    def git(self, *args: str) -> None:
+        subprocess.run(["git", *args], cwd=self.repo, check=True, capture_output=True)
+
+    def commit(self, message: str, *files: str) -> None:
+        for name in files:
+            path = self.repo / name
+            path.write_text(path.read_text() + message + "\n" if path.exists() else message + "\n")
+        self.git("add", *files)
+        self.git("commit", "-q", "-m", message)
+
+    def run_checker(self) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [sys.executable, str(CHECKER)],
-            cwd=ROOT,
-            input=changed_input,
+            cwd=self.repo,
             text=True,
             capture_output=True,
             check=False,
         )
 
-    def test_unrelated_file_only_passes(self) -> None:
-        result = self.run_checker("obsidian_wiki/cli.py\n")
+    def test_in_sync_passes(self) -> None:
+        self.commit("initial docs", "README.md", "README_TW.md")
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("up to date", result.stdout)
+
+    def test_english_only_commits_are_reported_with_diff(self) -> None:
+        self.commit("initial docs", "README.md", "README_TW.md")
+        self.commit("add install section", "README.md")
+
+        result = self.run_checker()
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("add install section", result.stdout)
+        self.assertIn("+add install section", result.stdout)
+        self.assertIn("backfill", result.stdout)
+
+    def test_later_translation_commit_clears_drift(self) -> None:
+        self.commit("initial docs", "README.md", "README_TW.md")
+        self.commit("add install section", "README.md")
+        self.commit("translate install section", "README_TW.md")
+
+        result = self.run_checker()
 
         self.assertEqual(result.returncode, 0)
 
-    def test_both_readmes_changed_passes(self) -> None:
-        result = self.run_checker("README.md\nREADME_TW.md\nAGENTS.md\n")
+    def test_unrelated_commits_do_not_trigger_drift(self) -> None:
+        self.commit("initial docs", "README.md", "README_TW.md")
+        self.commit("tweak cli", "cli.py")
+
+        result = self.run_checker()
 
         self.assertEqual(result.returncode, 0)
 
-    def test_english_readme_only_fails_with_specific_message(self) -> None:
-        result = self.run_checker("README.md\n")
-
-        self.assertEqual(result.returncode, 1)
-        self.assertEqual(
-            result.stderr,
-            "README sync check failed: README.md changed without README_TW.md. "
-            "Update both files in the same change set.\n",
-        )
-
-    def test_traditional_chinese_readme_only_fails_with_specific_message(self) -> None:
-        result = self.run_checker("README_TW.md\n")
-
-        self.assertEqual(result.returncode, 1)
-        self.assertEqual(
-            result.stderr,
-            "README sync check failed: README_TW.md changed without README.md. "
-            "Update both files in the same change set.\n",
-        )
-
-    def test_readme_sync_policy_is_documented(self) -> None:
+    def test_sync_workflow_is_documented(self) -> None:
         for path in (ROOT / "AGENTS.md", ROOT / "README.md", ROOT / "README_TW.md"):
             with self.subTest(path=path.name):
                 contents = path.read_text(encoding="utf-8")
-                self.assertIn("README.md", contents)
-                self.assertIn("README_TW.md", contents)
-                self.assertIn("readmes-change-together", contents)
-
-    def test_pull_requests_compare_changes_from_the_merge_base(self) -> None:
-        workflow = WORKFLOW.read_text(encoding="utf-8")
-
-        self.assertIn(
-            'if [[ "$EVENT_NAME" == "pull_request" ]]; then\n'
-            '            git diff --name-only "$BASE_SHA...$HEAD_SHA"',
-            workflow,
-        )
-
-    def test_all_zero_pushes_emit_the_complete_tip_tree(self) -> None:
-        workflow = WORKFLOW.read_text(encoding="utf-8")
-
-        self.assertIn(
-            'elif [[ "$BASE_SHA" =~ ^0+$ ]]; then\n'
-            '            git ls-tree -r --name-only "$HEAD_SHA"',
-            workflow,
-        )
+                self.assertIn("check_readme_sync.py", contents)
 
 
 if __name__ == "__main__":

--- a/tools/check_readme_sync.py
+++ b/tools/check_readme_sync.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import sys
+from typing import Iterable, Optional
+
+
+PAIRED_READMES = frozenset({"README.md", "README_TW.md"})
+
+
+def validation_error(changed_paths: Iterable[str]) -> Optional[str]:
+    normalized_paths = {
+        path[2:] if path.startswith("./") else path
+        for path in changed_paths
+        if path
+    }
+    changed_readmes = normalized_paths & PAIRED_READMES
+
+    if changed_readmes == {"README.md"}:
+        return (
+            "README.md changed without README_TW.md. "
+            "Update both files in the same change set."
+        )
+    if changed_readmes == {"README_TW.md"}:
+        return (
+            "README_TW.md changed without README.md. "
+            "Update both files in the same change set."
+        )
+    return None
+
+
+def main() -> int:
+    error = validation_error(sys.stdin.read().splitlines())
+    if error is not None:
+        print(f"README sync check failed: {error}", file=sys.stderr)
+        return 1
+
+    print("README sync check passed: both README files changed or neither changed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/check_readme_sync.py
+++ b/tools/check_readme_sync.py
@@ -1,41 +1,48 @@
+"""Report README translation drift.
+
+Lists commits that changed README.md after the last commit that touched
+README_TW.md, plus the combined English diff that still needs to be
+translated and backfilled into README_TW.md. Advisory only — exits 1 on
+drift so callers can detect it, but CI never uses it to block a merge.
+"""
 from __future__ import annotations
 
-import sys
-from typing import Iterable, Optional
+import subprocess
 
 
-PAIRED_READMES = frozenset({"README.md", "README_TW.md"})
+ENGLISH = "README.md"
+TRANSLATION = "README_TW.md"
 
 
-def validation_error(changed_paths: Iterable[str]) -> Optional[str]:
-    normalized_paths = {
-        path[2:] if path.startswith("./") else path
-        for path in changed_paths
-        if path
-    }
-    changed_readmes = normalized_paths & PAIRED_READMES
-
-    if changed_readmes == {"README.md"}:
-        return (
-            "README.md changed without README_TW.md. "
-            "Update both files in the same change set."
-        )
-    if changed_readmes == {"README_TW.md"}:
-        return (
-            "README_TW.md changed without README.md. "
-            "Update both files in the same change set."
-        )
-    return None
+def git(*args: str) -> str:
+    return subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=True
+    ).stdout
 
 
 def main() -> int:
-    error = validation_error(sys.stdin.read().splitlines())
-    if error is not None:
-        print(f"README sync check failed: {error}", file=sys.stderr)
-        return 1
+    # ponytail: a TW-only commit marks everything before it as synced;
+    # per-commit pairing if that ever misleads
+    last_tw = git("log", "-1", "--format=%H", "--", TRANSLATION).strip()
+    log_range = f"{last_tw}..HEAD" if last_tw else "HEAD"
+    pending = git(
+        "log", "--format=%h %s", log_range, "--", ENGLISH
+    ).strip()
 
-    print("README sync check passed: both README files changed or neither changed.")
-    return 0
+    if not pending:
+        print(f"{TRANSLATION} is up to date with {ENGLISH}.")
+        return 0
+
+    print(f"Commits that changed {ENGLISH} without a later {TRANSLATION} update:")
+    print(pending)
+    print()
+    print(f"English changes not yet reflected in {TRANSLATION}:")
+    if last_tw:
+        print(git("diff", log_range, "--", ENGLISH))
+    else:
+        print(f"{TRANSLATION} has no history — the entire {ENGLISH} is untranslated.")
+    print(f"Translate the changes above and backfill them into {TRANSLATION}.")
+    return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- **The README sync check is advisory — it never blocks PR merges.** The `readme-translation-drift (advisory)` job surfaces drift as a `::warning` annotation only and always succeeds.
- `tools/check_readme_sync.py` is now a drift reporter: it lists the commits that changed `README.md` after the last commit that touched `README_TW.md`, plus the combined English diff still pending translation. Run it locally, translate the diff, and backfill `README_TW.md`.
- A later translation-only commit to `README_TW.md` clears the drift, so translations can land asynchronously instead of being forced into the same PR as the English change.
- Documented the advisory workflow in `AGENTS.md` and both README contributor sections.
- `tests/test_readme_sync.py` exercises the drift semantics against a temporary git repo: in sync, English-only drift reported with diff, catch-up translation commit clears drift, unrelated commits ignored, and the workflow is documented in all three docs.

## Why non-blocking

A hard "both files must change together" gate forces every docs PR to bundle a translation, which blocks contributors who can't write Traditional Chinese. The advisory model keeps the parity goal visible — a recurring CI warning on every PR/push until the translation catches up, plus an on-demand local report — while letting translation land as a follow-up.

## Impact

No PR is ever failed by this check. While `README_TW.md` is behind, every CI run (any PR, any push to `main`) re-reports the warning until a commit touches `README_TW.md`.

Known limitation (marked `ponytail:` in the script): a Chinese-only edit (e.g. a typo fix) also counts as catching up and clears earlier drift; upgrade to per-commit pairing if that ever misleads.

## Validation

- `uv run --no-project --with pytest --python 3.12 pytest -q` — 218 passed, 14 subtests passed
- `python3 -m unittest tests.test_readme_sync -v` — 5 passed
- `python3 tools/check_readme_sync.py` on this branch — in sync, exit 0

## Follow-up

None required — the check is deliberately not part of any required ruleset. Do **not** add `README sync / readme-translation-drift` as a required status check; that would defeat the advisory design.
