### PR TITLE
fix: bundle wiki-stop-capture.sh in the published wheel (#143)

### DIFF
--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -127,6 +127,16 @@ updated: TIMESTAMP
 *None yet.*
 ```
 
+### .manifest.json
+
+Create an empty manifest so ingest skills have a tracking file to append to and
+`obsidian-wiki doctor` reports the vault as complete (it treats `.manifest.json`
+as a required core file):
+
+```bash
+printf '{}\n' > "$OBSIDIAN_VAULT_PATH/.manifest.json"
+```
+
 ## Step 4: Create .obsidian Configuration
 
 Create minimal Obsidian config for a good out-of-box experience:
@@ -164,6 +174,7 @@ Run a quick sanity check:
 - [ ] `index.md` exists at vault root
 - [ ] `log.md` exists at vault root
 - [ ] `hot.md` exists at vault root
+- [ ] `.manifest.json` exists at vault root (empty `{}` is fine)
 - [ ] `.env` has `OBSIDIAN_VAULT_PATH` set
 - [ ] `.obsidian/` directory exists
 - [ ] `_staging/` directory exists (required even when `WIKI_STAGED_WRITES` is not set — created on setup for future use)
@@ -191,11 +202,30 @@ inconclusive sessions are skipped automatically.
 
 **Installation steps:**
 
-1. Find the obsidian-wiki repo path (the directory where this skill lives). If
-   `OBSIDIAN_WIKI_REPO` is set in config, use that. Otherwise, check common locations:
-   `~/Documents/projects/obsidian-wiki`, `~/obsidian-wiki`, or ask the user.
+1. Find the obsidian-wiki repo path. If `OBSIDIAN_WIKI_REPO` is set in config, use that.
+   Otherwise, check common locations: `~/Documents/projects/obsidian-wiki`, `~/obsidian-wiki`,
+   or ask the user.
 
-2. Merge the hook entry into `~/.claude/settings.json`:
+2. Locate the `wiki-stop-capture.sh` script. Its path differs between a pip/uv install and a
+   source checkout, so check both layouts under `<REPO_PATH>` and use the first that exists:
+
+   - `<REPO_PATH>/hooks/wiki-stop-capture.sh` — packaged install (`OBSIDIAN_WIKI_REPO`
+     points at the bundled `_data/` dir, which ships the hook under `hooks/`).
+   - `<REPO_PATH>/.claude/hooks/wiki-stop-capture.sh` — source checkout.
+
+   If neither exists (e.g. an older wheel that predates bundling the hook), fetch the canonical
+   copy to a stable location and point at that instead:
+
+   ```bash
+   mkdir -p ~/.obsidian-wiki/hooks
+   curl -fsSL https://raw.githubusercontent.com/Ar9av/obsidian-wiki/main/.claude/hooks/wiki-stop-capture.sh \
+     -o ~/.obsidian-wiki/hooks/wiki-stop-capture.sh
+   chmod +x ~/.obsidian-wiki/hooks/wiki-stop-capture.sh
+   ```
+
+   Use the resolved absolute path as `<HOOK_PATH>` below.
+
+3. Merge the hook entry into `~/.claude/settings.json`:
 
 ```json
 {
@@ -206,7 +236,7 @@ inconclusive sessions are skipped automatically.
         "hooks": [
           {
             "type": "command",
-            "command": "bash <REPO_PATH>/.claude/hooks/wiki-stop-capture.sh"
+            "command": "bash <HOOK_PATH>"
           }
         ]
       }
@@ -218,7 +248,7 @@ inconclusive sessions are skipped automatically.
    If `~/.claude/settings.json` already exists and has a `hooks.Stop` array, **append** the new
    entry rather than replacing — don't clobber existing hooks.
 
-3. Confirm: "Stop hook installed. Claude Code will prompt `/wiki-capture --quick` at the
+4. Confirm: "Stop hook installed. Claude Code will prompt `/wiki-capture --quick` at the
    end of any session where you write files or run ≥ 4 shell commands."
 
 **To uninstall later:** remove the hook entry from `~/.claude/settings.json` or set

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ packages = ["obsidian_wiki"]
 
 [tool.hatch.build.targets.wheel.force-include]
 ".skills" = "obsidian_wiki/_data/skills"
+".claude/hooks/wiki-stop-capture.sh" = "obsidian_wiki/_data/hooks/wiki-stop-capture.sh"
 ".env.example" = "obsidian_wiki/_data/.env.example"
 "AGENTS.md" = "obsidian_wiki/_data/bootstrap/AGENTS.md"
 ".cursor/rules/obsidian-wiki.mdc" = "obsidian_wiki/_data/bootstrap/cursor/rules/obsidian-wiki.mdc"
@@ -90,5 +91,9 @@ exclude = [
 
 # Force the real .skills/ tree into the sdist regardless of the VCS walker, so
 # the wheel (built from the sdist) can in turn force-include it under _data/.
+# The Stop hook lives under /.claude (excluded above), so re-add just the one
+# script the wiki-setup skill wires up — otherwise the wheel force-include has
+# nothing to copy and the published package ships a dangling hook reference.
 [tool.hatch.build.targets.sdist.force-include]
 ".skills" = ".skills"
+".claude/hooks/wiki-stop-capture.sh" = ".claude/hooks/wiki-stop-capture.sh"

--- a/tests/test_stop_hook_packaging.py
+++ b/tests/test_stop_hook_packaging.py
@@ -1,0 +1,73 @@
+"""Regression guard for issue #143.
+
+The wiki-setup skill wires a Claude Code Stop hook that runs
+``wiki-stop-capture.sh``. That script lives under ``.claude/hooks/`` in the repo,
+which the sdist prunes — so it was silently missing from the published wheel and
+the installed hook pointed at a nonexistent path. These tests pin the packaging
+config that force-includes the script and the skill instructions that resolve it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    tomllib = None
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK_SRC = ROOT / ".claude" / "hooks" / "wiki-stop-capture.sh"
+PACKAGED_HOOK_DEST = "obsidian_wiki/_data/hooks/wiki-stop-capture.sh"
+
+
+@unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
+class StopHookPackagingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+    def test_hook_source_exists(self) -> None:
+        self.assertTrue(HOOK_SRC.is_file(), f"{HOOK_SRC} must exist to be bundled")
+
+    def test_wheel_force_includes_hook(self) -> None:
+        mapping = self.pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+        self.assertEqual(
+            mapping.get(".claude/hooks/wiki-stop-capture.sh"),
+            PACKAGED_HOOK_DEST,
+            "wheel must force-include the Stop hook under _data/hooks/",
+        )
+
+    def test_sdist_reincludes_hook_despite_claude_exclusion(self) -> None:
+        # The wheel is built from the sdist, and the sdist prunes /.claude — so
+        # the one hook script must be force-included back or the wheel copy fails.
+        sdist = self.pyproject["tool"]["hatch"]["build"]["targets"]["sdist"]
+        self.assertIn("/.claude", sdist["exclude"])
+        self.assertEqual(
+            sdist["force-include"].get(".claude/hooks/wiki-stop-capture.sh"),
+            ".claude/hooks/wiki-stop-capture.sh",
+        )
+
+
+class WikiSetupSkillTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill = (ROOT / ".skills" / "wiki-setup" / "SKILL.md").read_text()
+
+    def test_skill_points_at_packaged_hook_path(self) -> None:
+        # Must reference the packaged layout, not only the source-checkout path.
+        self.assertIn("<REPO_PATH>/hooks/wiki-stop-capture.sh", self.skill)
+
+    def test_skill_offers_github_fallback(self) -> None:
+        self.assertIn(
+            "raw.githubusercontent.com/Ar9av/obsidian-wiki/main/.claude/hooks/wiki-stop-capture.sh",
+            self.skill,
+        )
+
+    def test_setup_creates_manifest(self) -> None:
+        # Secondary fix: doctor requires .manifest.json among core vault files.
+        self.assertIn(".manifest.json", self.skill)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #143.

## Problem

`wiki-setup`'s "Install the Stop Hook" step wires `~/.claude/settings.json` to run
`<REPO_PATH>/.claude/hooks/wiki-stop-capture.sh`. But the sdist prunes `/.claude`,
and the wheel is built from the sdist — so the script was **never shipped in the
published pip/uv package**. Anyone who installed via `uv tool install` / `pip install`
got a Stop hook pointing at a file that doesn't exist (`bash: No such file or directory`
on every session Stop).

## Fix

- **Packaging:** force-include `wiki-stop-capture.sh` into the wheel under
  `obsidian_wiki/_data/hooks/`, and re-add it to the sdist force-include (since
  `/.claude` is excluded and the wheel builds from the sdist). Verified with a
  real `python -m build`: the script now appears in both artifacts.
- **Skill:** `wiki-setup` now resolves the hook robustly — packaged
  `<REPO_PATH>/hooks/` path first, then the source-checkout `.claude/hooks/`
  path, then a GitHub-raw fallback for older wheels — and points settings.json
  at the resolved absolute path.
- **Secondary note:** `wiki-setup` now creates an empty `.manifest.json`, so
  `obsidian-wiki doctor`'s required-core-files check flips from `warn` to `pass`.
- **Tests:** new `tests/test_stop_hook_packaging.py` pins the packaging config
  and skill wiring so this can't silently regress.

## Verification

```
$ unzip -l dist/*.whl | grep hook
    3079  ...  obsidian_wiki/_data/hooks/wiki-stop-capture.sh
$ python3 -m pytest tests/test_stop_hook_packaging.py tests/test_doctor.py -q
... passed
```
