### PR TITLE
fix: make cache-check/cache-update work with the manifest shape the skills write (#134)

### DIFF
--- a/obsidian_wiki/cache.py
+++ b/obsidian_wiki/cache.py
@@ -4,16 +4,25 @@ Provides a reliable, platform-independent alternative to running `sha256sum`
 in the skill. The agent calls `obsidian-wiki cache-check` / `cache-update`
 instead of shelling out to sha256sum and manually parsing .manifest.json.
 
-Manifest format (.manifest.json in the vault root):
-{
-  "sources": {
-    "<abs-or-rel-path>": {
-      "content_hash": "<sha256-hex>",
-      "last_ingested": "<ISO-8601>",
-      "pages_produced": ["<vault-relative-page-path>", ...]
-    }
-  }
-}
+Manifest format (.manifest.json in the vault root). Two `sources` shapes are
+supported, because real vaults contain both:
+
+1. Dict keyed by path (this module's original format)::
+
+    {"sources": {"<abs-or-rel-path>": {"content_hash": "...", ...}}}
+
+2. List of entry objects, each carrying its own ``path`` (the shape the
+   wiki-ingest skill writes)::
+
+    {"sources": [{"path": "_raw/foo.md", "content_hash": "sha256:...", ...}]}
+
+Both shapes are read transparently, and `update_source` edits the manifest
+*in place* — preserving its shape, any duplicate-path entries, and
+skill-written fields (``pages_created``, ``size_bytes``, ``source_type``, …).
+
+Hashes are compared prefix-insensitively: the skill records
+``"sha256:<hex>"`` while this module computes a bare ``<hex>``, so an optional
+``algo:`` prefix is stripped from both sides before comparison.
 """
 
 from __future__ import annotations
@@ -21,9 +30,10 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import re
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import TypedDict
+from typing import Iterator, TypedDict
 
 
 class SourceEntry(TypedDict, total=False):
@@ -43,27 +53,102 @@ def _manifest_path(vault: Path) -> Path:
     return vault / ".manifest.json"
 
 
-def _load_manifest(vault: Path) -> dict[str, SourceEntry]:
+def _load_raw(vault: Path) -> dict:
+    """Return the full manifest object (``{}`` if absent/unreadable)."""
     mp = _manifest_path(vault)
     if not mp.exists():
         return {}
     try:
         data = json.loads(mp.read_text(encoding="utf-8"))
-        return data.get("sources", {})
+        return data if isinstance(data, dict) else {}
     except (json.JSONDecodeError, OSError):
         return {}
 
 
-def _save_manifest(vault: Path, sources: dict[str, SourceEntry]) -> None:
-    mp = _manifest_path(vault)
-    existing: dict = {}
-    if mp.exists():
-        try:
-            existing = json.loads(mp.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError):
-            pass
-    existing["sources"] = sources
-    mp.write_text(json.dumps(existing, indent=2, ensure_ascii=False), encoding="utf-8")
+def _load_manifest(vault: Path):
+    """Return the raw ``sources`` value — a dict, a list, or ``{}`` if absent.
+
+    Kept for backward compatibility; callers that need shape-agnostic access
+    should use :func:`_iter_entries`.
+    """
+    return _load_raw(vault).get("sources", {})
+
+
+def _save_manifest(vault: Path, sources) -> None:
+    """Write *sources* back into the manifest, preserving other top-level keys."""
+    manifest = _load_raw(vault)
+    manifest["sources"] = sources
+    _manifest_path(vault).write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def _iter_entries(sources) -> Iterator[tuple[str | None, dict]]:
+    """Yield ``(stored_key, entry)`` pairs for either manifest shape.
+
+    For the dict shape the key is the dict key; for the list shape it is the
+    entry's ``path`` (falling back to ``source_id``).
+    """
+    if isinstance(sources, dict):
+        for key, entry in sources.items():
+            if isinstance(entry, dict):
+                yield key, entry
+    elif isinstance(sources, list):
+        for entry in sources:
+            if isinstance(entry, dict):
+                yield (entry.get("path") or entry.get("source_id")), entry
+
+
+# Matches "sha256:", "https://", "slack:#..." — anything with an algo/scheme
+# prefix that shouldn't be treated as a filesystem path.
+_SCHEME_RE = re.compile(r"^[A-Za-z][A-Za-z0-9+.\-]*:[^\\/]")
+
+
+def _strip_algo(value: str | None) -> str:
+    """Drop an optional ``algo:`` prefix so ``sha256:<hex>`` == ``<hex>``."""
+    value = value or ""
+    return value.split(":", 1)[1] if ":" in value else value
+
+
+def _format_hash(existing: str | None, new_hex: str) -> str:
+    """Format *new_hex* keeping any ``algo:`` prefix the existing value used."""
+    if existing and ":" in existing:
+        return f"{existing.split(':', 1)[0]}:{new_hex}"
+    return new_hex
+
+
+def _is_file_key(key: str | None) -> bool:
+    """True if *key* looks like a filesystem path rather than a URL/pseudo-key."""
+    return bool(key) and "://" not in key and not _SCHEME_RE.match(key)
+
+
+def _same_source(stored_key: str | None, query: Path, vault: Path) -> bool:
+    """True if a manifest key refers to the same source as *query*.
+
+    Matches on the raw string first (covers URLs and pseudo-keys), then on the
+    resolved absolute form (relative keys resolve against the vault root), so a
+    caller-supplied absolute path matches a manifest's vault-relative key.
+    """
+    if not stored_key:
+        return False
+    if str(query) == stored_key:
+        return True
+    if not _is_file_key(stored_key):
+        return False
+    k = Path(stored_key)
+    k_abs = k if k.is_absolute() else (vault / k)
+    try:
+        return k_abs.resolve() == query.resolve()
+    except OSError:
+        return False
+
+
+def _missing_on_disk(key: str | None, vault: Path) -> bool:
+    """True if a filesystem-style manifest key has no file on disk."""
+    if not _is_file_key(key):
+        return False
+    resolved = Path(key) if os.path.isabs(key) else (vault / key)
+    return not resolved.exists()
 
 
 def sha256_file(path: Path, chunk: int = 1 << 20) -> str:
@@ -99,40 +184,40 @@ def check_sources(vault: Path, source_paths: list[Path]) -> CheckResult:
     """Classify each source as new / modified / unchanged vs. the manifest.
 
     Also reports manifest entries whose source file no longer exists on disk.
+    Handles both manifest shapes and compares hashes prefix-insensitively.
     """
-    sources = _load_manifest(vault)
+    entries = list(_iter_entries(_load_manifest(vault)))
     result: CheckResult = {"new": [], "modified": [], "unchanged": [], "missing": []}
 
+    matched: set[int] = set()
     for path in source_paths:
         key = str(path)
         if not path.exists():
             result["missing"].append(key)
             continue
-        current_hash = compute_hash(path)
-        entry = (
-            sources.get(key)
-            or sources.get(os.path.abspath(key))
-            or sources.get(os.path.relpath(path, vault))
-        )
+        current_hash = _strip_algo(compute_hash(path))
+        entry = None
+        for i, (stored_key, e) in enumerate(entries):
+            if _same_source(stored_key, path, vault):
+                entry = e
+                matched.add(i)
+                break
         if entry is None:
             result["new"].append(key)
-        elif entry.get("content_hash") != current_hash:
+        elif _strip_algo(entry.get("content_hash")) != current_hash:
             result["modified"].append(key)
         else:
             result["unchanged"].append(key)
 
-    # Report manifest keys that no longer exist on disk (not in source_paths scan).
-    # Manifest keys may be stored absolute or vault-relative, so match each passed
-    # path in all three forms and resolve relative keys against the vault root.
-    checked: set[str] = set()
-    for p in source_paths:
-        checked.add(str(p))
-        checked.add(os.path.abspath(p))
-        checked.add(os.path.relpath(p, vault))
-    for key in sources:
-        resolved = Path(key) if os.path.isabs(key) else (vault / key)
-        if key not in checked and not resolved.exists():
-            result["missing"].append(key)
+    # Report manifest entries whose source file no longer exists on disk and
+    # that weren't among the scanned paths (in any path form).
+    for i, (stored_key, _entry) in enumerate(entries):
+        if i in matched:
+            continue
+        if any(_same_source(stored_key, p, vault) for p in source_paths):
+            continue
+        if _missing_on_disk(stored_key, vault):
+            result["missing"].append(stored_key)
 
     return result
 
@@ -143,17 +228,52 @@ def update_source(
     *,
     pages_produced: list[str] | None = None,
 ) -> str:
-    """Record the current hash of *source_path* in the manifest. Returns the hash."""
-    sources = _load_manifest(vault)
-    key = str(source_path)
+    """Record the current hash of *source_path* in the manifest. Returns the hash.
+
+    Edits the manifest in place: matches an existing entry across path forms and
+    updates it, otherwise appends a new one — preserving the manifest's shape
+    (dict or list), duplicate-path entries, and any skill-written fields.
+    """
+    manifest = _load_raw(vault)
+    sources = manifest.get("sources")
     current_hash = compute_hash(source_path)
-    entry: SourceEntry = sources.get(key, {})
-    entry["content_hash"] = current_hash
-    entry["last_ingested"] = datetime.now(timezone.utc).isoformat()
-    if pages_produced is not None:
-        entry["pages_produced"] = pages_produced
-    sources[key] = entry
-    _save_manifest(vault, sources)
+    now = datetime.now(timezone.utc).isoformat()
+
+    if isinstance(sources, list):
+        target: dict | None = None
+        for e in sources:
+            if isinstance(e, dict) and _same_source(
+                e.get("path") or e.get("source_id"), source_path, vault
+            ):
+                target = e
+                break
+        if target is None:
+            target = {"path": str(source_path)}
+            sources.append(target)
+        target["content_hash"] = _format_hash(target.get("content_hash"), current_hash)
+        target["last_ingested"] = now
+        if pages_produced is not None:
+            target["pages_produced"] = pages_produced
+    else:
+        if not isinstance(sources, dict):
+            sources = {}
+        match_key: str | None = None
+        for stored_key in sources:
+            if _same_source(stored_key, source_path, vault):
+                match_key = stored_key
+                break
+        key = match_key if match_key is not None else str(source_path)
+        entry = sources.get(key) if isinstance(sources.get(key), dict) else {}
+        entry["content_hash"] = _format_hash(entry.get("content_hash"), current_hash)
+        entry["last_ingested"] = now
+        if pages_produced is not None:
+            entry["pages_produced"] = pages_produced
+        sources[key] = entry
+
+    manifest["sources"] = sources
+    _manifest_path(vault).write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
     return current_hash
 
 

--- a/tests/test_cache_manifest_shapes.py
+++ b/tests/test_cache_manifest_shapes.py
@@ -1,0 +1,149 @@
+"""Regression tests for issue #134.
+
+cache-check / cache-update were written for a dict-keyed manifest with bare hex
+hashes, but the wiki-ingest skill writes ``sources`` as a list of objects with
+``sha256:``-prefixed hashes and vault-relative paths. That combination caused a
+crash, then false "modified"/"new" once the crash was patched. These tests pin
+all four failure modes the issue enumerated.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from obsidian_wiki.cache import (
+    check_sources,
+    compute_hash,
+    update_source,
+    _load_raw,
+    _manifest_path,
+)
+
+
+@pytest.fixture
+def vault(tmp_path):
+    v = tmp_path / "vault"
+    v.mkdir()
+    return v
+
+
+@pytest.fixture
+def raw_file(vault):
+    f = vault / "_raw" / "foo.md"
+    f.parent.mkdir(parents=True)
+    f.write_text("# Foo\nbody", encoding="utf-8")
+    return f
+
+
+def _write_list_manifest(vault: Path, entries: list[dict]) -> None:
+    _manifest_path(vault).write_text(
+        json.dumps({"version": 1, "sources": entries}, indent=2), encoding="utf-8"
+    )
+
+
+# 1. Crash on list-shaped sources ------------------------------------------
+
+def test_list_shaped_manifest_does_not_crash(vault, raw_file):
+    _write_list_manifest(vault, [{"path": "_raw/foo.md", "content_hash": "sha256:x"}])
+    result = check_sources(vault, [raw_file])  # previously: AttributeError
+    assert isinstance(result, dict)
+
+
+# 2. Hash prefix mismatch ---------------------------------------------------
+
+def test_sha256_prefixed_hash_reads_as_unchanged(vault, raw_file):
+    # Skill records "sha256:<hex>"; compute_hash returns bare hex.
+    _write_list_manifest(
+        vault, [{"path": "_raw/foo.md", "content_hash": f"sha256:{compute_hash(raw_file)}"}]
+    )
+    result = check_sources(vault, [raw_file])
+    assert str(raw_file) in result["unchanged"]
+    assert result["modified"] == []
+    assert result["new"] == []
+
+
+def test_prefixed_hash_still_detects_real_change(vault, raw_file):
+    _write_list_manifest(
+        vault, [{"path": "_raw/foo.md", "content_hash": f"sha256:{compute_hash(raw_file)}"}]
+    )
+    raw_file.write_text("# Foo\nchanged", encoding="utf-8")
+    result = check_sources(vault, [raw_file])
+    assert str(raw_file) in result["modified"]
+
+
+# 3. Vault-relative path stored, absolute path queried ----------------------
+
+def test_relative_list_path_matches_absolute_query(vault, raw_file):
+    _write_list_manifest(
+        vault, [{"path": "_raw/foo.md", "content_hash": f"sha256:{compute_hash(raw_file)}"}]
+    )
+    result = check_sources(vault, [raw_file.resolve()])
+    assert str(raw_file.resolve()) in result["unchanged"]
+
+
+# 4. update_source preserves shape, duplicates, and extra fields ------------
+
+def test_update_preserves_list_shape(vault, raw_file):
+    _write_list_manifest(
+        vault,
+        [{"path": "_raw/foo.md", "content_hash": "sha256:old", "source_type": "document",
+          "pages_produced": ["concepts/foo.md"]}],
+    )
+    update_source(vault, raw_file, pages_produced=["concepts/foo.md", "concepts/bar.md"])
+    sources = _load_raw(vault)["sources"]
+    assert isinstance(sources, list), "must stay a list, not collapse to a dict"
+    assert len(sources) == 1
+    entry = sources[0]
+    assert entry["source_type"] == "document"  # skill field preserved
+    assert entry["content_hash"] == f"sha256:{compute_hash(raw_file)}"  # prefix kept
+    assert entry["pages_produced"] == ["concepts/foo.md", "concepts/bar.md"]
+
+
+def test_update_preserves_duplicate_path_entries(vault, raw_file):
+    # Same path ingested on two occasions — a dict round-trip would collapse these.
+    _write_list_manifest(
+        vault,
+        [
+            {"path": "_raw/foo.md", "content_hash": "sha256:v1", "ingested_at": "2026-01-01"},
+            {"path": "_raw/foo.md", "content_hash": "sha256:v2", "ingested_at": "2026-02-01"},
+        ],
+    )
+    update_source(vault, raw_file)
+    sources = _load_raw(vault)["sources"]
+    assert len(sources) == 2, "duplicate-path entries must survive"
+    # First match updated; the second occasion is left intact.
+    assert sources[0]["content_hash"] == f"sha256:{compute_hash(raw_file)}"
+    assert sources[1]["content_hash"] == "sha256:v2"
+
+
+def test_update_appends_new_list_entry(vault, raw_file):
+    _write_list_manifest(vault, [{"path": "_raw/other.md", "content_hash": "sha256:z"}])
+    update_source(vault, raw_file)
+    sources = _load_raw(vault)["sources"]
+    assert isinstance(sources, list)
+    assert {e["path"] for e in sources} == {"_raw/other.md", str(raw_file)}
+
+
+def test_top_level_keys_preserved(vault, raw_file):
+    _manifest_path(vault).write_text(
+        json.dumps({"version": 1, "stats": {"total_sources_ingested": 5}, "sources": []}),
+        encoding="utf-8",
+    )
+    update_source(vault, raw_file)
+    manifest = _load_raw(vault)
+    assert manifest["version"] == 1
+    assert manifest["stats"]["total_sources_ingested"] == 5
+
+
+# Non-file keys (URLs / pseudo-paths) must not be flagged missing -----------
+
+def test_url_source_key_not_flagged_missing(vault):
+    _write_list_manifest(
+        vault,
+        [{"path": "https://example.com/x", "content_hash": "sha256:x", "source_type": "repository"}],
+    )
+    result = check_sources(vault, [])
+    assert result["missing"] == []


### PR DESCRIPTION
Fixes #134.

## Reproduced

`cache-check` / `cache-update` were written for a dict-keyed manifest with bare
hex hashes, but the `wiki-ingest` skill writes `sources` as a **list of entry
objects**, each with a `path` field and a `sha256:`-prefixed `content_hash`.
Both shapes exist in real vaults — confirmed against two on this machine (one
list-shaped, one dict with `sha256:` prefixes).

Against a skill-built (list-shaped) manifest the crash reproduces exactly as
reported:

```
$ python3 -c "from pathlib import Path; from obsidian_wiki import cache; \
    cache.check_sources(Path('vault'), [Path('vault/projects/prismor/prismor.md')])"
AttributeError: 'list' object has no attribute 'get'
```

Three failures stacked: (1) crash on list-shaped `sources`; (2) `sha256:` prefix
vs. bare hex → every unchanged file reported `modified`; (3) vault-relative
stored paths vs. absolute query paths → every file reported `new`. Plus a
data-loss hazard: `update_source` round-tripped the manifest through a
path-keyed dict, collapsing legitimate duplicate-path entries and rewriting
list manifests into a shape the skills' append logic no longer expects.

## Fix

Implements the four fixes the reporter outlined:

1. **Read both shapes** — `_iter_entries` indexes dict entries by key and list
   entries by their `path`/`source_id`.
2. **Prefix-insensitive hashes** — strip an optional `algo:` prefix on both
   sides before comparing.
3. **Match paths across forms** — raw string (covers URLs/pseudo-keys), then
   resolved absolute, with relative keys resolved against the vault root.
4. **In-place `update_source`** — updates the matching entry or appends,
   preserving manifest shape, duplicate-path entries, skill-written fields
   (`pages_created`, `size_bytes`, `source_type`, …), and top-level keys
   (`stats`/`version`).

Also: URL / pseudo-path source keys are no longer falsely flagged
missing-on-disk.

## Tests

New `tests/test_cache_manifest_shapes.py` pins all four failure modes plus the
URL guard. Full suite green:

```
$ python3 -m pytest -q
240 passed, 14 subtests passed
```

The 29 existing `test_cache.py` cases (dict-shape, bare-hex) still pass
unchanged — the fix is additive.
