### PR TITLE
fix(lint): stage trust-ledger enforcement behind strict_trust

### DIFF
--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -752,7 +752,12 @@ def cmd_lint(args: argparse.Namespace) -> int:
         print(f"error: vault not found: {vault}", file=sys.stderr)
         return 1
 
-    report = lint_vault(vault, require_trust_ledger=True)
+    strict_trust = args.strict_trust or _read_config_value("OBSIDIAN_TRUST_STRICT").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    report = lint_vault(vault, require_trust_ledger=True, strict_trust=strict_trust)
     if args.json:
         if args.pretty:
             print(json.dumps(report, indent=2))
@@ -1022,6 +1027,15 @@ def build_parser() -> argparse.ArgumentParser:
     lt.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     lt.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
     lt.add_argument("--strict", action="store_true", help="exit non-zero on warnings as well as failures")
+    lt.add_argument(
+        "--strict-trust",
+        action="store_true",
+        help=(
+            "fail lint on missing trust fields, ledger errors, stale reviews, and "
+            "score mismatches (default: legacy mode, these are warnings only). "
+            "Also settable per-vault via OBSIDIAN_TRUST_STRICT=1 in the config."
+        ),
+    )
     lt.set_defaults(func=cmd_lint)
 
     tr = sub.add_parser(

--- a/obsidian_wiki/lint.py
+++ b/obsidian_wiki/lint.py
@@ -17,6 +17,13 @@ REQUIRED_FRONTMATTER = (
     "sources",
     "created",
     "updated",
+)
+# Introduced by the trust-ledger rollout (#28, #132). Legacy pages that predate
+# the schema are missing these by construction; enforcement is staged behind
+# lint_vault's strict_trust switch so upgrading obsidian-wiki doesn't fail-close
+# every pre-existing page until a vault owner explicitly opts into strict mode
+# after a backfill/review pass.
+TRUST_REQUIRED_FRONTMATTER = (
     "base_confidence",
     "lifecycle",
 )
@@ -168,7 +175,12 @@ def _parse_page(path: Path, vault: Path) -> dict[str, Any]:
     }
 
 
-def lint_vault(vault: Path, *, require_trust_ledger: bool = True) -> dict[str, Any]:
+def lint_vault(
+    vault: Path,
+    *,
+    require_trust_ledger: bool = True,
+    strict_trust: bool = False,
+) -> dict[str, Any]:
     pages = [_parse_page(path, vault) for path in _iter_pages(vault)]
     slug_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
     node_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -189,12 +201,16 @@ def lint_vault(vault: Path, *, require_trust_ledger: bool = True) -> dict[str, A
             incoming[target] += 1
 
     missing_frontmatter = []
+    confidence_missing_fields = []
     for page in pages:
         if page["slug"] in RESERVED_PAGE_STEMS:
             continue
         missing = [field for field in REQUIRED_FRONTMATTER if field not in page["fields"]]
         if missing:
             missing_frontmatter.append({"page": page["path"], "missing": missing})
+        missing_trust = [field for field in TRUST_REQUIRED_FRONTMATTER if field not in page["fields"]]
+        if missing_trust:
+            confidence_missing_fields.append({"page": page["path"], "missing": missing_trust})
 
     title_index: dict[str, list[str]] = defaultdict(list)
     for page in pages:
@@ -291,6 +307,7 @@ def lint_vault(vault: Path, *, require_trust_ledger: bool = True) -> dict[str, A
         "missing_summaries": sorted(missing_summaries),
         "orphan_pages": sorted(orphan_pages),
         "typed_relationship_issues": typed_relationship_issues,
+        "confidence_missing_fields": confidence_missing_fields,
         "confidence_review_stale": trust_report["stale"] if trust_report else [],
         "confidence_unreviewed": trust_report["unreviewed"] if trust_report else [],
         "confidence_mismatches": trust_report["score_mismatches"] if trust_report else [],
@@ -298,23 +315,37 @@ def lint_vault(vault: Path, *, require_trust_ledger: bool = True) -> dict[str, A
     }
     counts = {name: len(items) for name, items in findings.items()}
 
-    if (
-        counts["broken_links"]
-        or counts["missing_frontmatter"]
-        or counts["confidence_mismatches"]
-        or counts["confidence_ledger_errors"]
-    ):
-        status = "fail"
-    elif any(
+    # Staged migration (#28, #146): a missing trust ledger or trust frontmatter
+    # on legacy pages only fails the vault when the owner has explicitly opted
+    # into strict_trust. Ledger presence alone never silently enables strict
+    # enforcement; core structural findings (broken links, missing core
+    # frontmatter) always fail regardless of trust mode.
+    trust_finding_names = (
+        "confidence_missing_fields",
+        "confidence_mismatches",
+        "confidence_ledger_errors",
+        "confidence_review_stale",
+        "confidence_unreviewed",
+    )
+    trust_findings_present = any(counts[name] for name in trust_finding_names)
+    trust_fails = strict_trust and any(
         counts[name]
         for name in (
-            "duplicate_titles",
-            "missing_summaries",
-            "orphan_pages",
-            "typed_relationship_issues",
+            "confidence_missing_fields",
+            "confidence_mismatches",
+            "confidence_ledger_errors",
             "confidence_review_stale",
-            "confidence_unreviewed",
         )
+    )
+
+    if counts["broken_links"] or counts["missing_frontmatter"] or trust_fails:
+        status = "fail"
+    elif (
+        any(
+            counts[name]
+            for name in ("duplicate_titles", "missing_summaries", "orphan_pages", "typed_relationship_issues")
+        )
+        or trust_findings_present
     ):
         status = "warn"
     else:

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -24,6 +24,7 @@ def _page(
     updated: str = "2026-07-01",
     links: list[str] | None = None,
     include_frontmatter: bool = True,
+    include_trust_fields: bool = True,
 ) -> Path:
     path = vault / relpath
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -38,10 +39,10 @@ def _page(
                 f"sources: {sources}",
                 f"created: {created}",
                 f"updated: {updated}",
-                "base_confidence: 0.80",
-                "lifecycle: reviewed",
             ]
         )
+        if include_trust_fields:
+            lines.extend(["base_confidence: 0.80", "lifecycle: reviewed"])
         if summary is not None:
             lines.append(f"summary: {summary}")
         lines.append("---")
@@ -124,3 +125,66 @@ def test_lint_cli_uses_configured_vault_and_strict_mode(tmp_path: Path) -> None:
     data = json.loads(proc.stdout)
     assert data["status"] == "warn"
     assert "concepts/alpha.md" in data["findings"]["missing_summaries"]
+
+
+def test_lint_vault_legacy_pages_without_trust_schema_warn_by_default(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", include_trust_fields=False)
+
+    report = lint_vault(vault)
+
+    assert report["status"] == "warn"
+    assert report["findings"]["missing_frontmatter"] == []
+    assert report["findings"]["confidence_missing_fields"] == [
+        {"page": "concepts/alpha.md", "missing": ["base_confidence", "lifecycle"]}
+    ]
+    assert any(item["issue"] == "ledger_missing" for item in report["findings"]["confidence_ledger_errors"])
+
+
+def test_lint_vault_missing_ledger_is_warning_not_failure_by_default(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+
+    report = lint_vault(vault)
+
+    assert report["status"] == "warn"
+    assert report["findings"]["confidence_ledger_errors"]
+
+
+def test_lint_vault_strict_trust_fails_on_missing_fields_and_ledger(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", include_trust_fields=False)
+
+    report = lint_vault(vault, strict_trust=True)
+
+    assert report["status"] == "fail"
+
+
+def test_lint_vault_strict_trust_still_passes_clean_reviewed_vault(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", links=["beta"])
+    _page(vault, "concepts/beta.md", links=["alpha"])
+    ledger = build_trust_ledger(vault, reviewed_at="2026-07-12T17:38:39+07:00")
+    write_trust_ledger(vault / "_meta" / "trust-ledger.json", ledger, vault=vault)
+
+    report = lint_vault(vault, strict_trust=True)
+
+    assert report["status"] == "pass"
+
+
+def test_lint_cli_strict_trust_flag_fails_legacy_vault(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md", include_trust_fields=False)
+
+    config_dir = home / ".obsidian-wiki"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / "config").write_text(f'OBSIDIAN_VAULT_PATH="{vault}"\n', encoding="utf-8")
+
+    default_proc = _run(home, "lint", "--json")
+    assert default_proc.returncode == 0
+    assert json.loads(default_proc.stdout)["status"] == "warn"
+
+    strict_proc = _run(home, "lint", "--json", "--strict-trust")
+    assert strict_proc.returncode == 1
+    assert json.loads(strict_proc.stdout)["status"] == "fail"

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -284,10 +284,15 @@ def test_lint_vault_requires_trust_ledger_by_default(tmp_path: Path) -> None:
 
     report = lint_vault(vault)
 
-    assert report["status"] == "fail"
+    # Staged migration (#28, #146): a missing ledger only warns until the
+    # vault owner opts into strict_trust.
+    assert report["status"] == "warn"
     assert report["findings"]["confidence_ledger_errors"] == [
         {"issue": "ledger_missing", "path": str(vault / "_meta" / "trust-ledger.json")}
     ]
+
+    strict_report = lint_vault(vault, strict_trust=True)
+    assert strict_report["status"] == "fail"
 
 
 def test_non_object_ledger_fails_cleanly(tmp_path: Path) -> None:
@@ -680,10 +685,16 @@ def test_lint_flags_content_page_missing_trust_schema(tmp_path: Path) -> None:
 
     report = lint_vault(vault)
 
-    assert report["status"] == "fail"
-    assert report["findings"]["missing_frontmatter"] == [
+    # Staged migration (#28, #146): legacy pages predating the trust schema
+    # warn instead of failing lint until the owner opts into strict_trust.
+    assert report["status"] == "warn"
+    assert report["findings"]["missing_frontmatter"] == []
+    assert report["findings"]["confidence_missing_fields"] == [
         {"page": "concepts/alpha.md", "missing": ["base_confidence", "lifecycle"]}
     ]
+
+    strict_report = lint_vault(vault, strict_trust=True)
+    assert strict_report["status"] == "fail"
 
 
 def test_required_trust_ledger_fails_closed_when_missing(tmp_path: Path) -> None:
@@ -692,10 +703,15 @@ def test_required_trust_ledger_fails_closed_when_missing(tmp_path: Path) -> None
 
     report = lint_vault(vault, require_trust_ledger=True)
 
-    assert report["status"] == "fail"
+    # require_trust_ledger controls whether the ledger check runs at all (and
+    # is thus reported); strict_trust controls whether its findings fail lint.
+    assert report["status"] == "warn"
     assert report["findings"]["confidence_ledger_errors"] == [
         {"issue": "ledger_missing", "path": str(vault / "_meta" / "trust-ledger.json")}
     ]
+
+    strict_report = lint_vault(vault, require_trust_ledger=True, strict_trust=True)
+    assert strict_report["status"] == "fail"
 
 
 def test_trust_record_cli_requires_explicit_approval(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #146.

Upgrading past `2026.7.4` made `obsidian-wiki lint` fail-closed on every legacy
page and on a missing trust ledger, skipping the staged migration from #28
(warn first, enforce for new pages, full enforcement only after a backfill
tool ships).

## Summary
- Split `base_confidence`/`lifecycle` out of the core required-frontmatter
  check into a new `confidence_missing_fields` finding.
- Added `strict_trust: bool = False` to `lint_vault()`. Default mode: missing
  trust fields, ledger errors, stale reviews, and score mismatches warn.
  `strict_trust=True` restores fail-closed enforcement.
- Added `--strict-trust` CLI flag and `OBSIDIAN_TRUST_STRICT=1` config switch
  for `obsidian-wiki lint`. Ledger presence alone no longer silently enables
  strict mode; the owner opts in explicitly.

## Test plan
- [x] `python3 -m pytest -q` — 245 passed
- [x] Updated three `tests/test_trust.py` cases that had encoded the old
      fail-closed behavior as expected
- [x] Added `tests/test_lint.py` coverage for legacy-mode warn, strict-mode
      fail, the CLI flag, and a clean fully-reviewed vault passing under
      strict mode
- [x] Manually reproduced the issue's minimal legacy-page example against the
      CLI before and after the fix