### PR TITLE
fix(hooks): claim Stop-hook sentinel atomically to survive duplicate registration

### DIFF
--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -23,14 +23,22 @@ print('1' if d.get('stop_hook_active') else '0')
 " 2>/dev/null || echo "0")
 [[ "$IS_HOOK_TURN" == "1" ]] && exit 0
 
-# Fire at most once per session — sentinel file keyed to session_id prevents
+# Fire at most once per session — sentinel keyed to session_id prevents
 # repeated nudges after the threshold is crossed on the first turn.
+#
+# The sentinel is a DIRECTORY, claimed with mkdir at the moment we decide to
+# nudge (see below). mkdir is atomic on POSIX filesystems, so when several
+# invocations run concurrently — which happens whenever the hook is registered
+# in both project and user settings.json — exactly one wins and the rest exit
+# silently. The check here is only a cheap short-circuit to skip transcript
+# parsing; it is NOT the correctness guarantee, since concurrent invocations
+# can all pass it before any of them claims.
 SESSION_ID=$(printf '%s' "$INPUT" | python3 -c "
 import json, sys; print(json.load(sys.stdin).get('session_id', ''))" 2>/dev/null || echo "")
 SENTINEL=""
 if [[ -n "$SESSION_ID" ]]; then
   SENTINEL="${TMPDIR:-/tmp}/wiki-stop-capture-${SESSION_ID}.done"
-  [[ -f "$SENTINEL" ]] && exit 0
+  [[ -e "$SENTINEL" ]] && exit 0
 fi
 
 TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | python3 -c "
@@ -80,7 +88,12 @@ BASH_COUNT=$(echo "$COUNTS" | awk '{print $2}')
 # Trigger if any file was written/edited, or if there were ≥ 4 shell calls
 # (suggesting investigation/debugging worth preserving).
 if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || [[ "${BASH_COUNT:-0}" -ge 4 ]]; then
-  [[ -n "$SENTINEL" ]] && : > "$SENTINEL" 2>/dev/null || true
+  # Atomically claim the right to nudge. Losers of the race exit silently so a
+  # duplicate registration produces one nudge, not two. Claimed here rather than
+  # earlier so that a below-threshold turn doesn't burn the session's one nudge.
+  if [[ -n "$SENTINEL" ]]; then
+    mkdir "$SENTINEL" 2>/dev/null || exit 0
+  fi
   echo "Session ended with ${WRITE_EDIT} file edit(s) and ${BASH_COUNT} shell call(s). Please run /wiki-capture --quick now to preserve any reusable findings before this context closes." >&2
   exit 2
 fi

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -251,6 +251,14 @@ inconclusive sessions are skipped automatically.
    If `~/.claude/settings.json` already exists and has a `hooks.Stop` array, **append** the new
    entry rather than replacing — don't clobber existing hooks.
 
+   > **Note — expect a duplicate nudge inside this repo.** The obsidian-wiki repo ships its own
+   > git-tracked `.claude/settings.json` registering the same Stop hook at a relative path. Claude
+   > Code *merges* project-level and user-level hook config rather than letting one override the
+   > other, so sessions ending inside the repo itself fire both registrations. This is expected and
+   > harmless — the hook claims an atomic per-session sentinel, so only one nudge is emitted. Leave
+   > both in place: removing the project entry dirties a tracked framework file and disables capture
+   > for anyone who clones the repo without doing the global install.
+
 4. Confirm: "Stop hook installed. Claude Code will prompt `/wiki-capture --quick` at the
    end of any session where you write files or run ≥ 4 shell commands."
 


### PR DESCRIPTION
## Problem

The `wiki-stop-capture.sh` "fire at most once per session" guard is a check-then-write with the two halves separated by the whole script:

```bash
[[ -f "$SENTINEL" ]] && exit 0     # near the top
# ...transcript parsing...
: > "$SENTINEL"                    # only just before exit 2
```

Claude Code **merges** project-level and user-level hook config rather than letting one override the other, and runs matching hooks **concurrently**. Since this repo ships its own `.claude/settings.json` registering the Stop hook, following `wiki-setup`'s instructions to *also* install it globally means two invocations run in parallel for the same `session_id`. Both pass the existence test before either performs the write, so the guard never fires.

Observed in practice — a single session end produced two nudges:

```
[bash /Users/…/obsidian-wiki/.claude/hooks/wiki-stop-capture.sh]: Session ended with 43 file edit(s)…
[bash .claude/hooks/wiki-stop-capture.sh]: Session ended with 43 file edit(s)…
```

(one from the absolute-path global registration, one from the relative-path project registration)

## Fix

Claim the sentinel with `mkdir`, which is atomic on POSIX filesystems — exactly one invocation wins, the losers `exit 0` silently. No lockfile or `flock` dependency.

Two placement details matter and are easy to get wrong:

1. **The claim stays at the decision point**, not at the top of the script. Claiming early would burn the session's single nudge on an early below-threshold turn, silencing a later turn that did meaningful work.
2. **The cheap short-circuit check moves `-f` → `-e`**, since the sentinel is now a directory. Left as `-f` it would silently stop matching.

The early check is kept purely to skip transcript parsing; it is explicitly *not* the correctness guarantee, and the comment now says so.

## Verification

Six cases, all passing against the patched script:

| Case | Expected | Result |
|---|---|---|
| Two **concurrent** invocations, same `session_id` | one nudge | exit `2` + `0`, **1 nudge** ✅ |
| Below-threshold turn, then a work turn | still nudges | exit `0` then `2` ✅ |
| Sequential re-fire after a nudge | suppressed | exit `0` ✅ |
| `stop_hook_active` re-entry guard | suppressed | exit `0` ✅ |
| Missing `session_id` (no dedup possible) | still nudges | exit `2` ✅ |
| Legacy **file**-shaped sentinel from an in-flight session | honored | exit `0` ✅ |

`bash -n` clean.

## Docs

`wiki-setup/SKILL.md` step 3 previously warned only about not clobbering an existing `hooks.Stop` array. Added a note that the duplicate registration inside this repo is expected, that the atomic sentinel means it now yields a single nudge, and that both entries should be left in place — removing the project one dirties a tracked framework file and disables capture for anyone who clones without doing the global install.

## Notes

The general rule generalizes beyond this hook: **anything that must happen once per session needs an atomic claim, because Claude Code hooks run concurrently.** Any future `SessionStart`/`SessionEnd` hook in this repo with a once-per-session guard would hit the same class of bug.

No README changes, so translation parity is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)