### PR TITLE
Share one GitHub-sync implementation across setup.sh and the CLI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,9 +10,11 @@ OBSIDIAN_VAULT_PATH=
 
 # --- Optional ---
 
-# GitHub remote for vault sync (set by setup.sh when you enable GitHub sync)
-# wiki-sync uses this to push committed vault changes
-VAULT_GITHUB_REMOTE=
+# GitHub sync (any install path — pip/uv or setup.sh) is opt-in and configured
+# with `obsidian-wiki sync-setup <repo-url>`, or the GitHub-sync prompt inside
+# `obsidian-wiki setup` / `setup.sh`. There's no env var for it: the vault's own
+# `git remote` is the source of truth, so it can't drift out of sync with this
+# file. Run `obsidian-wiki sync` any time to commit and push pending changes.
 
 # Comma-separated source directories to ingest documents from
 # Leave empty to skip document ingestion

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -257,6 +257,30 @@ inconclusive sessions are skipped automatically.
 **To uninstall later:** remove the hook entry from `~/.claude/settings.json` or set
 `HIVEMIND_CAPTURE=false` in your shell to skip capture for a single session.
 
+## Optional: Configure GitHub Sync
+
+Ask the user: **"Want to sync your vault to a private GitHub repo?"**
+
+The vault is plain markdown, so pushing it to git gets you version history, backup, and
+cross-device sync for free. This is opt-in — skip it if the user declines or has no repo ready.
+
+If yes:
+
+1. Ask for the repo URL (e.g. `https://github.com/you/my-wiki.git`). Recommend it be **private**
+   if the vault holds personal notes.
+2. Run the CLI, which handles `git init`, a default `.gitignore`, and wiring the `origin` remote —
+   this is the same code path `obsidian-wiki setup`'s interactive prompt and `setup.sh` use, so
+   there's one implementation to keep correct (see issue #153 for why that matters):
+   ```bash
+   obsidian-wiki sync-setup "<repo-url>" --vault "$OBSIDIAN_VAULT_PATH"
+   ```
+   If the `obsidian-wiki` binary isn't on PATH (source checkout without an install), run it from
+   the repo instead: `PYTHONPATH="$OBSIDIAN_WIKI_REPO" python3 -m obsidian_wiki.cli sync-setup ...`
+   using whichever of `OBSIDIAN_WIKI_REPO` or a local checkout path is available.
+3. Tell the user they can run `obsidian-wiki sync` any time afterward to commit and push pending
+   vault changes (stages everything, commits with a timestamp, pushes). There's no config file to
+   check for sync status — the vault's own `git remote` is the source of truth.
+
 ## Optional: Refresh QMD After Setup
 
 If `QMD_WIKI_COLLECTION` is configured and the local QMD CLI is available, run `qmd update` after the initial vault files exist so the fresh vault is immediately queryable. No embedding pass is usually needed at setup time because the vault starts empty, so a plain update is enough unless you have already populated pages.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ All supported agents can use this syntax after `obsidian-wiki setup` or `setup.s
 npx skills add Ar9av/obsidian-wiki
 ```
 
-This only installs the markdown skills into the current agent. It does **not** write `~/.obsidian-wiki/config`, install `~/.obsidian-wiki/sync.sh`, or wire the global multi-agent bootstrap that `obsidian-wiki setup` / `setup.sh` performs.
+This only installs the markdown skills into the current agent. It does **not** write `~/.obsidian-wiki/config`, configure GitHub sync, or wire the global multi-agent bootstrap that `obsidian-wiki setup` / `setup.sh` performs.
 
 Use this path only if you intentionally want a partial, agent-local install and are prepared to manage config yourself. For a complete setup, use **Install via pip** or **Install via git clone** instead.
 
@@ -364,40 +364,39 @@ After capturing pages into `_raw/`, ask your agent to process them:
 
 ## Syncing your vault to GitHub
 
-Your vault is a directory of plain markdown files — push it to a private GitHub repo and you get version history, backup, and cross-device sync for free. `setup.sh` (and `obsidian-wiki setup`) will ask you to configure this during the initial install.
+Your vault is a directory of plain markdown files — push it to a private GitHub repo and you get version history, backup, and cross-device sync for free. `obsidian-wiki setup` and `setup.sh` both ask you to configure this during the initial install — they share one implementation (`obsidian_wiki/sync.py`), so pip/uv and source/curl installs get the identical flow.
 
 **What setup does:**
 
 1. `git init` your vault if it isn't already a repo
 2. Creates a `.gitignore` that excludes Obsidian workspace/cache files
-3. Sets the GitHub remote you supply
-4. Writes `~/.obsidian-wiki/sync.sh` — a one-shot script that stages all changes, commits with a timestamp, and pushes
-5. Optionally adds a `wiki-sync` shell alias
-6. Optionally installs an hourly cron job
+3. Sets the GitHub remote you supply (the vault's `git remote` — not a config file — is the source of truth for whether sync is configured)
+4. Optionally adds a `wiki-sync` shell alias for `obsidian-wiki sync`
+5. Optionally installs an hourly cron job
 
 **Run a sync at any time:**
 
 ```bash
-wiki-sync                    # alias added by setup
-~/.obsidian-wiki/sync.sh     # or call the script directly
+wiki-sync           # alias added by setup
+obsidian-wiki sync  # or call it directly
 ```
 
-Each run commits staged changes as `sync 2026-06-08 14:00` and pushes.
+Each run stages all changes, commits as `sync 2026-06-08 14:00`, and pushes.
 
 **Manual setup (skip the prompt):**
 
 ```bash
+obsidian-wiki sync-setup https://github.com/you/my-wiki.git
+# or do it by hand:
 cd /path/to/your/vault
 git init
 git remote add origin https://github.com/you/my-wiki.git
-
-# then commit and push manually, or re-run setup.sh to get the sync script
 ```
 
 **Hourly auto-sync via cron (can be enabled during setup):**
 
 ```
-0 * * * * ~/.obsidian-wiki/sync.sh >> ~/.obsidian-wiki/sync.log 2>&1
+0 * * * * obsidian-wiki sync --vault /path/to/your/vault >> ~/.obsidian-wiki/sync.log 2>&1
 ```
 
 > Keep the repo **private** if your vault contains personal notes. Nothing is sent to any third-party service — your vault lives on your machines and your GitHub account only.

--- a/README_TW.md
+++ b/README_TW.md
@@ -79,7 +79,7 @@ obsidian-wiki graph-analyse /path/to/vault --pretty
 npx skills add Ar9av/obsidian-wiki
 ```
 
-這只會把 markdown skills 安裝到目前 agent。它**不會**寫入 `~/.obsidian-wiki/config`、安裝 `~/.obsidian-wiki/sync.sh`，也不會接上 `obsidian-wiki setup` / `setup.sh` 會設定的全域 multi-agent bootstrap。
+這只會把 markdown skills 安裝到目前 agent。它**不會**寫入 `~/.obsidian-wiki/config`、設定 GitHub sync，也不會接上 `obsidian-wiki setup` / `setup.sh` 會設定的全域 multi-agent bootstrap。
 
 只有在你明確想要部分、agent-local 的安裝，並且願意自行管理 config 時，才使用這條路徑。若要完整設定，請使用 **透過 pip 安裝** 或 **透過 git clone 安裝**。
 
@@ -361,40 +361,39 @@ awk -F= '/^OBSIDIAN_VAULT_PATH=/{print $2 "/_raw"; exit}' "$(git rev-parse --sho
 
 ## 將 vault 同步到 GitHub
 
-你的 vault 是 plain markdown files 的目錄；把它 push 到 private GitHub repo，就能免費得到 version history、backup 與 cross-device sync。`setup.sh`（以及 `obsidian-wiki setup`）會在初始安裝時詢問你是否設定。
+你的 vault 是 plain markdown files 的目錄；把它 push 到 private GitHub repo，就能免費得到 version history、backup 與 cross-device sync。`obsidian-wiki setup` 和 `setup.sh` 都會在初始安裝時詢問你是否設定——兩者共用同一套實作（`obsidian_wiki/sync.py`），所以 pip/uv 安裝和 source/curl 安裝拿到的是完全一樣的流程。
 
 **setup 會做什麼：**
 
 1. 如果 vault 還不是 repo，執行 `git init`
 2. 建立 `.gitignore`，排除 Obsidian workspace/cache files
-3. 設定你提供的 GitHub remote
-4. 寫入 `~/.obsidian-wiki/sync.sh`，這是一個 one-shot script，會 stage 所有 changes、用 timestamp commit，並 push
-5. 可選擇加入 `wiki-sync` shell alias
-6. 可選擇安裝 hourly cron job
+3. 設定你提供的 GitHub remote（vault 本身的 `git remote` 才是同步是否已設定的唯一依據，不是某個設定檔）
+4. 可選擇加入 `wiki-sync` shell alias，對應到 `obsidian-wiki sync`
+5. 可選擇安裝 hourly cron job
 
 **隨時執行同步：**
 
 ```bash
-wiki-sync                    # setup 加入的 alias
-~/.obsidian-wiki/sync.sh     # 或直接呼叫 script
+wiki-sync           # setup 加入的 alias
+obsidian-wiki sync  # 或直接呼叫
 ```
 
-每次執行都會以 `sync 2026-06-08 14:00` 這樣的訊息 commit staged changes 並 push。
+每次執行都會 stage 所有 changes，以 `sync 2026-06-08 14:00` 這樣的訊息 commit，並 push。
 
 **手動設定（略過 prompt）：**
 
 ```bash
+obsidian-wiki sync-setup https://github.com/you/my-wiki.git
+# 或手動處理：
 cd /path/to/your/vault
 git init
 git remote add origin https://github.com/you/my-wiki.git
-
-# then commit and push manually, or re-run setup.sh to get the sync script
 ```
 
 **透過 cron 每小時自動同步（可於 setup 時啟用）：**
 
 ```cron
-0 * * * * ~/.obsidian-wiki/sync.sh >> ~/.obsidian-wiki/sync.log 2>&1
+0 * * * * obsidian-wiki sync --vault /path/to/your/vault >> ~/.obsidian-wiki/sync.log 2>&1
 ```
 
 > 如果你的 vault 包含個人筆記，請保持 repo **private**。不會傳送任何內容到第三方服務；vault 只存在你的機器與你的 GitHub account 中。

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -582,6 +582,48 @@ def _print_doctor(report: dict[str, object]) -> None:
 
 
 # ── Commands ─────────────────────────────────────────────────────────────────
+def _maybe_configure_sync(vault_path: Path, remote_arg: str | None) -> bool:
+    """Offer (or apply) GitHub sync setup for the vault.
+
+    Non-interactive (`--remote` passed, or no TTY and no remote given): only
+    acts when a remote was explicitly supplied. Interactive: prompts, mirroring
+    setup.sh's flow, so pip/uv installs get the same offer shell/curl installs
+    always had (see #153).
+    """
+    from obsidian_wiki.sync import configure_sync, get_remote
+
+    if get_remote(vault_path):
+        return True  # already configured — nothing to do
+
+    remote = remote_arg
+    if not remote:
+        if not sys.stdin.isatty():
+            return False
+        print()
+        try:
+            answer = input("  Set up GitHub sync for your vault? [y/N]: ").strip()
+        except EOFError:
+            answer = ""
+        if answer.lower() != "y":
+            return False
+        try:
+            remote = input("  GitHub repo URL (e.g. https://github.com/you/my-wiki.git): ").strip()
+        except EOFError:
+            remote = ""
+        if not remote:
+            return False
+
+    try:
+        messages = configure_sync(vault_path, remote)
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        print(f"⚠️  GitHub sync setup skipped: {exc}", file=sys.stderr)
+        return False
+    for m in messages:
+        print(f"✅  {m}")
+    print("✅  Run `obsidian-wiki sync` any time to commit and push vault changes.")
+    return True
+
+
 def cmd_setup(args: argparse.Namespace) -> int:
     mode = "copy" if args.copy else "symlink"
     print("\n╔══════════════════════════════════════════════════╗")
@@ -602,12 +644,18 @@ def cmd_setup(args: argparse.Namespace) -> int:
         project_dir = Path(args.project or os.getcwd()).expanduser().resolve()
         install_project(project_dir, mode)
 
+    sync_configured = False
+    if vault_path and Path(vault_path).expanduser().is_dir():
+        sync_configured = _maybe_configure_sync(Path(vault_path).expanduser(), args.remote)
+
     n = len(list_skills())
     print("\n───────────────────────────────────────────────────")
     print(" Setup complete!\n")
     print(f" Skills installed: {n}  (mode: {mode})")
     if vault_path:
         print(f" Vault:            {vault_path}")
+    if sync_configured:
+        print(" GitHub sync:      obsidian-wiki sync")
     print("\n Next steps:")
     print("   1. Open a project in your agent")
     print('   2. Say: "set up my wiki"\n')
@@ -616,6 +664,37 @@ def cmd_setup(args: argparse.Namespace) -> int:
     print("   /wiki-query     → ask questions against your wiki")
     print("───────────────────────────────────────────────────\n")
     return 0
+
+
+def cmd_sync_setup(args: argparse.Namespace) -> int:
+    from obsidian_wiki.sync import configure_sync
+
+    vault_str = resolve_vault_path(args.vault)
+    if not vault_str:
+        print("error: no vault configured — pass --vault or run `obsidian-wiki setup` first", file=sys.stderr)
+        return 1
+    vault_path = Path(vault_str).expanduser()
+    try:
+        messages = configure_sync(vault_path, args.remote)
+    except (FileNotFoundError, ValueError, RuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    for m in messages:
+        print(f"✅  {m}")
+    print("✅  Run `obsidian-wiki sync` any time to commit and push vault changes.")
+    return 0
+
+
+def cmd_sync(args: argparse.Namespace) -> int:
+    from obsidian_wiki.sync import run_sync
+
+    vault_str = resolve_vault_path(args.vault)
+    if not vault_str:
+        print("error: no vault configured — pass --vault or run `obsidian-wiki setup` first", file=sys.stderr)
+        return 1
+    code, message = run_sync(Path(vault_str).expanduser())
+    print(message)
+    return code
 
 
 def cmd_graph_query(args: argparse.Namespace) -> int:
@@ -902,6 +981,10 @@ def cmd_info(args: argparse.Namespace) -> int:
         setup_ver = _read_config_value("OBSIDIAN_WIKI_VERSION")
         print(f"vault:     {vp or '(unset)'}")
         print(f"setup ran: {setup_ver or '(never)'}")
+        if vp:
+            from obsidian_wiki.sync import get_remote
+            remote = get_remote(Path(vp).expanduser())
+            print(f"sync:      {remote if remote else '(not configured — run: obsidian-wiki sync-setup <url>)'}")
     print(f"bundled skills: {len(bundled)}")
     print()
     print("Agent skill install status:")
@@ -935,6 +1018,18 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("setup", help="install skills into your agents and write config (default)")
     _add_setup_args(sp)
     sp.set_defaults(func=cmd_setup)
+
+    ssp = sub.add_parser(
+        "sync-setup",
+        help="configure GitHub sync for your vault (git init, .gitignore, remote)",
+    )
+    ssp.add_argument("remote", help="GitHub (or any git host) repo URL, e.g. https://github.com/you/my-wiki.git")
+    ssp.add_argument("--vault", metavar="PATH", help="absolute path to your Obsidian vault")
+    ssp.set_defaults(func=cmd_sync_setup)
+
+    syp = sub.add_parser("sync", help="commit and push pending vault changes (git add -A, commit, push)")
+    syp.add_argument("--vault", metavar="PATH", help="absolute path to your Obsidian vault")
+    syp.set_defaults(func=cmd_sync)
 
     lp = sub.add_parser("list", help="list bundled skills")
     lp.set_defaults(func=cmd_list)
@@ -1107,6 +1202,12 @@ def _add_setup_args(sp: argparse.ArgumentParser) -> None:
         "--copy",
         action="store_true",
         help="copy skill files instead of symlinking to the installed package",
+    )
+    sp.add_argument(
+        "--remote",
+        metavar="URL",
+        help="GitHub (or any git host) repo URL for vault sync — skips the interactive "
+        "prompt and configures it non-interactively (see also: obsidian-wiki sync-setup)",
     )
 
 

--- a/obsidian_wiki/sync.py
+++ b/obsidian_wiki/sync.py
@@ -1,0 +1,107 @@
+"""GitHub sync for an Obsidian vault.
+
+Single implementation of the git-sync flow, shared by `obsidian-wiki setup` /
+`obsidian-wiki sync-setup` (pip/uv installs) and `setup.sh` (source/curl
+installs) — see issue #153. Both entrypoints call into this module instead of
+each maintaining their own copy of the git plumbing.
+
+The vault's own `git remote` is the source of truth for "is sync configured
+and where does it push" — nothing here caches the remote URL elsewhere, so
+there's nothing to go stale if the user changes it with plain git commands.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+GITIGNORE_CONTENT = (
+    ".obsidian/workspace.json\n"
+    ".obsidian/workspace-mobile.json\n"
+    ".obsidian/cache\n"
+    ".trash/\n"
+)
+
+
+def _git(vault_path: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(vault_path), *args],
+        capture_output=True, text=True,
+    )
+
+
+def get_remote(vault_path: Path) -> str | None:
+    """Return the vault's `origin` remote URL, or None if unset/not a git repo."""
+    if not (vault_path / ".git").is_dir():
+        return None
+    proc = _git(vault_path, "remote", "get-url", "origin")
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.strip() or None
+
+
+def configure_sync(vault_path: Path, remote: str) -> list[str]:
+    """Init git in the vault (if needed), write a default .gitignore, and wire
+    `origin` at `remote`. Returns human-readable confirmation lines.
+
+    Raises FileNotFoundError if vault_path doesn't exist, ValueError if remote
+    is blank.
+    """
+    if not vault_path.is_dir():
+        raise FileNotFoundError(f"vault not found: {vault_path}")
+    remote = remote.strip()
+    if not remote:
+        raise ValueError("remote URL must not be blank")
+
+    messages = []
+
+    if not (vault_path / ".git").is_dir():
+        proc = _git(vault_path, "init", "-q")
+        if proc.returncode != 0:
+            raise RuntimeError(f"git init failed: {proc.stderr.strip()}")
+        messages.append("Initialized git repo in vault")
+
+    gitignore = vault_path / ".gitignore"
+    if not gitignore.is_file():
+        gitignore.write_text(GITIGNORE_CONTENT)
+        messages.append("Created .gitignore in vault")
+
+    has_origin = _git(vault_path, "remote", "get-url", "origin").returncode == 0
+    verb = "set-url" if has_origin else "add"
+    proc = _git(vault_path, "remote", verb, "origin", remote)
+    if proc.returncode != 0:
+        raise RuntimeError(f"git remote {verb} failed: {proc.stderr.strip()}")
+    messages.append(f"Git remote → {remote}")
+
+    return messages
+
+
+def run_sync(vault_path: Path) -> tuple[int, str]:
+    """Commit and push any pending vault changes. Returns (exit_code, message)."""
+    if not vault_path.is_dir():
+        return 1, f"wiki-sync: vault not found at '{vault_path}'"
+    if not (vault_path / ".git").is_dir():
+        return 1, "wiki-sync: vault is not a git repo — run `obsidian-wiki sync-setup <remote>` first"
+
+    add = _git(vault_path, "add", "-A")
+    if add.returncode != 0:
+        return 1, f"wiki-sync: git add failed: {add.stderr.strip()}"
+
+    diff = _git(vault_path, "diff", "--cached", "--quiet")
+    if diff.returncode == 0:
+        return 0, "wiki-sync: nothing to commit"
+
+    commit_msg = f"sync {datetime.now():%Y-%m-%d %H:%M}"
+    commit = _git(vault_path, "commit", "-m", commit_msg)
+    if commit.returncode != 0:
+        return 1, f"wiki-sync: git commit failed: {commit.stderr.strip()}"
+
+    has_upstream = _git(vault_path, "rev-parse", "--abbrev-ref", "@{u}").returncode == 0
+    push_args = ("push",) if has_upstream else ("push", "-u", "origin", "HEAD")
+    push = _git(vault_path, *push_args)
+    if push.returncode != 0:
+        return 1, f"wiki-sync: git push failed: {push.stderr.strip()}"
+
+    remote = get_remote(vault_path) or "origin"
+    return 0, f"wiki-sync: pushed to {remote}"

--- a/setup.sh
+++ b/setup.sh
@@ -211,86 +211,64 @@ install_skills "$HOME/.pi/agent/skills"           "~/.pi/agent/skills/ (Pi)"
 install_skills "$HOME/.agents/skills"             "~/.agents/skills/ (OpenCode, Aider, Droid, generic)"
 
 # ── Step 4: GitHub sync (optional) ───────────────────────────
+# Delegates to obsidian_wiki/sync.py — the same module `obsidian-wiki
+# setup`/`sync-setup` (pip/uv installs) use — so this flow can't drift out of
+# sync with the Python CLI again (see #153). Always runs the CLI straight out
+# of this checkout via PYTHONPATH rather than trusting a possibly-older
+# `obsidian-wiki` already on PATH (which may predate this subcommand); falls
+# back to that installed binary only if python3 isn't available at all.
 SYNC_CONFIGURED=false
 VAULT_REMOTE=""
+
+run_owiki() {
+  if command -v python3 &>/dev/null; then
+    PYTHONPATH="$SCRIPT_DIR" python3 -m obsidian_wiki.cli "$@"
+  elif command -v obsidian-wiki &>/dev/null; then
+    obsidian-wiki "$@"
+  else
+    echo "⚠️  Skipping GitHub sync setup — neither 'python3' nor 'obsidian-wiki' found on PATH." >&2
+    return 1
+  fi
+}
 
 echo ""
 read -p "  Set up GitHub sync for your vault? [y/N]: " SETUP_SYNC || true
 if [[ "$SETUP_SYNC" =~ ^[Yy]$ ]]; then
   read -p "  GitHub repo URL (e.g. https://github.com/you/my-wiki.git): " VAULT_REMOTE || true
   if [ -n "$VAULT_REMOTE" ] && [ -n "$VAULT_PATH" ] && [ -d "$VAULT_PATH" ]; then
-    # Init git repo in vault if needed
-    if [ ! -d "$VAULT_PATH/.git" ]; then
-      git -C "$VAULT_PATH" init -q
-      echo "✅  Initialized git repo in vault"
-    fi
-    # Create .gitignore if missing
-    if [ ! -f "$VAULT_PATH/.gitignore" ]; then
-      cat > "$VAULT_PATH/.gitignore" <<'GITIGNORE'
-.obsidian/workspace.json
-.obsidian/workspace-mobile.json
-.obsidian/cache
-.trash/
-GITIGNORE
-      echo "✅  Created .gitignore in vault"
-    fi
-    # Add or update remote
-    if git -C "$VAULT_PATH" remote get-url origin &>/dev/null 2>&1; then
-      git -C "$VAULT_PATH" remote set-url origin "$VAULT_REMOTE"
-    else
-      git -C "$VAULT_PATH" remote add origin "$VAULT_REMOTE"
-    fi
-    echo "✅  Git remote → $VAULT_REMOTE"
-    # Persist remote in global config
-    echo "VAULT_GITHUB_REMOTE=\"$VAULT_REMOTE\"" >> "$GLOBAL_CONFIG"
-    # Write ~/.obsidian-wiki/sync.sh
-    cat > "$GLOBAL_CONFIG_DIR/sync.sh" <<'SYNC_SCRIPT'
-#!/bin/bash
-# wiki-sync — commit and push vault changes to GitHub
-set -e
-# shellcheck source=/dev/null
-source "$HOME/.obsidian-wiki/config" 2>/dev/null || true
-VAULT="${OBSIDIAN_VAULT_PATH:-}"
-[ -d "$VAULT" ] || { echo "wiki-sync: vault not found at '$VAULT'" >&2; exit 1; }
-cd "$VAULT"
-git add -A
-if git diff --cached --quiet; then
-  echo "wiki-sync: nothing to commit"
-  exit 0
-fi
-git commit -m "sync $(date '+%Y-%m-%d %H:%M')"
-git push
-echo "wiki-sync: pushed to $(git remote get-url origin)"
-SYNC_SCRIPT
-    chmod +x "$GLOBAL_CONFIG_DIR/sync.sh"
-    echo "✅  Wrote ~/.obsidian-wiki/sync.sh"
-    SYNC_CONFIGURED=true
+    if run_owiki sync-setup "$VAULT_REMOTE" --vault "$VAULT_PATH"; then
+      SYNC_CONFIGURED=true
 
-    # Offer shell alias
-    echo ""
-    read -p "  Add 'wiki-sync' alias to your shell? [Y/n]: " ADD_ALIAS || true
-    if [[ ! "$ADD_ALIAS" =~ ^[Nn]$ ]]; then
-      SHELL_RC=""
-      [ -f "$HOME/.zshrc" ]  && SHELL_RC="$HOME/.zshrc"
-      [ -z "$SHELL_RC" ] && [ -f "$HOME/.bashrc" ] && SHELL_RC="$HOME/.bashrc"
-      if [ -n "$SHELL_RC" ]; then
-        if ! grep -q "wiki-sync" "$SHELL_RC"; then
-          printf '\n# wiki-sync — push Obsidian vault to GitHub\nalias wiki-sync='"'"'~/.obsidian-wiki/sync.sh'"'"'\n' >> "$SHELL_RC"
-          echo "✅  Added wiki-sync alias to $SHELL_RC"
-          echo "    → Run: source $SHELL_RC  (or open a new terminal)"
-        else
-          echo "    ℹ️  wiki-sync alias already in $SHELL_RC"
+      # Offer shell alias
+      echo ""
+      read -p "  Add 'wiki-sync' alias to your shell? [Y/n]: " ADD_ALIAS || true
+      if [[ ! "$ADD_ALIAS" =~ ^[Nn]$ ]]; then
+        SHELL_RC=""
+        [ -f "$HOME/.zshrc" ]  && SHELL_RC="$HOME/.zshrc"
+        [ -z "$SHELL_RC" ] && [ -f "$HOME/.bashrc" ] && SHELL_RC="$HOME/.bashrc"
+        if [ -n "$SHELL_RC" ]; then
+          if ! grep -q "wiki-sync" "$SHELL_RC"; then
+            printf '\n# wiki-sync — push Obsidian vault to GitHub\nalias wiki-sync='"'"'obsidian-wiki sync'"'"'\n' >> "$SHELL_RC"
+            echo "✅  Added wiki-sync alias to $SHELL_RC"
+            echo "    → Run: source $SHELL_RC  (or open a new terminal)"
+          else
+            echo "    ℹ️  wiki-sync alias already in $SHELL_RC"
+          fi
         fi
       fi
-    fi
 
-    # Offer hourly cron
-    echo ""
-    read -p "  Enable hourly auto-sync (cron)? [y/N]: " ADD_CRON || true
-    if [[ "$ADD_CRON" =~ ^[Yy]$ ]]; then
-      CRON_LINE="0 * * * * $GLOBAL_CONFIG_DIR/sync.sh >> $GLOBAL_CONFIG_DIR/sync.log 2>&1"
-      ( crontab -l 2>/dev/null; echo "$CRON_LINE" ) | sort -u | crontab -
-      echo "✅  Hourly cron installed  (logs: ~/.obsidian-wiki/sync.log)"
+      # Offer hourly cron
+      echo ""
+      read -p "  Enable hourly auto-sync (cron)? [y/N]: " ADD_CRON || true
+      if [[ "$ADD_CRON" =~ ^[Yy]$ ]]; then
+        # Same preference as run_owiki: PYTHONPATH into this checkout over a
+        # possibly-older installed binary. If this checkout is later moved or
+        # deleted, re-run setup.sh (or edit the crontab) to point it elsewhere.
+        SYNC_CMD="$(command -v python3 &>/dev/null && echo "env PYTHONPATH=$SCRIPT_DIR python3 -m obsidian_wiki.cli sync" || echo "obsidian-wiki sync")"
+        CRON_LINE="0 * * * * $SYNC_CMD --vault $VAULT_PATH >> $GLOBAL_CONFIG_DIR/sync.log 2>&1"
+        ( crontab -l 2>/dev/null; echo "$CRON_LINE" ) | sort -u | crontab -
+        echo "✅  Hourly cron installed  (logs: ~/.obsidian-wiki/sync.log)"
+      fi
     fi
   fi
 fi
@@ -307,7 +285,7 @@ echo " Agents ready:    Claude Code, Cursor, Windsurf, Gemini CLI, Antigravity,"
 echo "                  Codex, Hermes, OpenClaw, OpenCode, Aider, Factory Droid,"
 echo "                  Trae, Trae CN, Kiro, Pi, GitHub Copilot (CLI + VS Code Chat)"
 if $SYNC_CONFIGURED; then
-echo " GitHub sync:     wiki-sync  (script: ~/.obsidian-wiki/sync.sh)"
+echo " GitHub sync:     wiki-sync  (obsidian-wiki sync)"
 fi
 echo ""
 echo " Bootstrap files:"

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,137 @@
+"""Tests for GitHub vault sync (obsidian_wiki/sync.py).
+
+Regression coverage for issue #153: setup.sh had a git-sync flow the pip/uv
+CLI (`obsidian-wiki setup`) never got, so pip/uv installs silently skipped it.
+sync.py is now the single implementation both entrypoints call into.
+"""
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from obsidian_wiki.sync import configure_sync, get_remote, run_sync
+
+
+def _git(repo_dir: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(["git", "-C", str(repo_dir), *args], check=True,
+                           capture_output=True, text=True)
+
+
+@pytest.fixture
+def vault(tmp_path):
+    v = tmp_path / "vault"
+    v.mkdir()
+    return v
+
+
+@pytest.fixture
+def remote_repo(tmp_path):
+    """A bare repo to act as a real push target."""
+    r = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "-q", "--bare", str(r)], check=True)
+    return r
+
+
+class TestGetRemote:
+    def test_not_a_git_repo(self, vault):
+        assert get_remote(vault) is None
+
+    def test_no_origin_set(self, vault):
+        _git(vault, "init", "-q")
+        assert get_remote(vault) is None
+
+    def test_returns_configured_remote(self, vault):
+        _git(vault, "init", "-q")
+        _git(vault, "remote", "add", "origin", "https://example.com/x.git")
+        assert get_remote(vault) == "https://example.com/x.git"
+
+
+class TestConfigureSync:
+    def test_missing_vault_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            configure_sync(tmp_path / "nope", "https://example.com/x.git")
+
+    def test_blank_remote_raises(self, vault):
+        with pytest.raises(ValueError):
+            configure_sync(vault, "   ")
+
+    def test_inits_git_repo(self, vault):
+        configure_sync(vault, "https://example.com/x.git")
+        assert (vault / ".git").is_dir()
+
+    def test_does_not_reinit_existing_repo(self, vault):
+        _git(vault, "init", "-q")
+        (vault / "existing.md").write_text("keep me")
+        _git(vault, "add", "-A")
+        _git(vault, "commit", "-q", "-m", "seed")
+        configure_sync(vault, "https://example.com/x.git")
+        log = _git(vault, "log", "--oneline").stdout
+        assert "seed" in log
+
+    def test_writes_gitignore(self, vault):
+        configure_sync(vault, "https://example.com/x.git")
+        content = (vault / ".gitignore").read_text()
+        assert ".obsidian/workspace.json" in content
+        assert ".trash/" in content
+
+    def test_does_not_overwrite_existing_gitignore(self, vault):
+        vault.mkdir(exist_ok=True)
+        (vault / ".gitignore").write_text("custom-rule/\n")
+        configure_sync(vault, "https://example.com/x.git")
+        assert (vault / ".gitignore").read_text() == "custom-rule/\n"
+
+    def test_sets_remote(self, vault):
+        configure_sync(vault, "https://example.com/x.git")
+        assert get_remote(vault) == "https://example.com/x.git"
+
+    def test_updates_existing_remote(self, vault):
+        configure_sync(vault, "https://example.com/old.git")
+        configure_sync(vault, "https://example.com/new.git")
+        assert get_remote(vault) == "https://example.com/new.git"
+
+    def test_returns_confirmation_messages(self, vault):
+        messages = configure_sync(vault, "https://example.com/x.git")
+        joined = " ".join(messages)
+        assert "Initialized git repo" in joined
+        assert "https://example.com/x.git" in joined
+
+
+class TestRunSync:
+    def test_vault_missing(self, tmp_path):
+        code, message = run_sync(tmp_path / "nope")
+        assert code == 1
+        assert "not found" in message
+
+    def test_not_a_git_repo(self, vault):
+        code, message = run_sync(vault)
+        assert code == 1
+        assert "sync-setup" in message
+
+    def test_nothing_to_commit(self, vault):
+        _git(vault, "init", "-q")
+        code, message = run_sync(vault)
+        assert code == 0
+        assert "nothing to commit" in message
+
+    def test_commits_and_pushes(self, vault, remote_repo):
+        configure_sync(vault, str(remote_repo))
+        _git(vault, "config", "user.email", "test@example.com")
+        _git(vault, "config", "user.name", "Test")
+        (vault / "note.md").write_text("hello")
+        code, message = run_sync(vault)
+        assert code == 0
+        assert "pushed to" in message
+        log = _git(vault, "log", "--oneline").stdout
+        assert "sync " in log
+
+    def test_second_run_with_no_changes_is_clean(self, vault, remote_repo):
+        configure_sync(vault, str(remote_repo))
+        _git(vault, "config", "user.email", "test@example.com")
+        _git(vault, "config", "user.name", "Test")
+        (vault / "note.md").write_text("hello")
+        run_sync(vault)
+        code, message = run_sync(vault)
+        assert code == 0
+        assert "nothing to commit" in message

--- a/tests/test_sync_setup_parity.py
+++ b/tests/test_sync_setup_parity.py
@@ -1,0 +1,60 @@
+"""Regression guard for issue #153.
+
+setup.sh (source/curl installs) used to hand-roll its own git-sync logic while
+`obsidian-wiki setup` (the pip/uv CLI) had none at all — the two entrypoints
+had diverged, and the one most users actually run (pip/uv) silently skipped
+GitHub sync. Both now delegate to obsidian_wiki/sync.py. These tests pin that
+setup.sh calls into the CLI instead of re-implementing git plumbing, and that
+the CLI exposes the subcommands setup.sh (and agents, via wiki-setup) depend on.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class SetupShDelegatesToCliTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.setup_sh = (ROOT / "setup.sh").read_text()
+
+    def test_calls_sync_setup_subcommand(self) -> None:
+        self.assertIn("sync-setup", self.setup_sh)
+
+    def test_calls_cli_module_not_a_standalone_git_flow(self) -> None:
+        self.assertIn("obsidian_wiki.cli", self.setup_sh)
+
+    def test_does_not_hand_roll_git_init(self) -> None:
+        # The old setup.sh ran `git -C "$VAULT_PATH" init` directly; that logic
+        # must now live only in obsidian_wiki/sync.py.
+        self.assertNotIn('git -C "$VAULT_PATH" init', self.setup_sh)
+
+    def test_does_not_generate_a_standalone_sync_script(self) -> None:
+        # The old setup.sh wrote a hand-rolled ~/.obsidian-wiki/sync.sh with its
+        # own git add/commit/push logic — that's now `obsidian-wiki sync`.
+        self.assertNotIn("Wrote ~/.obsidian-wiki/sync.sh", self.setup_sh)
+
+
+class EnvExampleDoesNotOverclaimTest(unittest.TestCase):
+    def test_no_dangling_vault_github_remote_var(self) -> None:
+        env_example = (ROOT / ".env.example").read_text()
+        self.assertNotIn("VAULT_GITHUB_REMOTE", env_example)
+
+
+class CliExposesSyncSubcommandsTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cli = (ROOT / "obsidian_wiki" / "cli.py").read_text()
+
+    def test_sync_setup_subcommand_registered(self) -> None:
+        self.assertIn('sub.add_parser(\n        "sync-setup"', self.cli)
+
+    def test_sync_subcommand_registered(self) -> None:
+        self.assertIn('sub.add_parser("sync"', self.cli)
+
+    def test_setup_command_offers_sync(self) -> None:
+        self.assertIn("_maybe_configure_sync", self.cli)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #153. `setup.sh` (source/curl installs) had an interactive GitHub-sync flow — `git init`, `.gitignore`, remote wiring, a generated `~/.obsidian-wiki/sync.sh`, optional shell alias and hourly cron — that `obsidian-wiki setup` (the entrypoint pip/uv installs actually run) never had. Net effect: the documented pip/uv install path silently skipped git setup, and `.env.example` documented a `VAULT_GITHUB_REMOTE` var that setup.sh only ever wrote to the *global* config (never `.env`) and nothing in the package ever read.

- **New `obsidian_wiki/sync.py`** — single implementation of the git-sync flow: `configure_sync()` (init/`.gitignore`/remote), `run_sync()` (add/commit/push), `get_remote()` (live status, no cached var to drift).
- **New CLI subcommands**: `obsidian-wiki sync-setup <url> [--vault PATH]` and `obsidian-wiki sync [--vault PATH]`.
- **`obsidian-wiki setup`** now offers the same interactive "Set up GitHub sync?" prompt setup.sh always had (guarded by `sys.stdin.isatty()`, same pattern as the existing vault-path prompt), or accepts `--remote <url>` non-interactively.
- **`setup.sh`** no longer hand-rolls git plumbing or generates a `sync.sh` script — its own prompt now calls into the same Python module via the CLI (`PYTHONPATH=$SCRIPT_DIR python3 -m obsidian_wiki.cli sync-setup ...`, preferring the checkout's own source over a possibly-older globally-installed `obsidian-wiki`, which is what actually broke when I first tested this against a stale local install).
- **`obsidian-wiki info`** now shows live GitHub-sync status, read straight from the vault's `git remote` — not a config var that could go stale.
- **`.env.example`, `README.md`, `README_TW.md`, `.skills/wiki-setup/SKILL.md`** updated: dropped the dead `VAULT_GITHUB_REMOTE` var/comment, documented the new `sync-setup`/`sync` commands, and gave the `wiki-setup` agent skill the same sync-offer capability the raw CLI/setup.sh now share.

## Test plan
- [x] `uv run --with pytest pytest -q` — 274 passed (up from 249; 25 new tests), no regressions
- [x] New `tests/test_sync.py` — `configure_sync`/`run_sync`/`get_remote` against real throwaway git repos (init idempotency, `.gitignore` preservation, remote add vs update, actual commit+push to a bare repo, "nothing to commit" on repeat runs, first-push-sets-upstream)
- [x] New `tests/test_sync_setup_parity.py` — regression guard (pattern matches `test_stop_hook_packaging.py` from #143) pinning that `setup.sh` delegates into `obsidian_wiki.cli` instead of re-implementing git logic, and that the CLI exposes the subcommands it depends on
- [x] Manually exercised `obsidian-wiki sync-setup`/`sync`/`info` end-to-end against a scratch vault + bare remote repo
- [x] Manually ran `setup.sh` end-to-end in an isolated scratch checkout (own `$HOME`, fresh `.env`) piping through the vault path → "y" → repo URL → alias → cron prompts; confirmed `git remote -v`, `.gitignore`, and the CLI's live `info` sync line all reflect the configured remote
- [x] Caught and fixed a real bug in my first pass this way: `setup.sh` preferred an already-installed (older, pre-`sync-setup`) global `obsidian-wiki` binary over its own checkout, so the delegation call failed with `invalid choice: 'sync-setup'` — swapped the preference to always run from the checkout via `PYTHONPATH` first