### PR TITLE
Bundle scripts/ into the published wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,9 +61,17 @@ source = "vcs"
 
 [tool.hatch.build.targets.wheel]
 packages = ["obsidian_wiki"]
+# force-include copies straight from the working tree, not a VCS-filtered
+# view — without this, a local `scripts/__pycache__` picked up stray .pyc
+# files into the published wheel.
+exclude = [
+  "**/__pycache__",
+  "**/*.py[co]",
+]
 
 [tool.hatch.build.targets.wheel.force-include]
 ".skills" = "obsidian_wiki/_data/skills"
+"scripts" = "obsidian_wiki/_data/scripts"
 ".claude/hooks/wiki-stop-capture.sh" = "obsidian_wiki/_data/hooks/wiki-stop-capture.sh"
 ".env.example" = "obsidian_wiki/_data/.env.example"
 "AGENTS.md" = "obsidian_wiki/_data/bootstrap/AGENTS.md"

--- a/tests/test_scripts_packaging.py
+++ b/tests/test_scripts_packaging.py
@@ -1,0 +1,79 @@
+"""Regression guard for issue #152.
+
+The daily-update skill's Setup Mode references helper scripts under
+``scripts/`` (daily-update.sh, the launchd plist, wiki-notify.sh) that are
+committed to the repo but were never force-included into the published wheel
+— the same packaging-gap class as #143 (the Stop hook), which that fix did
+not cover. These tests pin the packaging config that force-includes
+``scripts/`` and the skill instructions that resolve it via
+``$OBSIDIAN_WIKI_REPO``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python < 3.11
+    tomllib = None
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = ROOT / "scripts"
+PACKAGED_SCRIPTS_DEST = "obsidian_wiki/_data/scripts"
+
+REFERENCED_SCRIPTS = (
+    "daily-update.sh",
+    "com.obsidian-wiki.daily-update.plist",
+    "wiki-notify.sh",
+)
+
+
+@unittest.skipIf(tomllib is None, "tomllib requires Python 3.11+")
+class ScriptsPackagingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
+
+    def test_referenced_scripts_exist(self) -> None:
+        for name in REFERENCED_SCRIPTS:
+            with self.subTest(script=name):
+                self.assertTrue((SCRIPTS_DIR / name).is_file(), f"{name} must exist to be bundled")
+
+    def test_wheel_force_includes_scripts_dir(self) -> None:
+        mapping = self.pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+        self.assertEqual(
+            mapping.get("scripts"),
+            PACKAGED_SCRIPTS_DEST,
+            "wheel must force-include scripts/ under _data/scripts/",
+        )
+
+    def test_scripts_dir_not_excluded_from_sdist(self) -> None:
+        # Unlike /.claude, scripts/ isn't pruned, so the default VCS-tracked
+        # sdist already carries it — the wheel (built from the sdist) can
+        # force-include it from there. If this ever gets added to the sdist
+        # exclude list, it would also need a matching force-include re-add.
+        sdist_exclude = self.pyproject["tool"]["hatch"]["build"]["targets"]["sdist"]["exclude"]
+        self.assertNotIn("/scripts", sdist_exclude)
+
+    def test_wheel_excludes_pycache_from_force_included_dirs(self) -> None:
+        # force-include copies straight from the working tree (not a
+        # VCS-filtered view), so a local scripts/__pycache__ can otherwise
+        # leak stray .pyc files into the published wheel.
+        wheel_exclude = self.pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["exclude"]
+        self.assertIn("**/__pycache__", wheel_exclude)
+
+
+class DailyUpdateSkillTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.skill = (ROOT / ".skills" / "daily-update" / "SKILL.md").read_text()
+
+    def test_skill_resolves_scripts_via_repo_var(self) -> None:
+        for name in REFERENCED_SCRIPTS:
+            with self.subTest(script=name):
+                self.assertIn(f"$OBSIDIAN_WIKI_REPO/scripts/{name}", self.skill)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #152 — same packaging-gap class as #143 (the Stop hook), which didn't cover `scripts/`. The `daily-update` skill's Setup Mode references `$OBSIDIAN_WIKI_REPO/scripts/daily-update.sh`, `.../scripts/com.obsidian-wiki.daily-update.plist`, and `.../scripts/wiki-notify.sh`, but `scripts/` was never force-included into the wheel, so pip/uv installs had no `_data/scripts/` and Setup Mode failed at its first existence check.

- `pyproject.toml`: added `"scripts" = "obsidian_wiki/_data/scripts"` to `[tool.hatch.build.targets.wheel.force-include]`, matching the existing `.skills` entry. `scripts/` isn't pruned from the sdist (unlike `/.claude`), so no sdist-side re-add was needed — the wheel just needed to know to pull it in.
- Also added a wheel-level `exclude = ["**/__pycache__", "**/*.py[co]"]`: while testing this fix I found force-include copies straight from the working tree rather than a VCS-filtered view, so my local `scripts/__pycache__` (from running `extract-jsonl.py`/`manifest.py`) leaked stray `.pyc` files into the built wheel. Confirmed clean after adding the exclude.

## Test plan
- [x] `uv run --with pytest pytest -q` — 279 passed (up from 274; 5 new), no regressions
- [x] New `tests/test_scripts_packaging.py` (same pattern as `test_stop_hook_packaging.py` from #143) pins the force-include config and that the daily-update skill's referenced script names actually exist in `scripts/`
- [x] Built the wheel for real (`python -m build --wheel`) and inspected it: `obsidian_wiki/_data/scripts/{daily-update.sh,com.obsidian-wiki.daily-update.plist,extract-jsonl.py,manifest.py,wiki-notify.sh}` all present, `daily-update.sh`'s executable bit preserved, no `__pycache__`/`.pyc` leakage
- [x] `pip install`ed the built wheel into a throwaway venv, ran `obsidian-wiki setup`, and confirmed `OBSIDIAN_WIKI_REPO` in the written config resolves to a real `_data` dir where `scripts/daily-update.sh` exists and is executable — i.e. the daily-update skill's Setup Mode Step 1 check now actually passes on a pip/uv install