### PR TITLE
fix(hooks): exempt read-only sessions from the Stop-hook capture nudge

### DIFF
--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -15,7 +15,9 @@
 # (grep/log/status style research) are exempt: nudging them only costs a full
 # skill invocation that ends in SKIP. The classifier is conservative — any
 # command it can't prove read-only counts as mutating, which preserves the
-# pre-exemption behavior for that session.
+# pre-exemption behavior for that session. In particular, command/process
+# substitution ($(…), `…`, <(…)) is treated as mutating without inspecting
+# the inner command.
 
 set -euo pipefail
 
@@ -58,8 +60,13 @@ print(d.get('transcript_path', ''))
 # Count meaningful tool uses: Write/Edit = file mutations, Bash = shell work.
 # Bash commands are additionally classified read-only vs mutating so that
 # edit-free research sessions can be exempted below.
-COUNTS=$(python3 - "$TRANSCRIPT_PATH" <<'PYEOF'
-import json, re, sys
+#
+# The classifier is written to a temp file rather than fed inline through
+# $(python3 <<heredoc): bash 3.2 (macOS /bin/bash) scans a $() body naively
+# and chokes on backticks or unbalanced quotes inside the heredoc text.
+CLASSIFIER="${TMPDIR:-/tmp}/wiki-stop-capture-classify-$$.py"
+cat > "$CLASSIFIER" <<'PYEOF'
+import json, re, shlex, sys
 
 path = sys.argv[1]
 write_edit = 0
@@ -67,17 +74,19 @@ bash_count = 0
 mutating_bash = 0
 
 # Commands that never mutate state on their own (writes would need a shell
-# redirect, which is detected separately). Anything absent from every list
-# below counts as mutating — unknown means "assume it changed something".
+# redirect or substitution, both detected separately). Anything absent from
+# every list below counts as mutating — unknown means "assume it changed
+# something". Commands with a mutating flag form (find -delete, sort -o,
+# date -s, …) get an explicit flag check instead of a blanket entry.
 READONLY_CMDS = {
-    "cat", "ls", "head", "tail", "grep", "egrep", "fgrep", "rg", "find", "fd",
+    "cat", "ls", "head", "tail", "grep", "egrep", "fgrep", "rg", "fd",
     "wc", "echo", "printf", "pwd", "which", "whereis", "type", "file", "stat",
-    "du", "df", "ps", "env", "printenv", "id", "whoami", "uname", "date",
+    "du", "df", "ps", "printenv", "id", "whoami", "uname",
     "true", "false", "test", "[", "diff", "cmp", "tree", "basename", "dirname",
-    "readlink", "realpath", "sort", "uniq", "cut", "tr", "column", "jq", "awk",
+    "readlink", "realpath", "cut", "tr", "column", "jq",
     "md5", "md5sum", "shasum", "sha256sum", "hexdump", "xxd", "strings",
     "less", "more", "nl", "od", "seq", "sleep", "uptime", "dig", "host",
-    "nslookup", "sw_vers", "sysctl", "history",
+    "nslookup", "sw_vers", "history",
 }
 GIT_READONLY = {
     "status", "log", "diff", "show", "rev-parse", "describe", "blame",
@@ -85,27 +94,55 @@ GIT_READONLY = {
     "cat-file", "count-objects",
 }
 GH_READONLY = {"view", "list", "status", "diff", "checks"}
-# Wrappers whose real command is the next token.
-WRAPPERS = {"sudo", "command", "nohup", "time", "xargs"}
+# Wrappers whose real command comes later in the token list. env belongs here,
+# not in READONLY_CMDS: `env FOO=1 cmd` runs cmd, so it must be unwrapped
+# (a bare `env` unwraps to nothing and stays read-only).
+WRAPPERS = {"sudo", "command", "nohup", "time", "xargs", "env", "nice", "stdbuf"}
+FIND_MUTATING_FLAGS = {"-delete", "-exec", "-execdir", "-ok", "-okdir", "-fls"}
 
 # Harmless stderr/dev-null redirects, stripped before the generic ">" check.
 HARMLESS_REDIRECTS = re.compile(r"\s*(2>&1|&?>{1,2}\s*/dev/null|2>{1,2}\s*/dev/null)")
-ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
+ENV_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+# Write/exec patterns inside an inline python -c payload. Heuristic: parsing
+# and printing stay read-only; anything that touches the filesystem, spawns
+# processes, or issues writing HTTP verbs counts as mutating.
+PY_RISKY = re.compile(
+    r"subprocess|shutil\.|socket"
+    r"|os\.(system|popen|remove|unlink|rename|replace|rmdir|mkdir|makedirs"
+    r"|chmod|chown|symlink|link|truncate|environ\[)"
+    r"|\.write\w*\(|\.unlink\(|\.touch\(|\.mkdir\(|\.rename\(|\.rmdir\("
+    r"|open\([^()]*,\s*[\"']?[wax]"
+    r"|urlopen\([^()]*data|requests\.(post|put|patch|delete)"
+)
+# awk writing through its own redirection or shelling out: `print > "file"`,
+# `system("…")`. Checked on the raw segment because the awk program is quoted.
+AWK_RISKY = re.compile(r">>?\s*[\"']|system\s*\(")
 
 
 def split_segments(cmd):
     """Split on |, ||, &&, ;, newline — but never inside quotes.
 
-    Returns (segment, unquoted_text) pairs; redirects are only meaningful in
-    the unquoted portion, so ">" inside a quoted argument doesn't misclassify.
+    Returns (segment, unquoted, expandable) triples. Redirects only count in
+    the unquoted portion (">" inside a quoted argument is literal), while
+    substitution markers count anywhere the shell expands them — outside
+    quotes and inside double quotes, but not inside single quotes.
     """
-    segs, buf, ubuf = [], [], []
+    segs, buf, ubuf, ebuf = [], [], [], []
     quote = None
     i, n = 0, len(cmd)
+
+    def close():
+        segs.append(("".join(buf), "".join(ubuf), "".join(ebuf)))
+        buf.clear()
+        ubuf.clear()
+        ebuf.clear()
+
     while i < n:
         c = cmd[i]
         if quote:
             buf.append(c)
+            if quote == '"':
+                ebuf.append(c)
             if c == quote and cmd[i - 1] != "\\":
                 quote = None
             i += 1
@@ -121,71 +158,97 @@ def split_segments(cmd):
             i += 2
             continue
         if cmd[i : i + 2] in ("||", "&&"):
-            segs.append(("".join(buf), "".join(ubuf)))
-            buf, ubuf = [], []
+            close()
             i += 2
             continue
         if c in (";", "|", "\n"):
-            segs.append(("".join(buf), "".join(ubuf)))
-            buf, ubuf = [], []
+            close()
             i += 1
             continue
         buf.append(c)
         ubuf.append(c)
+        ebuf.append(c)
         i += 1
-    segs.append(("".join(buf), "".join(ubuf)))
+    close()
     return segs
 
 
-def segment_readonly(seg, unquoted):
+def tokenize(text):
+    try:
+        return shlex.split(text)
+    except ValueError:
+        return text.split()
+
+
+def segment_readonly(seg, unquoted, expandable):
     seg = seg.strip().lstrip("(!").strip()
     if not seg:
         return True
     if ">" in HARMLESS_REDIRECTS.sub(" ", unquoted):  # writes a file
         return False
-    stripped = seg
-    while True:
-        replaced = ENV_ASSIGNMENT.sub("", stripped, count=1)
-        if replaced == stripped:
-            break
-        stripped = replaced
-    tokens = stripped.split()
-    if not tokens:
-        return True
-    while tokens and tokens[0].rsplit("/", 1)[-1] in WRAPPERS:
-        tokens = tokens[1:]
-    if tokens and tokens[0].rsplit("/", 1)[-1] == "timeout":
-        tokens = tokens[2:]
+    # Command/process substitution runs an arbitrary inner command — treat as
+    # mutating rather than trying to classify the payload.
+    if "$(" in expandable or "`" in expandable or "<(" in expandable or ">(" in expandable:
+        return False
+    tokens = tokenize(seg)
+    while tokens:
+        head = tokens[0].rsplit("/", 1)[-1]
+        if head in WRAPPERS or ENV_TOKEN.match(tokens[0]):
+            tokens = tokens[1:]
+            continue
+        if head == "timeout":
+            tokens = tokens[2:]
+            continue
+        break
     if not tokens:
         return True
     cmd = tokens[0].rsplit("/", 1)[-1]
-    if cmd in READONLY_CMDS:
-        if cmd == "awk" and any(t == "-i" or t.startswith("inplace") for t in tokens[1:]):
+    args = tokens[1:]
+    if cmd == "find":
+        return not any(t in FIND_MUTATING_FLAGS or t.startswith("-fprint") for t in args)
+    if cmd == "sort":
+        return not any(t == "-o" or t.startswith("--output") or (t.startswith("-o") and len(t) > 2) for t in args)
+    if cmd == "uniq":
+        return len([t for t in args if not t.startswith("-")]) < 2
+    if cmd == "date":
+        return not any(t == "-s" or t.startswith("--set") for t in args)
+    if cmd == "sysctl":
+        return not any(t == "-w" or "=" in t for t in args)
+    if cmd == "awk":
+        if any(t == "-i" or t.startswith("inplace") for t in args):
             return False
+        return not AWK_RISKY.search(seg)
+    if cmd in READONLY_CMDS:
         return True
     if cmd == "sed":
-        return not any(t.startswith("-i") or t == "--in-place" for t in tokens[1:])
+        return not any(t.startswith("-i") or t == "--in-place" for t in args)
     if cmd == "git":
-        sub = next((t for t in tokens[1:] if not t.startswith("-")), "")
+        sub = next((t for t in args if not t.startswith("-")), "")
         return sub in GIT_READONLY
     if cmd == "gh":
-        rest = [t for t in tokens[1:] if not t.startswith("-")]
+        rest = [t for t in args if not t.startswith("-")]
         return bool(rest) and (rest[0] in GH_READONLY or (len(rest) > 1 and rest[1] in GH_READONLY))
     if cmd in ("python", "python3"):
-        return "-c" in tokens or "-V" in tokens or "--version" in tokens
+        if "-V" in args or "--version" in args:
+            return True
+        return "-c" in args and not PY_RISKY.search(seg)
     if cmd == "curl":
-        writes = {"-o", "-O", "--output", "-T", "--upload-file", "-F", "--form"}
-        if any(t in writes or t.startswith("-d") or t.startswith("--data") for t in tokens[1:]):
-            return False
-        if "-X" in tokens:
-            method = tokens[tokens.index("-X") + 1] if tokens.index("-X") + 1 < len(tokens) else ""
-            return method.upper() in ("GET", "HEAD")
+        writes = {"-o", "-O", "--output", "-T", "--upload-file", "-F", "--form", "--form-string", "--json"}
+        for idx, t in enumerate(args):
+            if t in writes or t.startswith("-d") or t.startswith("--data"):
+                return False
+            if t == "-X" or t == "--request":
+                method = args[idx + 1] if idx + 1 < len(args) else ""
+                if method.upper() not in ("GET", "HEAD"):
+                    return False
+            elif t.startswith("-X") and t[2:].upper() not in ("GET", "HEAD"):
+                return False
         return True
     return False
 
 
 def command_readonly(cmd):
-    return all(segment_readonly(seg, unquoted) for seg, unquoted in split_segments(cmd))
+    return all(segment_readonly(*parts) for parts in split_segments(cmd))
 
 
 with open(path) as f:
@@ -214,7 +277,9 @@ with open(path) as f:
 
 print(write_edit, bash_count, mutating_bash)
 PYEOF
-) || COUNTS="0 0 0"
+
+COUNTS=$(python3 "$CLASSIFIER" "$TRANSCRIPT_PATH" 2>/dev/null) || COUNTS="0 0 0"
+rm -f "$CLASSIFIER"
 
 WRITE_EDIT=$(echo "$COUNTS" | awk '{print $1}')
 BASH_COUNT=$(echo "$COUNTS" | awk '{print $2}')

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -10,6 +10,12 @@
 #
 # The stop_hook_active flag in the payload prevents re-entry (this hook won't
 # fire again for the follow-up capture turn).
+#
+# Sessions with zero file edits whose shell commands are all read-only
+# (grep/log/status style research) are exempt: nudging them only costs a full
+# skill invocation that ends in SKIP. The classifier is conservative — any
+# command it can't prove read-only counts as mutating, which preserves the
+# pre-exemption behavior for that session.
 
 set -euo pipefail
 
@@ -49,13 +55,138 @@ print(d.get('transcript_path', ''))
 
 [[ -z "$TRANSCRIPT_PATH" || ! -f "$TRANSCRIPT_PATH" ]] && exit 0
 
-# Count meaningful tool uses: Write/Edit = file mutations, Bash = shell work
+# Count meaningful tool uses: Write/Edit = file mutations, Bash = shell work.
+# Bash commands are additionally classified read-only vs mutating so that
+# edit-free research sessions can be exempted below.
 COUNTS=$(python3 - "$TRANSCRIPT_PATH" <<'PYEOF'
-import json, sys
+import json, re, sys
 
 path = sys.argv[1]
 write_edit = 0
 bash_count = 0
+mutating_bash = 0
+
+# Commands that never mutate state on their own (writes would need a shell
+# redirect, which is detected separately). Anything absent from every list
+# below counts as mutating — unknown means "assume it changed something".
+READONLY_CMDS = {
+    "cat", "ls", "head", "tail", "grep", "egrep", "fgrep", "rg", "find", "fd",
+    "wc", "echo", "printf", "pwd", "which", "whereis", "type", "file", "stat",
+    "du", "df", "ps", "env", "printenv", "id", "whoami", "uname", "date",
+    "true", "false", "test", "[", "diff", "cmp", "tree", "basename", "dirname",
+    "readlink", "realpath", "sort", "uniq", "cut", "tr", "column", "jq", "awk",
+    "md5", "md5sum", "shasum", "sha256sum", "hexdump", "xxd", "strings",
+    "less", "more", "nl", "od", "seq", "sleep", "uptime", "dig", "host",
+    "nslookup", "sw_vers", "sysctl", "history",
+}
+GIT_READONLY = {
+    "status", "log", "diff", "show", "rev-parse", "describe", "blame",
+    "shortlog", "ls-files", "ls-tree", "ls-remote", "grep", "reflog",
+    "cat-file", "count-objects",
+}
+GH_READONLY = {"view", "list", "status", "diff", "checks"}
+# Wrappers whose real command is the next token.
+WRAPPERS = {"sudo", "command", "nohup", "time", "xargs"}
+
+# Harmless stderr/dev-null redirects, stripped before the generic ">" check.
+HARMLESS_REDIRECTS = re.compile(r"\s*(2>&1|&?>{1,2}\s*/dev/null|2>{1,2}\s*/dev/null)")
+ENV_ASSIGNMENT = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=\S*\s+")
+
+
+def split_segments(cmd):
+    """Split on |, ||, &&, ;, newline — but never inside quotes.
+
+    Returns (segment, unquoted_text) pairs; redirects are only meaningful in
+    the unquoted portion, so ">" inside a quoted argument doesn't misclassify.
+    """
+    segs, buf, ubuf = [], [], []
+    quote = None
+    i, n = 0, len(cmd)
+    while i < n:
+        c = cmd[i]
+        if quote:
+            buf.append(c)
+            if c == quote and cmd[i - 1] != "\\":
+                quote = None
+            i += 1
+            continue
+        if c in ("'", '"'):
+            quote = c
+            buf.append(c)
+            i += 1
+            continue
+        if c == "\\" and i + 1 < n:
+            buf.append(cmd[i : i + 2])
+            ubuf.append(cmd[i + 1])
+            i += 2
+            continue
+        if cmd[i : i + 2] in ("||", "&&"):
+            segs.append(("".join(buf), "".join(ubuf)))
+            buf, ubuf = [], []
+            i += 2
+            continue
+        if c in (";", "|", "\n"):
+            segs.append(("".join(buf), "".join(ubuf)))
+            buf, ubuf = [], []
+            i += 1
+            continue
+        buf.append(c)
+        ubuf.append(c)
+        i += 1
+    segs.append(("".join(buf), "".join(ubuf)))
+    return segs
+
+
+def segment_readonly(seg, unquoted):
+    seg = seg.strip().lstrip("(!").strip()
+    if not seg:
+        return True
+    if ">" in HARMLESS_REDIRECTS.sub(" ", unquoted):  # writes a file
+        return False
+    stripped = seg
+    while True:
+        replaced = ENV_ASSIGNMENT.sub("", stripped, count=1)
+        if replaced == stripped:
+            break
+        stripped = replaced
+    tokens = stripped.split()
+    if not tokens:
+        return True
+    while tokens and tokens[0].rsplit("/", 1)[-1] in WRAPPERS:
+        tokens = tokens[1:]
+    if tokens and tokens[0].rsplit("/", 1)[-1] == "timeout":
+        tokens = tokens[2:]
+    if not tokens:
+        return True
+    cmd = tokens[0].rsplit("/", 1)[-1]
+    if cmd in READONLY_CMDS:
+        if cmd == "awk" and any(t == "-i" or t.startswith("inplace") for t in tokens[1:]):
+            return False
+        return True
+    if cmd == "sed":
+        return not any(t.startswith("-i") or t == "--in-place" for t in tokens[1:])
+    if cmd == "git":
+        sub = next((t for t in tokens[1:] if not t.startswith("-")), "")
+        return sub in GIT_READONLY
+    if cmd == "gh":
+        rest = [t for t in tokens[1:] if not t.startswith("-")]
+        return bool(rest) and (rest[0] in GH_READONLY or (len(rest) > 1 and rest[1] in GH_READONLY))
+    if cmd in ("python", "python3"):
+        return "-c" in tokens or "-V" in tokens or "--version" in tokens
+    if cmd == "curl":
+        writes = {"-o", "-O", "--output", "-T", "--upload-file", "-F", "--form"}
+        if any(t in writes or t.startswith("-d") or t.startswith("--data") for t in tokens[1:]):
+            return False
+        if "-X" in tokens:
+            method = tokens[tokens.index("-X") + 1] if tokens.index("-X") + 1 < len(tokens) else ""
+            return method.upper() in ("GET", "HEAD")
+        return True
+    return False
+
+
+def command_readonly(cmd):
+    return all(segment_readonly(seg, unquoted) for seg, unquoted in split_segments(cmd))
+
 
 with open(path) as f:
     for line in f:
@@ -77,17 +208,23 @@ with open(path) as f:
                 write_edit += 1
             elif name == "Bash":
                 bash_count += 1
+                command = (block.get("input") or {}).get("command", "")
+                if not command_readonly(command):
+                    mutating_bash += 1
 
-print(write_edit, bash_count)
+print(write_edit, bash_count, mutating_bash)
 PYEOF
-)
+) || COUNTS="0 0 0"
 
 WRITE_EDIT=$(echo "$COUNTS" | awk '{print $1}')
 BASH_COUNT=$(echo "$COUNTS" | awk '{print $2}')
+MUTATING_BASH=$(echo "$COUNTS" | awk '{print $3}')
 
-# Trigger if any file was written/edited, or if there were ≥ 4 shell calls
-# (suggesting investigation/debugging worth preserving).
-if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || [[ "${BASH_COUNT:-0}" -ge 4 ]]; then
+# Trigger if any file was written/edited, or if there were ≥ 4 shell calls at
+# least one of which mutated state (suggesting investigation/debugging worth
+# preserving). Edit-free sessions whose shell activity is entirely read-only
+# are exempt — see the header note.
+if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || { [[ "${BASH_COUNT:-0}" -ge 4 ]] && [[ "${MUTATING_BASH:-0}" -ge 1 ]]; }; then
   # Atomically claim the right to nudge. Losers of the race exit silently so a
   # duplicate registration produces one nudge, not two. Claimed here rather than
   # earlier so that a below-threshold turn doesn't burn the session's one nudge.

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -12,8 +12,9 @@
 # fire again for the follow-up capture turn).
 #
 # Sessions with zero file edits whose shell commands are all read-only
-# (grep/log/status style research) are exempt: nudging them only costs a full
-# skill invocation that ends in SKIP. The classifier is conservative — any
+# (grep/log/status style research) — and whose other tool calls are provably
+# read-only too — are exempt: nudging them only costs a full skill invocation
+# that ends in SKIP. The classifier is conservative — any
 # command it can't prove read-only counts as mutating, which preserves the
 # pre-exemption behavior for that session. In particular, command/process
 # substitution ($(…), `…`, <(…)) is treated as mutating without inspecting
@@ -72,6 +73,7 @@ path = sys.argv[1]
 write_edit = 0
 bash_count = 0
 mutating_bash = 0
+suspicious_tools = 0
 
 # Commands that never mutate state on their own (writes would need a shell
 # redirect or substitution, both detected separately). Anything absent from
@@ -101,6 +103,37 @@ GIT_READONLY = {
     "cat-file", "count-objects",
 }
 GH_READONLY = {"view", "list", "status", "diff", "checks"}
+# Harness tools that never mutate anything outside the session: file/web
+# reading, planning, task bookkeeping. Any other non-Bash tool call —
+# notably MCP tools without a clear read verb — makes the session
+# ineligible for the read-only exemption, because a real system mutation
+# (a CRM update, an SQL INSERT) may hide behind it.
+CORE_READONLY_TOOLS = {
+    "Read", "Glob", "Grep", "LS", "WebFetch", "WebSearch", "TodoWrite",
+    "TodoRead", "NotebookRead", "Task", "Agent", "AskUserQuestion",
+    "ToolSearch", "Skill", "SkillSearch", "SlashCommand", "EnterPlanMode",
+    "ExitPlanMode", "EnterWorktree", "ExitWorktree", "Explore", "Plan",
+    "TaskCreate", "TaskUpdate", "TaskGet", "TaskList", "TaskOutput",
+    "TaskStop", "BashOutput", "KillShell", "SendUserFile", "Monitor",
+    "ScheduleWakeup", "ListMcpResourcesTool", "ReadMcpResourceTool",
+    "ReadMcpResourceDirTool",
+}
+MCP_READ_VERBS = {
+    "get", "list", "search", "read", "query", "fetch", "find", "describe",
+    "inspect", "explain", "compare", "view", "check", "status", "whoami",
+    "resolve", "analyze", "show", "health", "info", "download", "lookup",
+    "browse", "watch", "screenshot",
+}
+# Write verbs take priority over read verbs for names carrying both
+# ("get-or-create-session" creates).
+MCP_WRITE_VERBS = {
+    "create", "update", "delete", "remove", "write", "insert", "upsert",
+    "execute", "run", "send", "post", "put", "patch", "move", "add", "set",
+    "complete", "archive", "clone", "push", "upload", "provision", "reset",
+    "apply", "schedule", "cancel", "start", "stop", "restart", "deploy",
+    "publish", "merge", "commit", "approve", "assign", "register", "enable",
+    "disable", "duplicate",
+}
 # Wrappers whose real command comes later in the token list. env belongs here,
 # not in READONLY_CMDS: `env FOO=1 cmd` runs cmd, so it must be unwrapped
 # (a bare `env` unwraps to nothing and stays read-only).
@@ -216,6 +249,18 @@ def segment_readonly(seg, unquoted, expandable):
     args = tokens[1:]
     if cmd == "find":
         return not any(t in FIND_MUTATING_FLAGS or t.startswith("-fprint") for t in args)
+    if cmd == "fd":
+        return not any(t in ("-x", "--exec", "-X", "--exec-batch") for t in args)
+    if cmd == "rg":
+        return not any(t == "--pre" or t.startswith("--pre=") for t in args)
+    if cmd == "tree":
+        return not any(t == "-o" for t in args)
+    if cmd == "hostname":
+        # Bare hostname prints; with a non-flag argument it SETS the hostname.
+        return not [t for t in args if not t.startswith("-")]
+    if cmd == "xxd":
+        # A second positional argument is an output file (xxd -r patch.hex bin).
+        return len([t for t in args if not t.startswith("-")]) < 2
     if cmd == "sort":
         return not any(t == "-o" or t.startswith("--output") or (t.startswith("-o") and len(t) > 2) for t in args)
     if cmd == "uniq":
@@ -304,8 +349,19 @@ with open(path) as f:
                 command = (block.get("input") or {}).get("command", "")
                 if not command_readonly(command):
                     mutating_bash += 1
+            elif name in CORE_READONLY_TOOLS:
+                continue
+            elif name.startswith("mcp__"):
+                words = re.split(r"[-_]", name.rsplit("__", 1)[-1].lower())
+                if any(w in MCP_WRITE_VERBS for w in words) or not any(
+                    w in MCP_READ_VERBS for w in words
+                ):
+                    suspicious_tools += 1
+            else:
+                # Unknown harness tool — assume it mutated something.
+                suspicious_tools += 1
 
-print(write_edit, bash_count, mutating_bash)
+print(write_edit, bash_count, mutating_bash, suspicious_tools)
 PYEOF
 
 COUNTS=$(python3 "$CLASSIFIER" "$TRANSCRIPT_PATH" 2>/dev/null) || COUNTS="0 0 0"
@@ -314,12 +370,16 @@ rm -f "$CLASSIFIER"
 WRITE_EDIT=$(echo "$COUNTS" | awk '{print $1}')
 BASH_COUNT=$(echo "$COUNTS" | awk '{print $2}')
 MUTATING_BASH=$(echo "$COUNTS" | awk '{print $3}')
+SUSPICIOUS_TOOLS=$(echo "$COUNTS" | awk '{print $4}')
 
 # Trigger if any file was written/edited, or if there were ≥ 4 shell calls at
 # least one of which mutated state (suggesting investigation/debugging worth
 # preserving). Edit-free sessions whose shell activity is entirely read-only
-# are exempt — see the header note.
-if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || { [[ "${BASH_COUNT:-0}" -ge 4 ]] && [[ "${MUTATING_BASH:-0}" -ge 1 ]]; }; then
+# are exempt — but only when no other tool call could have mutated a real
+# system (MCP writes, unknown harness tools). Suspicious tool calls never
+# trigger on their own — they only disable the exemption, so this hook never
+# nudges where the pre-exemption threshold (edits >= 1 or bash >= 4) wouldn't.
+if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || { [[ "${BASH_COUNT:-0}" -ge 4 ]] && { [[ "${MUTATING_BASH:-0}" -ge 1 ]] || [[ "${SUSPICIOUS_TOOLS:-0}" -ge 1 ]]; }; }; then
   # Atomically claim the right to nudge. Losers of the race exit silently so a
   # duplicate registration produces one nudge, not two. Claimed here rather than
   # earlier so that a below-threshold turn doesn't burn the session's one nudge.

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -88,7 +88,7 @@ READONLY_CMDS = {
     "readlink", "realpath", "cut", "tr", "column", "jq",
     "md5", "md5sum", "shasum", "sha256sum", "hexdump", "xxd", "strings",
     "less", "more", "nl", "od", "seq", "sleep", "uptime", "dig", "host",
-    "nslookup", "sw_vers", "history",
+    "nslookup", "sw_vers",
     # Shell-session state only — nothing durable outside the (already
     # finished) shell process, so treating these as read-only keeps common
     # research chains like `cd repo && git log` in the exemption.
@@ -156,10 +156,12 @@ PY_RISKY = re.compile(
     r"|open\([^()]*,\s*[\"']?[wax]|open\([^()]*mode\s*=\s*[\"'][wax]"
     r"|urlopen\([^()]*data|Request\([^()]*data|requests\.(post|put|patch|delete)"
     r"|INSERT INTO|DELETE FROM|DROP TABLE|CREATE TABLE|ALTER TABLE"
+    r"|smtplib|ftplib|paramiko|os\.kill"
 )
 # awk writing through its own redirection or shelling out: `print > "file"`,
-# `system("…")`. Checked on the raw segment because the awk program is quoted.
-AWK_RISKY = re.compile(r">>?\s*[\"']|system\s*\(")
+# `system("…")`, `print | "cmd"`, `"cmd" | getline`. Checked on the raw
+# segment because the awk program is quoted.
+AWK_RISKY = re.compile(r">>?\s*[\"']|system\s*\(|\|\s*[\"']|[\"']\s*\|")
 
 
 def split_segments(cmd):
@@ -186,7 +188,9 @@ def split_segments(cmd):
             buf.append(c)
             if quote == '"':
                 ebuf.append(c)
-            if c == quote and cmd[i - 1] != "\\":
+            # A single quote always closes — the shell does not allow
+            # escaping inside '…'; only double quotes honor a backslash.
+            if c == quote and (quote == "'" or cmd[i - 1] != "\\"):
                 quote = None
             i += 1
             continue
@@ -279,15 +283,21 @@ def segment_readonly(seg, unquoted, expandable):
         if any(t.startswith("-i") or t == "--in-place" for t in args):
             return False
         # The sed `w` script command writes a file without any -i flag:
-        # `sed -n 'w out.txt'`, `s/a/b/w out.txt`.
-        return not any(
-            re.search(r"(^|;)\s*w\s|/w\b", t) for t in args if not t.startswith("-")
-        )
+        # `sed -n 'w out.txt'`, `s/a/b/w out.txt` — scanned on every token
+        # so a glued `-e's/a/b/w out'` script is caught too.
+        return not any(re.search(r"(^|;)\s*w\s|/w\b", t) for t in args)
+    if cmd == "history":
+        # history -c/-d clear entries, -w/-a/-r touch the history file.
+        return not any(t.startswith("-") and t != "--" for t in args)
     if cmd == "git":
         # `git diff/log --output=file` writes without a shell redirect.
         if any(t.startswith("--output") for t in args):
             return False
-        sub = next((t for t in args if not t.startswith("-")), "")
+        positional = [t for t in args if not t.startswith("-")]
+        sub = positional[0] if positional else ""
+        if sub == "reflog":
+            # `git reflog expire/delete` mutates; bare reflog / reflog show reads.
+            return len(positional) < 2 or positional[1] == "show"
         return sub in GIT_READONLY
     if cmd == "gh":
         rest = [t for t in args if not t.startswith("-")]
@@ -299,10 +309,11 @@ def segment_readonly(seg, unquoted, expandable):
     if cmd == "curl":
         long_writes = {
             "--output", "--output-dir", "--remote-name", "--upload-file",
-            "--form", "--form-string", "--json",
+            "--form", "--form-string", "--json", "--cookie-jar",
+            "--dump-header", "--etag-save",
         }
         for idx, t in enumerate(args):
-            if t in long_writes or t.startswith("--data"):
+            if t in long_writes or t.startswith("--data") or t.startswith("--trace"):
                 return False
             if t == "--request":
                 method = args[idx + 1] if idx + 1 < len(args) else ""
@@ -314,9 +325,10 @@ def segment_readonly(seg, unquoted, expandable):
                 method = t[2:] or (args[idx + 1] if idx + 1 < len(args) else "")
                 if method.upper() not in ("GET", "HEAD"):
                     return False
-            elif re.match(r"^-[A-Za-z]*[dDoOTFX]", t):
-                # Short flags cluster (-sd, -sLo, -sT): d/D/o/O/T/F/X all send
-                # data or write files, wherever they sit in the cluster.
+            elif re.match(r"^-[A-Za-z]*[dDoOTFXc]", t):
+                # Short flags cluster (-sd, -sLo, -sT, -sc): d/D/o/O/T/F/X/c
+                # all send data or write files (c = cookie jar), wherever
+                # they sit in the cluster.
                 return False
         return True
     return False

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -87,6 +87,13 @@ READONLY_CMDS = {
     "md5", "md5sum", "shasum", "sha256sum", "hexdump", "xxd", "strings",
     "less", "more", "nl", "od", "seq", "sleep", "uptime", "dig", "host",
     "nslookup", "sw_vers", "history",
+    # Shell-session state only — nothing durable outside the (already
+    # finished) shell process, so treating these as read-only keeps common
+    # research chains like `cd repo && git log` in the exemption.
+    "cd", "pushd", "popd", "export", "unset", "umask", "ulimit", "shopt",
+    "set", "local", "declare", "typeset", "read", "wait", ":",
+    "man", "whatis", "apropos", "hostname", "arch", "nproc", "getconf",
+    "locale", "groups", "tty", "clear",
 }
 GIT_READONLY = {
     "status", "log", "diff", "show", "rev-parse", "describe", "blame",
@@ -107,12 +114,15 @@ ENV_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 # and printing stay read-only; anything that touches the filesystem, spawns
 # processes, or issues writing HTTP verbs counts as mutating.
 PY_RISKY = re.compile(
-    r"subprocess|shutil\.|socket"
+    r"subprocess|shutil\.|socket|http\.client|HTTPConnection"
+    r"|\bexec\s*\(|\beval\s*\(|__import__"
     r"|os\.(system|popen|remove|unlink|rename|replace|rmdir|mkdir|makedirs"
     r"|chmod|chown|symlink|link|truncate|environ\[)"
     r"|\.write\w*\(|\.unlink\(|\.touch\(|\.mkdir\(|\.rename\(|\.rmdir\("
-    r"|open\([^()]*,\s*[\"']?[wax]"
-    r"|urlopen\([^()]*data|requests\.(post|put|patch|delete)"
+    r"|\.save\(|\.to_csv\(|\.to_excel\(|\.commit\("
+    r"|open\([^()]*,\s*[\"']?[wax]|open\([^()]*mode\s*=\s*[\"'][wax]"
+    r"|urlopen\([^()]*data|Request\([^()]*data|requests\.(post|put|patch|delete)"
+    r"|INSERT INTO|DELETE FROM|DROP TABLE|CREATE TABLE|ALTER TABLE"
 )
 # awk writing through its own redirection or shelling out: `print > "file"`,
 # `system("…")`. Checked on the raw segment because the awk program is quoted.
@@ -221,8 +231,17 @@ def segment_readonly(seg, unquoted, expandable):
     if cmd in READONLY_CMDS:
         return True
     if cmd == "sed":
-        return not any(t.startswith("-i") or t == "--in-place" for t in args)
+        if any(t.startswith("-i") or t == "--in-place" for t in args):
+            return False
+        # The sed `w` script command writes a file without any -i flag:
+        # `sed -n 'w out.txt'`, `s/a/b/w out.txt`.
+        return not any(
+            re.search(r"(^|;)\s*w\s|/w\b", t) for t in args if not t.startswith("-")
+        )
     if cmd == "git":
+        # `git diff/log --output=file` writes without a shell redirect.
+        if any(t.startswith("--output") for t in args):
+            return False
         sub = next((t for t in args if not t.startswith("-")), "")
         return sub in GIT_READONLY
     if cmd == "gh":
@@ -233,15 +252,26 @@ def segment_readonly(seg, unquoted, expandable):
             return True
         return "-c" in args and not PY_RISKY.search(seg)
     if cmd == "curl":
-        writes = {"-o", "-O", "--output", "-T", "--upload-file", "-F", "--form", "--form-string", "--json"}
+        long_writes = {
+            "--output", "--output-dir", "--remote-name", "--upload-file",
+            "--form", "--form-string", "--json",
+        }
         for idx, t in enumerate(args):
-            if t in writes or t.startswith("-d") or t.startswith("--data"):
+            if t in long_writes or t.startswith("--data"):
                 return False
-            if t == "-X" or t == "--request":
+            if t == "--request":
                 method = args[idx + 1] if idx + 1 < len(args) else ""
                 if method.upper() not in ("GET", "HEAD"):
                     return False
-            elif t.startswith("-X") and t[2:].upper() not in ("GET", "HEAD"):
+            elif t.startswith("--"):
+                continue
+            elif t.startswith("-X"):
+                method = t[2:] or (args[idx + 1] if idx + 1 < len(args) else "")
+                if method.upper() not in ("GET", "HEAD"):
+                    return False
+            elif re.match(r"^-[A-Za-z]*[dDoOTFX]", t):
+                # Short flags cluster (-sd, -sLo, -sT): d/D/o/O/T/F/X all send
+                # data or write files, wherever they sit in the cluster.
                 return False
         return True
     return False

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -189,6 +189,48 @@ class StopHookBehaviorTest(unittest.TestCase):
         entries = [_bash_entry("awk '{print > \"split.txt\"}' data.txt")] * 4
         self.assertEqual(self._run(entries).returncode, 2)
 
+    def test_cd_chain_stays_readonly(self):
+        entries = [_bash_entry("cd /repo && git log --oneline -5")] * 4
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_python_exec_counts_as_mutating(self):
+        entries = [_bash_entry("python3 -c \"exec(open('payload.py').read())\"")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_python_open_mode_kwarg_counts_as_mutating(self):
+        entries = [_bash_entry("python3 -c \"open('f', mode='w')\"")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_sed_write_command_counts_as_mutating(self):
+        entries = [
+            _bash_entry("sed -n 'w /tmp/out.txt' input.txt"),
+            _bash_entry("sed 's/a/b/w changed.txt' input.txt"),
+            _bash_entry("sed -n 'w /tmp/out2.txt' input.txt"),
+            _bash_entry("sed 's/x/y/w other.txt' input.txt"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_plain_sed_stays_readonly(self):
+        entries = [_bash_entry("sed -n '5,10p' input.txt")] * 4
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_git_output_flag_counts_as_mutating(self):
+        entries = [_bash_entry("git diff --output=changes.patch main")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_curl_short_flag_clusters_count_as_mutating(self):
+        entries = [
+            _bash_entry("curl -sd '{\"a\":1}' https://api.example.com/x"),
+            _bash_entry("curl -sLo out.json https://api.example.com/x"),
+            _bash_entry("curl -sT upload.bin https://api.example.com/x"),
+            _bash_entry("curl -sD headers.txt https://api.example.com/x"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_curl_plain_get_flags_stay_readonly(self):
+        entries = [_bash_entry("curl -fsSL https://api.example.com/status")] * 4
+        self.assertEqual(self._run(entries).returncode, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -293,6 +293,50 @@ class StopHookBehaviorTest(unittest.TestCase):
         entries = [_bash_entry("tree -o listing.txt src/")] * 4
         self.assertEqual(self._run(entries).returncode, 2)
 
+    def test_single_quote_always_closes(self):
+        # In shell, backslash does not escape inside '…': the quote after
+        # the backslash CLOSES the string and the rm runs unquoted.
+        entries = [_bash_entry("echo 'a\\' ; rm -rf /tmp/probe'")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_git_reflog_expire_counts_as_mutating(self):
+        entries = [
+            _bash_entry("git reflog expire --expire=now --all"),
+            _bash_entry("git reflog delete HEAD@{2}"),
+            _bash_entry("git reflog expire --expire=now --all"),
+            _bash_entry("git reflog delete HEAD@{1}"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_git_reflog_show_stays_readonly(self):
+        entries = [_bash_entry("git reflog"), _bash_entry("git reflog show HEAD")] * 2
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_curl_cookie_jar_counts_as_mutating(self):
+        entries = [
+            _bash_entry("curl -sc cookies.txt https://example.com/login"),
+            _bash_entry("curl --cookie-jar cj.txt https://example.com"),
+            _bash_entry("curl --dump-header h.txt https://example.com"),
+            _bash_entry("curl --trace-ascii t.log https://example.com"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_awk_pipe_to_command_counts_as_mutating(self):
+        entries = [_bash_entry("awk '{print | \"sh\"}' cmds.txt")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_sed_glued_write_script_counts_as_mutating(self):
+        entries = [_bash_entry("sed -e's/a/b/w out.txt' input.txt")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_history_clear_counts_as_mutating(self):
+        entries = [_bash_entry("history -c")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_python_smtplib_counts_as_mutating(self):
+        entries = [_bash_entry("python3 -c \"import smtplib; ...\"")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -38,6 +38,23 @@ def _edit_entry(tool="Edit"):
     }
 
 
+def _tool_entry(name):
+    return {
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": name, "input": {}}],
+        }
+    }
+
+
+_READONLY_BASH = [
+    _bash_entry("git status"),
+    _bash_entry("ls -la"),
+    _bash_entry("grep foo bar.txt"),
+    _bash_entry("cat notes.md"),
+]
+
+
 @unittest.skipIf(shutil.which("bash") is None, "requires bash")
 class StopHookBehaviorTest(unittest.TestCase):
     def setUp(self):
@@ -230,6 +247,51 @@ class StopHookBehaviorTest(unittest.TestCase):
     def test_curl_plain_get_flags_stay_readonly(self):
         entries = [_bash_entry("curl -fsSL https://api.example.com/status")] * 4
         self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_mcp_write_tool_disables_exemption(self):
+        # A real system mutation hides behind an MCP call: read-only bash
+        # alone must not exempt the session.
+        entries = _READONLY_BASH + [_tool_entry("mcp__notion__notion-update-page")]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_mcp_read_tools_keep_exemption(self):
+        entries = _READONLY_BASH + [
+            _tool_entry("mcp__postgres__list_schemas"),
+            _tool_entry("mcp__notion__notion-search"),
+            _tool_entry("Read"),
+            _tool_entry("Grep"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_mcp_write_alone_matches_upstream_threshold(self):
+        # Upstream never triggered on MCP-only sessions (no edits, < 4 bash);
+        # suspicious tools only disable the exemption, they don't nudge alone.
+        entries = [_tool_entry("mcp__notion__notion-update-page")] * 3
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_mcp_get_or_create_counts_as_write(self):
+        entries = _READONLY_BASH + [_tool_entry("mcp__x__get-or-create-session")]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_unknown_harness_tool_disables_exemption(self):
+        entries = _READONLY_BASH + [_tool_entry("Artifact")]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_hostname_with_argument_counts_as_mutating(self):
+        entries = [_bash_entry("hostname build-box-7")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_bare_hostname_stays_readonly(self):
+        entries = [_bash_entry("hostname"), _bash_entry("hostname -f")] * 2
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_fd_exec_counts_as_mutating(self):
+        entries = [_bash_entry("fd -e tmp -x rm {}")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_tree_output_flag_counts_as_mutating(self):
+        entries = [_bash_entry("tree -o listing.txt src/")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -135,6 +135,60 @@ class StopHookBehaviorTest(unittest.TestCase):
         busy = self._run([_edit_entry()], session_id="keep")
         self.assertEqual(busy.returncode, 2)
 
+    def test_command_substitution_counts_as_mutating(self):
+        # $(…) runs an arbitrary inner command — even inside double quotes.
+        entries = [_bash_entry('echo "$(rm -rf /tmp/x)"')] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_single_quoted_substitution_stays_literal(self):
+        entries = [_bash_entry("grep -F '$(not executed)' file.txt")] * 4
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_find_delete_counts_as_mutating(self):
+        entries = [_bash_entry("find . -name '*.tmp' -delete")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_find_exec_counts_as_mutating(self):
+        entries = [_bash_entry("find . -name '*.log' -exec rm {} +")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_plain_find_stays_readonly(self):
+        entries = [_bash_entry("find . -name '*.md' -type f")] * 4
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_curl_glued_method_counts_as_mutating(self):
+        entries = [
+            _bash_entry("curl -XPOST https://api.example.com/things"),
+            _bash_entry("curl --request DELETE https://api.example.com/things/1"),
+            _bash_entry("curl --json '{}' https://api.example.com/things"),
+            _bash_entry("curl -XPUT https://api.example.com/things/2"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_sort_output_flag_counts_as_mutating(self):
+        entries = [_bash_entry("sort -o sorted.txt input.txt")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_env_unwraps_to_real_command(self):
+        entries = [_bash_entry("env FOO=1 python3 build.py")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_bare_env_stays_readonly(self):
+        entries = [_bash_entry("env | grep PATH")] * 4
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_python_inline_write_counts_as_mutating(self):
+        entries = [_bash_entry("python3 -c \"import os; os.remove('x')\"")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_python_inline_parse_stays_readonly(self):
+        entries = [_bash_entry("python3 -c \"import json,sys; print(json.load(sys.stdin)['a'])\"")] * 4
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_awk_internal_redirect_counts_as_mutating(self):
+        entries = [_bash_entry("awk '{print > \"split.txt\"}' data.txt")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -1,0 +1,140 @@
+"""Behavioral tests for the Stop hook's trigger logic.
+
+Runs ``wiki-stop-capture.sh`` against synthetic transcripts and asserts on the
+exit code contract (0 = silent, 2 = nudge on stderr). Covers the read-only
+session exemption: a session with zero file edits whose shell commands are all
+provably read-only must not nudge, while any file edit — or shell activity the
+classifier can't prove read-only — keeps the pre-exemption behavior.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+HOOK = ROOT / ".claude" / "hooks" / "wiki-stop-capture.sh"
+
+
+def _bash_entry(command):
+    return {
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": "Bash", "input": {"command": command}}],
+        }
+    }
+
+
+def _edit_entry(tool="Edit"):
+    return {
+        "message": {
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": tool, "input": {"file_path": "/tmp/x"}}],
+        }
+    }
+
+
+@unittest.skipIf(shutil.which("bash") is None, "requires bash")
+class StopHookBehaviorTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+        self._session_seq = 0
+
+    def _run(self, entries, session_id=None, stop_hook_active=False):
+        transcript = self.tmp / "transcript.jsonl"
+        transcript.write_text("".join(json.dumps(e) + "\n" for e in entries))
+        if session_id is None:
+            self._session_seq += 1
+            session_id = f"s{self._session_seq}"
+        payload = {
+            "session_id": session_id,
+            "transcript_path": str(transcript),
+            "stop_hook_active": stop_hook_active,
+        }
+        # Isolated TMPDIR so sentinel state never leaks between tests.
+        return subprocess.run(
+            ["bash", str(HOOK)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(self.tmp)},
+        )
+
+    def test_file_edit_triggers_nudge(self):
+        result = self._run([_edit_entry()])
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("/wiki-capture --quick", result.stderr)
+
+    def test_readonly_session_is_exempt(self):
+        entries = [
+            _bash_entry("gh pr list --state open"),
+            _bash_entry("git log --oneline -20"),
+            _bash_entry("grep -rn 'pattern' src/ | head -50"),
+            _bash_entry("cat README.md"),
+            _bash_entry("python3 -c \"import json,sys; print(json.load(sys.stdin))\""),
+            _bash_entry("curl -s https://api.example.com/status"),
+        ]
+        result = self._run(entries)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stderr, "")
+
+    def test_one_mutating_command_restores_trigger(self):
+        entries = [
+            _bash_entry("git status"),
+            _bash_entry("ls -la"),
+            _bash_entry("grep foo bar.txt"),
+            _bash_entry("npm install left-pad"),
+        ]
+        result = self._run(entries)
+        self.assertEqual(result.returncode, 2)
+
+    def test_redirect_counts_as_mutating(self):
+        entries = [_bash_entry("echo hi > out.txt")] * 4
+        result = self._run(entries)
+        self.assertEqual(result.returncode, 2)
+
+    def test_devnull_redirect_stays_readonly(self):
+        entries = [_bash_entry("grep -c foo bar.txt 2>/dev/null")] * 4
+        result = self._run(entries)
+        self.assertEqual(result.returncode, 0)
+
+    def test_mutating_git_and_sed_classified(self):
+        entries = [
+            _bash_entry("git checkout -b feature"),
+            _bash_entry("sed -i '' 's/a/b/' file.txt"),
+            _bash_entry("git push origin main"),
+            _bash_entry("mkdir -p build"),
+        ]
+        result = self._run(entries)
+        self.assertEqual(result.returncode, 2)
+
+    def test_below_threshold_is_silent(self):
+        entries = [_bash_entry("npm install"), _bash_entry("rm -rf build")]
+        result = self._run(entries)
+        self.assertEqual(result.returncode, 0)
+
+    def test_sentinel_prevents_second_nudge(self):
+        first = self._run([_edit_entry()], session_id="same")
+        self.assertEqual(first.returncode, 2)
+        second = self._run([_edit_entry()], session_id="same")
+        self.assertEqual(second.returncode, 0)
+        self.assertEqual(second.stderr, "")
+
+    def test_stop_hook_active_suppresses(self):
+        result = self._run([_edit_entry()], stop_hook_active=True)
+        self.assertEqual(result.returncode, 0)
+
+    def test_below_threshold_does_not_burn_sentinel(self):
+        quiet = self._run([_bash_entry("ls")], session_id="keep")
+        self.assertEqual(quiet.returncode, 0)
+        busy = self._run([_edit_entry()], session_id="keep")
+        self.assertEqual(busy.returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# fix(hooks): exempt read-only sessions from the Stop-hook capture nudge

## Problem

The Stop hook nudges `/wiki-capture --quick` when a session has `edits >= 1 OR bash >= 4`. The bash-count arm fires on pure research sessions — e.g. 0 file edits and a run of `gh pr list` / `git log` / `grep` / `cat` commands that only read state. Each false nudge costs a full skill invocation that predictably ends in the KEEP/SKIP gate's SKIP: wasted tokens and an extra turn at every session end.

Observed in practice (2026-08-03): a status-check session with 0 edits and ~30 read-only shell commands (`gh`, `grep`, `python3 -c` parsers) was nudged, and the capture skill correctly skipped — the whole round-trip bought nothing.

## Change

The transcript scan now also classifies each `Bash` command as read-only or mutating:

- **Quote-aware pipeline splitting** — segments split on `| || && ; \n`, but never inside quotes, so `python3 -c "…; print(…)"` stays one command.
- **Redirect detection** — an unquoted `>` marks the segment mutating; `2>&1` and `/dev/null` redirects stay harmless; `>` inside a quoted argument is ignored.
- **Command awareness** — an allowlist of never-mutating commands, plus subcommand/flag checks for `git` (status/log/diff/show/…), `gh` (view/list/status/diff/checks), `sed` (`-i` → mutating), `python`/`python3` (`-c`/`-V` only), and `curl` (write/data/upload flags or non-GET `-X` → mutating). Wrappers (`sudo`, `time`, `xargs`, `timeout`, env assignments) are stripped first.
- **Conservative default** — anything the classifier can't prove read-only counts as mutating, so behavior for such sessions is exactly as before this change.

New trigger:

| Session shape | Before | After |
|---|---|---|
| ≥ 1 file edit | nudge | nudge (unchanged) |
| 0 edits, ≥ 4 bash, ≥ 1 mutating | nudge | nudge (unchanged) |
| 0 edits, ≥ 4 bash, all read-only | nudge → SKIP | **silent exit 0** |

This doubles as a cheap pre-gate: the SKIP decision for research sessions now happens inside the hook for free, instead of costing a skill turn.

## Not changed

- The sentinel / `stop_hook_active` logic from #151 is untouched (and covered by the new tests).
- The nudge message and exit-code contract (0 silent / 2 stderr) are unchanged.

## Tests

`tests/test_stop_hook_behavior.py` runs the hook against synthetic transcripts with an isolated `TMPDIR` and pins: edit-trigger, read-only exemption, single-mutating-command restore, redirect edges (`> file` vs `2>/dev/null`), git/sed classification, below-threshold silence, sentinel once-per-session, sentinel not burned by quiet turns, and `stop_hook_active` suppression. All 10 fail (2 assertions) against the current hook and pass with the patch; the existing `test_stop_hook_packaging` suite still passes.

## Possible follow-up (out of scope here)

Excluding the vault's `_raw/` writes from the edit counter would keep a session whose only writes are wiki captures from triggering its first nudge. With the once-per-session sentinel it no longer causes loops, so it's left out to keep this change small.
