### PR TITLE
fix(hooks): harden the read-only classifier; re-arm the nudge for long sessions

### DIFF
--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -108,32 +108,48 @@ GH_READONLY = {"view", "list", "status", "diff", "checks"}
 # notably MCP tools without a clear read verb — makes the session
 # ineligible for the read-only exemption, because a real system mutation
 # (a CRM update, an SQL INSERT) may hide behind it.
+# Task/Agent are NOT here: a spawned subagent can edit files or call write
+# APIs, so they get argument-aware handling in the counting loop (only the
+# read-only agent types Explore/Plan stay neutral). EnterWorktree/ExitWorktree
+# are not here either — they create/remove git branches and worktrees.
 CORE_READONLY_TOOLS = {
     "Read", "Glob", "Grep", "LS", "WebFetch", "WebSearch", "TodoWrite",
-    "TodoRead", "NotebookRead", "Task", "Agent", "AskUserQuestion",
+    "TodoRead", "NotebookRead", "AskUserQuestion",
     "ToolSearch", "Skill", "SkillSearch", "SlashCommand", "EnterPlanMode",
-    "ExitPlanMode", "EnterWorktree", "ExitWorktree", "Explore", "Plan",
+    "ExitPlanMode", "Explore", "Plan",
     "TaskCreate", "TaskUpdate", "TaskGet", "TaskList", "TaskOutput",
     "TaskStop", "BashOutput", "KillShell", "SendUserFile", "Monitor",
     "ScheduleWakeup", "ListMcpResourcesTool", "ReadMcpResourceTool",
     "ReadMcpResourceDirTool",
 }
+READONLY_AGENT_TYPES = {"Explore", "Plan"}
+# "resolve" is deliberately absent from the read verbs: resolving a review
+# thread mutates it, so resolve-named tools stay suspicious.
 MCP_READ_VERBS = {
     "get", "list", "search", "read", "query", "fetch", "find", "describe",
     "inspect", "explain", "compare", "view", "check", "status", "whoami",
-    "resolve", "analyze", "show", "health", "info", "download", "lookup",
+    "analyze", "show", "health", "info", "download", "lookup",
     "browse", "watch", "screenshot",
 }
 # Write verbs take priority over read verbs for names carrying both
-# ("get-or-create-session" creates).
+# ("get-or-create-session" creates; "prepare_query_tuning" provisions).
 MCP_WRITE_VERBS = {
     "create", "update", "delete", "remove", "write", "insert", "upsert",
     "execute", "run", "send", "post", "put", "patch", "move", "add", "set",
     "complete", "archive", "clone", "push", "upload", "provision", "reset",
     "apply", "schedule", "cancel", "start", "stop", "restart", "deploy",
     "publish", "merge", "commit", "approve", "assign", "register", "enable",
-    "disable", "duplicate",
+    "disable", "duplicate", "prepare",
 }
+# A read-verb-named SQL tool can still execute DML (EXPLAIN ANALYZE runs the
+# statement; run_sql-style payloads carry writes) — when the tool name hints
+# at SQL, its serialized input is scanned for write statements too.
+SQL_TOOL_HINT = {"sql", "statement", "query", "database", "db"}
+SQL_WRITE_RX = re.compile(
+    r"\b(insert|update|delete|drop|alter|truncate|grant|revoke|vacuum)\b"
+    r"|\"analyze\"\s*:\s*true",
+    re.IGNORECASE,
+)
 # Wrappers whose real command comes later in the token list. env belongs here,
 # not in READONLY_CMDS: `env FOO=1 cmd` runs cmd, so it must be unwrapped
 # (a bare `env` unwraps to nothing and stays read-only).
@@ -149,19 +165,28 @@ ENV_TOKEN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
 PY_RISKY = re.compile(
     r"subprocess|shutil\.|socket|http\.client|HTTPConnection"
     r"|\bexec\s*\(|\beval\s*\(|__import__"
+    r"|import\s+os\s+as|from\s+os\s+import"
     r"|os\.(system|popen|remove|unlink|rename|replace|rmdir|mkdir|makedirs"
     r"|chmod|chown|symlink|link|truncate|environ\[)"
     r"|\.write\w*\(|\.unlink\(|\.touch\(|\.mkdir\(|\.rename\(|\.rmdir\("
     r"|\.save\(|\.to_csv\(|\.to_excel\(|\.commit\("
+    r"|\.execute(many|script)?\s*\("
+    r"|\.open\(\s*[\"'][wax]"
     r"|open\([^()]*,\s*[\"']?[wax]|open\([^()]*mode\s*=\s*[\"'][wax]"
     r"|urlopen\([^()]*data|Request\([^()]*data|requests\.(post|put|patch|delete)"
     r"|INSERT INTO|DELETE FROM|DROP TABLE|CREATE TABLE|ALTER TABLE"
-    r"|smtplib|ftplib|paramiko|os\.kill"
+    r"|smtplib|ftplib|paramiko|os\.kill",
+    re.IGNORECASE,
 )
-# awk writing through its own redirection or shelling out: `print > "file"`,
-# `system("…")`, `print | "cmd"`, `"cmd" | getline`. Checked on the raw
-# segment because the awk program is quoted.
-AWK_RISKY = re.compile(r">>?\s*[\"']|system\s*\(|\|\s*[\"']|[\"']\s*\|")
+# awk writing or shelling out through its own syntax: redirection or pipe to
+# a quoted string OR a variable (`print > f`, `print | c`), system(),
+# close() (only used with files/pipes), getline. `>` followed by a digit
+# stays clean so numeric comparisons ($3 > 100) don't trip it. Checked on
+# the raw segment because the awk program is quoted.
+AWK_RISKY = re.compile(
+    r">>?\s*[\"'A-Za-z_]|\|\s*[\"'A-Za-z_]|[\"']\s*\|"
+    r"|system\s*\(|close\s*\(|getline"
+)
 
 
 def split_segments(cmd):
@@ -189,9 +214,17 @@ def split_segments(cmd):
             if quote == '"':
                 ebuf.append(c)
             # A single quote always closes — the shell does not allow
-            # escaping inside '…'; only double quotes honor a backslash.
-            if c == quote and (quote == "'" or cmd[i - 1] != "\\"):
-                quote = None
+            # escaping inside '…'. A double quote is escaped only by an ODD
+            # run of preceding backslashes ("a\\" closes: the backslashes
+            # escape each other, not the quote).
+            if c == quote:
+                bs = 0
+                j = i - 1
+                while j >= 0 and cmd[j] == "\\":
+                    bs += 1
+                    j -= 1
+                if quote == "'" or bs % 2 == 0:
+                    quote = None
             i += 1
             continue
         if c in ("'", '"'):
@@ -264,13 +297,27 @@ def segment_readonly(seg, unquoted, expandable):
         return not [t for t in args if not t.startswith("-")]
     if cmd == "xxd":
         # A second positional argument is an output file (xxd -r patch.hex bin).
-        return len([t for t in args if not t.startswith("-")]) < 2
+        # A bare "-" is the stdin positional, not a flag.
+        return len([t for t in args if t == "-" or not t.startswith("-")]) < 2
+    if cmd in ("less", "more"):
+        # less -o/-O/--log-file copies its input into a file.
+        return not any(
+            t in ("-o", "-O") or t.startswith("--log-file") or t.startswith("--LOG-FILE")
+            for t in args
+        )
     if cmd == "sort":
         return not any(t == "-o" or t.startswith("--output") or (t.startswith("-o") and len(t) > 2) for t in args)
     if cmd == "uniq":
-        return len([t for t in args if not t.startswith("-")]) < 2
+        return len([t for t in args if t == "-" or not t.startswith("-")]) < 2
     if cmd == "date":
-        return not any(t == "-s" or t.startswith("--set") for t in args)
+        # -s/--set explicitly set the clock; BSD/macOS date also sets it from
+        # a positional operand (date 010100002025). Only +format positionals
+        # are output formatting.
+        if any(t == "-s" or t.startswith("--set") for t in args):
+            return False
+        if "-j" in args:  # macOS: -j explicitly forbids setting the clock
+            return True
+        return not [t for t in args if not t.startswith("-") and not t.startswith("+")]
     if cmd == "sysctl":
         return not any(t == "-w" or "=" in t for t in args)
     if cmd == "awk":
@@ -283,15 +330,25 @@ def segment_readonly(seg, unquoted, expandable):
         if any(t.startswith("-i") or t == "--in-place" for t in args):
             return False
         # The sed `w` script command writes a file without any -i flag:
-        # `sed -n 'w out.txt'`, `s/a/b/w out.txt` — scanned on every token
-        # so a glued `-e's/a/b/w out'` script is caught too.
-        return not any(re.search(r"(^|;)\s*w\s|/w\b", t) for t in args)
+        # `sed -n 'w out.txt'`, `s/a/b/w out.txt`, and with ANY substitution
+        # delimiter (`s#a#b#w out`). Scanned on every token so a glued
+        # `-e's/a/b/w out'` script is caught too.
+        return not any(
+            re.search(r"(^|;)\s*w\s|[^\w\s]w(\s|$)", t) for t in args
+        )
     if cmd == "history":
         # history -c/-d clear entries, -w/-a/-r touch the history file.
         return not any(t.startswith("-") and t != "--" for t in args)
     if cmd == "git":
-        # `git diff/log --output=file` writes without a shell redirect.
-        if any(t.startswith("--output") for t in args):
+        # `git diff/log --output=file` writes without a shell redirect;
+        # --upload-pack/--receive-pack inject a command executed remotely.
+        if any(
+            t.startswith("--output")
+            or t.startswith("--upload-pack")
+            or t.startswith("--receive-pack")
+            or t.startswith("--exec")
+            for t in args
+        ):
             return False
         positional = [t for t in args if not t.startswith("-")]
         sub = positional[0] if positional else ""
@@ -310,7 +367,7 @@ def segment_readonly(seg, unquoted, expandable):
         long_writes = {
             "--output", "--output-dir", "--remote-name", "--upload-file",
             "--form", "--form-string", "--json", "--cookie-jar",
-            "--dump-header", "--etag-save",
+            "--dump-header", "--etag-save", "--quote", "--config",
         }
         for idx, t in enumerate(args):
             if t in long_writes or t.startswith("--data") or t.startswith("--trace"):
@@ -325,10 +382,11 @@ def segment_readonly(seg, unquoted, expandable):
                 method = t[2:] or (args[idx + 1] if idx + 1 < len(args) else "")
                 if method.upper() not in ("GET", "HEAD"):
                     return False
-            elif re.match(r"^-[A-Za-z]*[dDoOTFXc]", t):
-                # Short flags cluster (-sd, -sLo, -sT, -sc): d/D/o/O/T/F/X/c
-                # all send data or write files (c = cookie jar), wherever
-                # they sit in the cluster.
+            elif re.match(r"^-[A-Za-z]*[dDoOTFXcQK]", t):
+                # Short flags cluster (-sd, -sLo, -sT, -sc, -sQ):
+                # d/D/o/O/T/F/X/c/Q/K all send data, write files, run
+                # protocol commands (Q) or load a config (K), wherever they
+                # sit in the cluster.
                 return False
         return True
     return False
@@ -363,11 +421,23 @@ with open(path) as f:
                     mutating_bash += 1
             elif name in CORE_READONLY_TOOLS:
                 continue
+            elif name in ("Task", "Agent"):
+                # Subagents can edit files and call write APIs; only the
+                # read-only agent types stay neutral.
+                agent_type = (block.get("input") or {}).get("subagent_type", "")
+                if agent_type not in READONLY_AGENT_TYPES:
+                    suspicious_tools += 1
             elif name.startswith("mcp__"):
                 words = re.split(r"[-_]", name.rsplit("__", 1)[-1].lower())
                 if any(w in MCP_WRITE_VERBS for w in words) or not any(
                     w in MCP_READ_VERBS for w in words
                 ):
+                    suspicious_tools += 1
+                elif set(words) & SQL_TOOL_HINT and SQL_WRITE_RX.search(
+                    json.dumps(block.get("input") or {})
+                ):
+                    # Read-verb SQL tool carrying a write statement
+                    # (EXPLAIN ANALYZE executes it).
                     suspicious_tools += 1
             else:
                 # Unknown harness tool — assume it mutated something.

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -60,7 +60,17 @@ if [[ -n "$SESSION_ID" ]]; then
   SENTINEL="${TMPDIR:-/tmp}/wiki-stop-capture-${SESSION_ID}.done"
   if [[ -e "$SENTINEL" ]]; then
     NOW=$(date +%s)
-    CLAIMED_AT=$(stat -f %m "$SENTINEL" 2>/dev/null || stat -c %Y "$SENTINEL" 2>/dev/null || echo "$NOW")
+    # GNU stat's -f flag doesn't take a format argument (it means "show
+    # filesystem status"), so on Linux `stat -f %m FILE` treats %m as a
+    # second FILE operand: it errors on that bogus arg but still prints
+    # real filesystem info for the sentinel to stdout, and exits nonzero
+    # overall — so `||` ALSO runs `stat -c %Y`, and $(...) concatenates
+    # both outputs into one non-numeric string that silently falls back to
+    # $NOW below, permanently defeating the age check. Try the GNU form
+    # first: `stat -c` is an invalid option on BSD/macOS stat and fails
+    # clean (nonzero exit, no stdout), so the fallback to -f still works
+    # there.
+    CLAIMED_AT=$(stat -c %Y "$SENTINEL" 2>/dev/null || stat -f %m "$SENTINEL" 2>/dev/null || echo "$NOW")
     [[ "$CLAIMED_AT" =~ ^[0-9]+$ ]] || CLAIMED_AT="$NOW"
     if [[ $((NOW - CLAIMED_AT)) -lt "$REARM_SECONDS" ]]; then
       exit 0
@@ -502,7 +512,10 @@ if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || { [[ "${BASH_COUNT:-0}" -ge 4 ]] && { [[ "$
     # happened — put it back and stand down. (If the restore fails, yet
     # another invocation claimed meanwhile; its sentinel wins, ours is
     # discarded.)
-    RET_AT=$(stat -f %m "$RETIRED" 2>/dev/null || stat -c %Y "$RETIRED" 2>/dev/null || echo 0)
+    # Same GNU-first ordering as the CLAIMED_AT lookup above, and for the
+    # same reason: a BSD-first fallback returns a non-numeric value on
+    # Linux instead of failing clean.
+    RET_AT=$(stat -c %Y "$RETIRED" 2>/dev/null || stat -f %m "$RETIRED" 2>/dev/null || echo 0)
     [[ "$RET_AT" =~ ^[0-9]+$ ]] || RET_AT=0
     if [[ $(( $(date +%s) - RET_AT )) -lt "$REARM_SECONDS" ]]; then
       if mv "$RETIRED" "$SENTINEL" 2>/dev/null; then

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -505,7 +505,17 @@ if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || { [[ "${BASH_COUNT:-0}" -ge 4 ]] && { [[ "$
     RET_AT=$(stat -f %m "$RETIRED" 2>/dev/null || stat -c %Y "$RETIRED" 2>/dev/null || echo 0)
     [[ "$RET_AT" =~ ^[0-9]+$ ]] || RET_AT=0
     if [[ $(( $(date +%s) - RET_AT )) -lt "$REARM_SECONDS" ]]; then
-      mv "$RETIRED" "$SENTINEL" 2>/dev/null || rm -rf "$RETIRED"
+      if mv "$RETIRED" "$SENTINEL" 2>/dev/null; then
+        # We may have grabbed the winner's sentinel in the gap between its
+        # mkdir and its count write — then the restored sentinel is missing
+        # its edit-count state. Both invocations counted the same stop's
+        # transcript, so our own count stands in for the winner's.
+        if [[ ! -e "$SENTINEL/edits" ]]; then
+          printf '%s' "$WRITE_EDIT" > "$SENTINEL/edits" 2>/dev/null || true
+        fi
+      else
+        rm -rf "$RETIRED"
+      fi
       exit 0
     fi
     rm -rf "$RETIRED"

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -42,12 +42,33 @@ print('1' if d.get('stop_hook_active') else '0')
 # silently. The check here is only a cheap short-circuit to skip transcript
 # parsing; it is NOT the correctness guarantee, since concurrent invocations
 # can all pass it before any of them claims.
+#
+# RE-ARM: "once per session" starves long-running sessions — a multi-day
+# session gets its one nudge early and everything after is never captured.
+# The sentinel therefore expires when BOTH are true: it is older than
+# REARM_SECONDS (so one nudge per work stretch), AND at least REARM_EDITS new
+# file edits happened since the last nudge (so an idle session that just sits
+# open stays silent). The edit count at nudge time is stored inside the
+# sentinel; sentinels predating this feature have no count and behave as 0.
+REARM_SECONDS="${WIKI_STOP_REARM_SECONDS:-21600}"   # 6h between nudges
+REARM_EDITS="${WIKI_STOP_REARM_EDITS:-10}"          # new edits required
 SESSION_ID=$(printf '%s' "$INPUT" | python3 -c "
 import json, sys; print(json.load(sys.stdin).get('session_id', ''))" 2>/dev/null || echo "")
 SENTINEL=""
+REARM_CANDIDATE=0
 if [[ -n "$SESSION_ID" ]]; then
   SENTINEL="${TMPDIR:-/tmp}/wiki-stop-capture-${SESSION_ID}.done"
-  [[ -e "$SENTINEL" ]] && exit 0
+  if [[ -e "$SENTINEL" ]]; then
+    NOW=$(date +%s)
+    CLAIMED_AT=$(stat -f %m "$SENTINEL" 2>/dev/null || stat -c %Y "$SENTINEL" 2>/dev/null || echo "$NOW")
+    [[ "$CLAIMED_AT" =~ ^[0-9]+$ ]] || CLAIMED_AT="$NOW"
+    if [[ $((NOW - CLAIMED_AT)) -lt "$REARM_SECONDS" ]]; then
+      exit 0
+    fi
+    # Old enough — the edit-delta half of the re-arm test needs the
+    # transcript counts, so fall through to parsing.
+    REARM_CANDIDATE=1
+  fi
 fi
 
 TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | python3 -c "
@@ -462,11 +483,26 @@ SUSPICIOUS_TOOLS=$(echo "$COUNTS" | awk '{print $4}')
 # trigger on their own — they only disable the exemption, so this hook never
 # nudges where the pre-exemption threshold (edits >= 1 or bash >= 4) wouldn't.
 if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || { [[ "${BASH_COUNT:-0}" -ge 4 ]] && { [[ "${MUTATING_BASH:-0}" -ge 1 ]] || [[ "${SUSPICIOUS_TOOLS:-0}" -ge 1 ]]; }; }; then
+  # Re-arm gate: an expired sentinel only re-fires when enough NEW edits
+  # happened since the nudge that claimed it. The count file may be missing
+  # (pre-feature sentinel) — treat as 0 so the full current count is the delta.
+  if [[ "$REARM_CANDIDATE" == "1" ]]; then
+    PREV_EDITS=$(cat "$SENTINEL/edits" 2>/dev/null || echo 0)
+    [[ "$PREV_EDITS" =~ ^[0-9]+$ ]] || PREV_EDITS=0
+    if [[ $((WRITE_EDIT - PREV_EDITS)) -lt "$REARM_EDITS" ]]; then
+      exit 0
+    fi
+    # Atomically retire the expired sentinel: mv succeeds for exactly one of
+    # any concurrent invocations, so only that one may proceed to re-claim.
+    mv "$SENTINEL" "${SENTINEL}.retired.$$" 2>/dev/null || exit 0
+    rm -rf "${SENTINEL}.retired.$$"
+  fi
   # Atomically claim the right to nudge. Losers of the race exit silently so a
   # duplicate registration produces one nudge, not two. Claimed here rather than
   # earlier so that a below-threshold turn doesn't burn the session's one nudge.
   if [[ -n "$SENTINEL" ]]; then
     mkdir "$SENTINEL" 2>/dev/null || exit 0
+    printf '%s' "$WRITE_EDIT" > "$SENTINEL/edits" 2>/dev/null || true
   fi
   echo "Session ended with ${WRITE_EDIT} file edit(s) and ${BASH_COUNT} shell call(s). Please run /wiki-capture --quick now to preserve any reusable findings before this context closes." >&2
   exit 2

--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -494,8 +494,21 @@ if [[ "${WRITE_EDIT:-0}" -ge 1 ]] || { [[ "${BASH_COUNT:-0}" -ge 4 ]] && { [[ "$
     fi
     # Atomically retire the expired sentinel: mv succeeds for exactly one of
     # any concurrent invocations, so only that one may proceed to re-claim.
-    mv "$SENTINEL" "${SENTINEL}.retired.$$" 2>/dev/null || exit 0
-    rm -rf "${SENTINEL}.retired.$$"
+    RETIRED="${SENTINEL}.retired.$$"
+    mv "$SENTINEL" "$RETIRED" 2>/dev/null || exit 0
+    # Guard against retiring the WRONG sentinel: a concurrent invocation may
+    # have re-armed, nudged, and claimed a FRESH sentinel between our age
+    # check and our mv. If what we grabbed is young, that nudge already
+    # happened — put it back and stand down. (If the restore fails, yet
+    # another invocation claimed meanwhile; its sentinel wins, ours is
+    # discarded.)
+    RET_AT=$(stat -f %m "$RETIRED" 2>/dev/null || stat -c %Y "$RETIRED" 2>/dev/null || echo 0)
+    [[ "$RET_AT" =~ ^[0-9]+$ ]] || RET_AT=0
+    if [[ $(( $(date +%s) - RET_AT )) -lt "$REARM_SECONDS" ]]; then
+      mv "$RETIRED" "$SENTINEL" 2>/dev/null || rm -rf "$RETIRED"
+      exit 0
+    fi
+    rm -rf "$RETIRED"
   fi
   # Atomically claim the right to nudge. Losers of the race exit silently so a
   # duplicate registration produces one nudge, not two. Claimed here rather than

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -536,6 +536,7 @@ class StopHookBehaviorTest(unittest.TestCase):
         transcript.write_text(
             "".join(json.dumps(_edit_entry()) + "\n" for _ in range(200))
         )
+        raced_rounds = 0
         for round_no in range(10):
             sid = f"race{round_no}"
             sentinel = self._sentinel(sid)
@@ -547,12 +548,15 @@ class StopHookBehaviorTest(unittest.TestCase):
                 json.dumps({"session_id": sid, "transcript_path": str(transcript)})
             )
             env = {"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(self.tmp)}
+            # bash -x: the xtrace on stderr is evidence of WHICH path each
+            # process took, asserted on below — outcome checks alone cannot
+            # distinguish a genuine race from accidental serialization.
             procs = []
             for _ in range(2):
                 with payload_file.open() as stdin_file:
                     procs.append(
                         subprocess.Popen(
-                            ["bash", str(HOOK)],
+                            ["bash", "-x", str(HOOK)],
                             stdin=stdin_file,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
@@ -561,9 +565,11 @@ class StopHookBehaviorTest(unittest.TestCase):
                         )
                     )
             codes = []
+            traces = []
             for p in procs:
-                p.communicate()
+                _, stderr = p.communicate()
                 codes.append(p.returncode)
+                traces.append(stderr)
             self.assertEqual(
                 sorted(codes), [0, 2], f"round {round_no}: exactly one nudge, got {codes}"
             )
@@ -578,6 +584,29 @@ class StopHookBehaviorTest(unittest.TestCase):
                 "200",
                 f"round {round_no}: sentinel lost its edit-count state",
             )
+            # A process that reached the claim phase shows an mv or mkdir on
+            # the sentinel path in its xtrace; a serialized loser instead
+            # exits at the top age check and never touches the sentinel.
+            marker = f"wiki-stop-capture-{sid}.done"
+            if all(
+                any(
+                    marker in line and ("+ mv " in line or "+ mkdir " in line)
+                    for line in trace.splitlines()
+                )
+                for trace in traces
+            ):
+                raced_rounds += 1
+        # The race path must demonstrably execute: in a genuinely concurrent
+        # round BOTH processes pass the age check and reach the claim.
+        # Requiring 3 of 10 rounds tolerates a loaded machine occasionally
+        # serializing a round (unloaded runs hit 10/10) while still failing
+        # loudly if the harness ever degrades back to sequential execution.
+        self.assertGreaterEqual(
+            raced_rounds,
+            3,
+            f"only {raced_rounds}/10 rounds raced — the test is not exercising "
+            "the concurrent claim path",
+        )
 
     def test_rearm_env_knobs_override_defaults(self):
         first = self._run([_edit_entry()] * 5, session_id="knobs")

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -10,9 +10,11 @@ classifier can't prove read-only — keeps the pre-exemption behavior.
 from __future__ import annotations
 
 import json
+import os
 import shutil
 import subprocess
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -62,7 +64,14 @@ class StopHookBehaviorTest(unittest.TestCase):
         self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
         self._session_seq = 0
 
-    def _run(self, entries, session_id=None, stop_hook_active=False):
+    def _sentinel(self, session_id):
+        return self.tmp / f"wiki-stop-capture-{session_id}.done"
+
+    def _age_sentinel(self, session_id, seconds):
+        old = time.time() - seconds
+        os.utime(self._sentinel(session_id), (old, old))
+
+    def _run(self, entries, session_id=None, stop_hook_active=False, extra_env=None):
         transcript = self.tmp / "transcript.jsonl"
         transcript.write_text("".join(json.dumps(e) + "\n" for e in entries))
         if session_id is None:
@@ -79,7 +88,7 @@ class StopHookBehaviorTest(unittest.TestCase):
             input=json.dumps(payload),
             capture_output=True,
             text=True,
-            env={"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(self.tmp)},
+            env={"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(self.tmp), **(extra_env or {})},
         )
 
     def test_file_edit_triggers_nudge(self):
@@ -463,6 +472,61 @@ class StopHookBehaviorTest(unittest.TestCase):
     def test_less_log_file_counts_as_mutating(self):
         entries = [_bash_entry("printf x | less -F -o /tmp/log")] * 4
         self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_rearm_after_age_and_new_edits(self):
+        first = self._run([_edit_entry()] * 5, session_id="long")
+        self.assertEqual(first.returncode, 2)
+        self._age_sentinel("long", 7 * 3600)
+        second = self._run([_edit_entry()] * 20, session_id="long")
+        self.assertEqual(second.returncode, 2)
+        self.assertIn("20 file edit(s)", second.stderr)
+
+    def test_no_rearm_while_sentinel_is_young(self):
+        first = self._run([_edit_entry()] * 5, session_id="young")
+        self.assertEqual(first.returncode, 2)
+        # Plenty of new edits, but the nudge was moments ago.
+        second = self._run([_edit_entry()] * 40, session_id="young")
+        self.assertEqual(second.returncode, 0)
+
+    def test_no_rearm_without_enough_new_edits(self):
+        first = self._run([_edit_entry()] * 5, session_id="idle")
+        self.assertEqual(first.returncode, 2)
+        self._age_sentinel("idle", 7 * 3600)
+        # Only 3 edits since the nudge that recorded 5.
+        second = self._run([_edit_entry()] * 8, session_id="idle")
+        self.assertEqual(second.returncode, 0)
+        # The sentinel must survive, still holding the original count.
+        self.assertEqual((self._sentinel("idle") / "edits").read_text(), "5")
+
+    def test_rearm_updates_stored_count_and_rests_again(self):
+        first = self._run([_edit_entry()] * 5, session_id="cycle")
+        self.assertEqual(first.returncode, 2)
+        self._age_sentinel("cycle", 7 * 3600)
+        second = self._run([_edit_entry()] * 20, session_id="cycle")
+        self.assertEqual(second.returncode, 2)
+        self.assertEqual((self._sentinel("cycle") / "edits").read_text(), "20")
+        # Fresh sentinel again: more edits right away stay silent.
+        third = self._run([_edit_entry()] * 40, session_id="cycle")
+        self.assertEqual(third.returncode, 0)
+
+    def test_pre_feature_sentinel_rearms_from_zero(self):
+        # A sentinel claimed before the re-arm feature has no edits file:
+        # the whole current count is the delta.
+        self._sentinel("legacy").mkdir()
+        self._age_sentinel("legacy", 7 * 3600)
+        result = self._run([_edit_entry()] * 12, session_id="legacy")
+        self.assertEqual(result.returncode, 2)
+
+    def test_rearm_env_knobs_override_defaults(self):
+        first = self._run([_edit_entry()] * 5, session_id="knobs")
+        self.assertEqual(first.returncode, 2)
+        # Zero cool-down and a 1-edit delta: the very next stop re-fires.
+        second = self._run(
+            [_edit_entry()] * 6,
+            session_id="knobs",
+            extra_env={"WIKI_STOP_REARM_SECONDS": "0", "WIKI_STOP_REARM_EDITS": "1"},
+        )
+        self.assertEqual(second.returncode, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -556,6 +556,16 @@ class StopHookBehaviorTest(unittest.TestCase):
                 sorted(codes), [0, 2], f"round {round_no}: exactly one nudge, got {codes}"
             )
             self.assertTrue(sentinel.exists(), f"round {round_no}: sentinel must survive")
+            # State invariant: whichever invocation ends up owning the
+            # sentinel, the edit count must be present — the winner writes
+            # it, and a restorer repairs it if it grabbed the sentinel in
+            # the winner's mkdir-to-write gap. Without it, the next re-arm
+            # would compute its delta from zero and fire early.
+            self.assertEqual(
+                (sentinel / "edits").read_text(),
+                "20",
+                f"round {round_no}: sentinel lost its edit-count state",
+            )
 
     def test_rearm_env_knobs_override_defaults(self):
         first = self._run([_edit_entry()] * 5, session_id="knobs")

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -517,6 +517,46 @@ class StopHookBehaviorTest(unittest.TestCase):
         result = self._run([_edit_entry()] * 12, session_id="legacy")
         self.assertEqual(result.returncode, 2)
 
+    def test_concurrent_rearm_produces_exactly_one_nudge(self):
+        # Duplicate hook registration fires two invocations per stop. With an
+        # expired sentinel both pass the age check; the mv claim plus the
+        # young-retire guard must let exactly one of them re-nudge — the
+        # loser either loses the mv or grabs the winner's FRESH sentinel,
+        # sees it is young, restores it, and stands down.
+        transcript = self.tmp / "transcript.jsonl"
+        transcript.write_text(
+            "".join(json.dumps(_edit_entry()) + "\n" for _ in range(20))
+        )
+        for round_no in range(10):
+            sid = f"race{round_no}"
+            sentinel = self._sentinel(sid)
+            sentinel.mkdir()
+            (sentinel / "edits").write_text("0")
+            self._age_sentinel(sid, 7 * 3600)
+            payload = json.dumps(
+                {"session_id": sid, "transcript_path": str(transcript)}
+            )
+            env = {"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(self.tmp)}
+            procs = [
+                subprocess.Popen(
+                    ["bash", str(HOOK)],
+                    stdin=subprocess.PIPE,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    env=env,
+                )
+                for _ in range(2)
+            ]
+            codes = []
+            for p in procs:
+                p.communicate(payload)
+                codes.append(p.returncode)
+            self.assertEqual(
+                sorted(codes), [0, 2], f"round {round_no}: exactly one nudge, got {codes}"
+            )
+            self.assertTrue(sentinel.exists(), f"round {round_no}: sentinel must survive")
+
     def test_rearm_env_knobs_override_defaults(self):
         first = self._run([_edit_entry()] * 5, session_id="knobs")
         self.assertEqual(first.returncode, 2)

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -38,11 +38,11 @@ def _edit_entry(tool="Edit"):
     }
 
 
-def _tool_entry(name):
+def _tool_entry(name, tool_input=None):
     return {
         "message": {
             "role": "assistant",
-            "content": [{"type": "tool_use", "name": name, "input": {}}],
+            "content": [{"type": "tool_use", "name": name, "input": tool_input or {}}],
         }
     }
 
@@ -335,6 +335,133 @@ class StopHookBehaviorTest(unittest.TestCase):
 
     def test_python_smtplib_counts_as_mutating(self):
         entries = [_bash_entry("python3 -c \"import smtplib; ...\"")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_task_subagent_disables_exemption(self):
+        entries = _READONLY_BASH + [
+            _tool_entry("Task", {"subagent_type": "general-purpose", "prompt": "fix the bug"})
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_readonly_agent_types_keep_exemption(self):
+        entries = _READONLY_BASH + [
+            _tool_entry("Task", {"subagent_type": "Explore", "prompt": "find the config"}),
+            _tool_entry("Task", {"subagent_type": "Plan", "prompt": "plan the change"}),
+        ]
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_enter_worktree_disables_exemption(self):
+        entries = _READONLY_BASH + [_tool_entry("EnterWorktree")]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_explain_analyze_dml_disables_exemption(self):
+        entries = _READONLY_BASH + [
+            _tool_entry(
+                "mcp__neon__explain_sql_statement",
+                {"analyze": True, "sql": "DELETE FROM users"},
+            )
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_explain_plain_select_keeps_exemption(self):
+        entries = _READONLY_BASH + [
+            _tool_entry("mcp__neon__explain_sql_statement", {"sql": "SELECT count(*) FROM users"})
+        ]
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_prepare_named_tool_disables_exemption(self):
+        entries = _READONLY_BASH + [_tool_entry("mcp__neon__prepare_query_tuning")]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_resolve_named_tool_disables_exemption(self):
+        entries = _READONLY_BASH + [
+            _tool_entry("mcp__codex_apps__github_resolve_review_thread")
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_double_quote_backslash_parity(self):
+        # "a\\" — the two backslashes escape each other, the quote CLOSES,
+        # and the rm after the semicolon runs unquoted.
+        entries = [_bash_entry('echo "a\\\\" ; rm -rf ./victim')] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_curl_config_and_quote_count_as_mutating(self):
+        entries = [
+            _bash_entry("printf 'request = \"DELETE\"\\n' | curl --config - http://h/items/42"),
+            _bash_entry("curl -Q 'DELE important.txt' ftp://server/"),
+            _bash_entry("curl -sK curlrc http://h/"),
+            _bash_entry("curl --quote 'DELE x' ftp://server/"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_python_sqlite_execute_counts_as_mutating(self):
+        entries = [
+            _bash_entry(
+                "python3 -c \"import sqlite3; sqlite3.connect('app.db', isolation_level=None)"
+                ".execute('delete from users')\""
+            )
+        ] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_python_os_alias_counts_as_mutating(self):
+        entries = [_bash_entry("python3 -c \"import os as x; x.remove('/tmp/victim')\"")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_python_path_open_write_counts_as_mutating(self):
+        entries = [
+            _bash_entry(
+                "python3 -c \"from pathlib import Path; Path('/tmp/out').open('w').close()\""
+            )
+        ] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_sudo_date_positional_counts_as_mutating(self):
+        entries = [_bash_entry("sudo date 010100002025")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_date_readonly_forms_stay_readonly(self):
+        entries = [
+            _bash_entry("date +%Y-%m-%d"),
+            _bash_entry("date -u"),
+            _bash_entry("date -j -f '%Y' '2026' +%s"),
+            _bash_entry("date"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_git_upload_pack_counts_as_mutating(self):
+        entries = [
+            _bash_entry("git ls-remote --upload-pack='touch /tmp/pwn' ssh://host/repo")
+        ] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_awk_variable_targets_count_as_mutating(self):
+        entries = [
+            _bash_entry("awk 'BEGIN { c=\"rm -rf /tmp/victim\"; print | c; close(c) }'"),
+            _bash_entry("awk 'BEGIN { f=\"/tmp/out\"; print \"x\" > f; close(f) }'"),
+            _bash_entry("awk 'BEGIN { c=\"rm x\"; print | c }'"),
+            _bash_entry("awk '{ print > outfile }' outfile=/tmp/o data.txt"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_awk_numeric_comparison_stays_readonly(self):
+        entries = [_bash_entry("awk '$3 > 100 { print $1 }' data.txt")] * 4
+        self.assertEqual(self._run(entries).returncode, 0)
+
+    def test_sed_alternate_delimiter_write_counts_as_mutating(self):
+        entries = [_bash_entry("sed 's#a#b#w /tmp/out' input.txt")] * 4
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_xxd_uniq_stdin_output_counts_as_mutating(self):
+        entries = [
+            _bash_entry("printf 41 | xxd -r -p - /tmp/out.bin"),
+            _bash_entry("printf 'x\\nx\\n' | uniq - /tmp/out.txt"),
+            _bash_entry("printf 42 | xxd -r -p - /tmp/out2.bin"),
+            _bash_entry("printf 'y\\ny\\n' | uniq - /tmp/out2.txt"),
+        ]
+        self.assertEqual(self._run(entries).returncode, 2)
+
+    def test_less_log_file_counts_as_mutating(self):
+        entries = [_bash_entry("printf x | less -F -o /tmp/log")] * 4
         self.assertEqual(self._run(entries).returncode, 2)
 
 

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -523,9 +523,18 @@ class StopHookBehaviorTest(unittest.TestCase):
         # young-retire guard must let exactly one of them re-nudge — the
         # loser either loses the mv or grabs the winner's FRESH sentinel,
         # sees it is young, restores it, and stands down.
+        #
+        # TRUE concurrency matters: the hook's first statement is
+        # INPUT=$(cat), so feeding stdin through sequential communicate()
+        # calls would hold the second process at that read until the first
+        # had fully exited — serializing the bodies and never exercising
+        # the race. Both processes therefore get stdin from a pre-written
+        # file and run the whole body simultaneously; the transcript is
+        # large so the parse phase gives a wide overlap window between the
+        # age check and the claim.
         transcript = self.tmp / "transcript.jsonl"
         transcript.write_text(
-            "".join(json.dumps(_edit_entry()) + "\n" for _ in range(20))
+            "".join(json.dumps(_edit_entry()) + "\n" for _ in range(200))
         )
         for round_no in range(10):
             sid = f"race{round_no}"
@@ -533,24 +542,27 @@ class StopHookBehaviorTest(unittest.TestCase):
             sentinel.mkdir()
             (sentinel / "edits").write_text("0")
             self._age_sentinel(sid, 7 * 3600)
-            payload = json.dumps(
-                {"session_id": sid, "transcript_path": str(transcript)}
+            payload_file = self.tmp / f"payload{round_no}.json"
+            payload_file.write_text(
+                json.dumps({"session_id": sid, "transcript_path": str(transcript)})
             )
             env = {"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(self.tmp)}
-            procs = [
-                subprocess.Popen(
-                    ["bash", str(HOOK)],
-                    stdin=subprocess.PIPE,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                    text=True,
-                    env=env,
-                )
-                for _ in range(2)
-            ]
+            procs = []
+            for _ in range(2):
+                with payload_file.open() as stdin_file:
+                    procs.append(
+                        subprocess.Popen(
+                            ["bash", str(HOOK)],
+                            stdin=stdin_file,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            text=True,
+                            env=env,
+                        )
+                    )
             codes = []
             for p in procs:
-                p.communicate(payload)
+                p.communicate()
                 codes.append(p.returncode)
             self.assertEqual(
                 sorted(codes), [0, 2], f"round {round_no}: exactly one nudge, got {codes}"
@@ -563,7 +575,7 @@ class StopHookBehaviorTest(unittest.TestCase):
             # would compute its delta from zero and fire early.
             self.assertEqual(
                 (sentinel / "edits").read_text(),
-                "20",
+                "200",
                 f"round {round_no}: sentinel lost its edit-count state",
             )
 


### PR DESCRIPTION
Follow-up to #158, two commits:

1. **19 read-only-classifier escapes closed** — this commit was pushed to the #158 branch about an hour after the merge, so it missed the train.
2. **Re-arm for long-running sessions** — fixes the starvation the once-per-session sentinel introduced.

## Commit 1 — classifier escapes

An adversarial review pass hunted for commands and tool calls the read-only classifier would misclassify as safe, and found 19 concrete escapes. All are closed, each pinned by a transcript-level test.

**Tool-call layer**
- **Task/Agent are no longer blanket-neutral** — a spawned subagent can edit files or call write APIs. The classifier now reads `subagent_type`: only read-only agent types (Explore, Plan) keep the exemption.
- **EnterWorktree/ExitWorktree** removed from the neutral set (they create/remove branches and worktrees).
- **Read-verb SQL tools scan their payload**: `EXPLAIN ANALYZE` executes the statement, so DML keywords or `"analyze": true` in the input disable the exemption; plain `SELECT` explains stay neutral.
- Verb lists: `prepare` moved to write verbs (`prepare_query_tuning` provisions a branch); `resolve` dropped from read verbs (resolving a review thread mutates it).

**Quote scanner**
- Double-quote escaping now uses **backslash parity**: `"a\\"` closes the quote (the backslashes escape each other), so a command hidden after `;` is seen. Previously any backslash before the quote kept the scanner in-quote and swallowed the rest of the command.

**Command classifiers**
- **python -c**: `.execute()/.executemany()`, `Path.open('w')`, aliased os imports (`import os as x`, `from os import …`); matching is now case-insensitive so lowercase `delete from` in a sqlite call is caught.
- **curl**: `--config`/`-K` (a config file can carry any request), `-Q`/`--quote` (FTP protocol commands like `DELE`), with Q/K detected inside short-flag clusters.
- **git**: `--upload-pack`/`--receive-pack`/`--exec` inject remotely-executed commands even under read-only subcommands (`git ls-remote --upload-pack='…'`).
- **date**: a positional operand sets the clock on BSD/macOS (`sudo date 010100002025`); `+format`, `-u`, `-j` forms stay read-only.
- **awk**: redirects/pipes to *variables* (`print > f`, `print | c`), `close()`, `getline` — numeric comparisons (`$3 > 100`) stay clean.
- **sed**: the `w` script command is caught with any substitution delimiter (`s#a#b#w out`), not just `/`.
- **xxd/uniq**: a bare `-` stdin marker now counts as a positional, so the *output file* argument is no longer missed (`xxd -r -p - out.bin`).
- **less/more**: `-o`/`-O`/`--log-file` copy input into a file.

## Commit 2 — re-arm for long sessions

"Once per session" starves multi-day sessions: the single nudge fires early (usually after the first few edits), and all later work is never captured automatically.

The sentinel now **expires** when BOTH hold:

- it is older than `WIKI_STOP_REARM_SECONDS` (default **6h**), and
- at least `WIKI_STOP_REARM_EDITS` (default **10**) new file edits happened since the nudge that claimed it.

| Session shape | Behavior |
|---|---|
| Short session | one nudge, exactly as before |
| Long, busy session | roughly one nudge per work stretch |
| Long, idle session | one nudge, then silence |

Mechanics: the edit count at nudge time is stored inside the sentinel directory; the young-sentinel path stays the cheap pre-parse short-circuit; an expired sentinel is retired with an atomic `mv`, so duplicate hook registrations still produce exactly one re-nudge. Sentinels predating the feature have no stored count and re-arm from zero. Both thresholds are env-overridable.

## Tests

Suite grows to **73** (20 for the classifier escapes, 6 for re-arm — age gate, delta gate, count storage and reset, pre-feature sentinels, env knobs). All passing; hook stays bash-3.2 compatible.

Design rule unchanged: every classifier fix errs toward *mutating* — unknown or ambiguous means the nudge fires.
