### PR TITLE
feat(trust): enforce owner authority and correction provenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,31 @@ WIKI_STAGED_WRITES=
 # passing --strict-trust on every lint run. See also: obsidian-wiki trust-check.
 OBSIDIAN_TRUST_STRICT=
 
+# --- Vault schema overrides (optional) ---
+#
+# Resolution precedence is CLI flags > these environment/config values >
+# framework defaults. Lifecycle and relationship values extend the defaults;
+# required trust fields replace default requiredness. Values are trimmed first.
+# Empty or whitespace-only values fail closed. Do not use an
+# empty assignment such as `OBSIDIAN_ALLOWED_LIFECYCLES=`; leave the variable
+# commented out to use defaults. Empty comma-separated entries and trailing
+# commas also fail closed.
+
+# Additional lifecycle values. Framework defaults are:
+# draft,reviewed,verified,disputed,archived
+# OBSIDIAN_ALLOWED_LIFECYCLES=active,confirmed,stub
+
+# Additional typed relationship values.
+# OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES=synthesizes,builds_on
+
+# Effective required trust fields. Allowed values are base_confidence,
+# lifecycle, lifecycle_changed, and updated. Lint defaults to
+# base_confidence,lifecycle; standalone trust commands also require updated.
+# OBSIDIAN_REQUIRED_TRUST_FIELDS=updated,lifecycle
+
+# Owner authority locator emitted in schema reports.
+# OBSIDIAN_SCHEMA_SOURCE=/absolute/path/to/vault/AGENTS.md
+
 # --- QMD Semantic Search (optional) ---
 #
 # QMD indexes your wiki and sources for fast semantic search.

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -272,6 +272,8 @@ A Mermaid diagram reconstructed from the paper's prose is a synthesis, not a tra
 
 Every claim on a wiki page has one of three provenance states. Mark them inline so the reader (and future ingest passes) can tell signal from synthesis.
 
+These are framework defaults. A vault's `AGENTS.md` may add markers or workflow flags. Preserve owner extensions and treat orthogonal workflow flags separately from the extracted/inferred/ambiguous truth-state axis.
+
 | State | Marker | Meaning |
 |---|---|---|
 | **Extracted** | *(no marker — default)* | A paraphrase of something a source actually says. |
@@ -324,6 +326,8 @@ Each entry has two required fields:
 
 ### Allowed relationship types
 
+The table below is the framework default allowlist. A vault's `AGENTS.md` may extend it; consumers must use the effective allowlist and preserve owner semantics without coercion.
+
 | Type | Meaning | Example |
 |---|---|---|
 | `extends` | This page builds on or generalises the target | GPT extends Transformer Architecture |
@@ -346,6 +350,10 @@ Skills that read `relationships:`: `wiki-export` (emits typed edges), `cross-lin
 ## Confidence and Lifecycle
 
 Every page carries two orthogonal trust signals plus an optional supersession link.
+
+The requiredness and lifecycle values below are framework defaults. A vault's `AGENTS.md` may extend lifecycle values or make trust fields optional. Validators must apply that effective owner schema while still validating any trust value that is present.
+
+The deterministic lint/trust consumer accepts owner schema through `OBSIDIAN_ALLOWED_LIFECYCLES`, `OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES`, `OBSIDIAN_REQUIRED_TRUST_FIELDS`, and `OBSIDIAN_SCHEMA_SOURCE`. Resolution precedence is CLI > environment/config > these framework defaults (with lifecycle and relationship extensions additive). Explicit blank or whitespace-only values fail closed; omit the variable to select defaults. `wiki-lint/SKILL.md` owns the operational invocation contract.
 
 ### Required fields
 

--- a/.skills/wiki-capture/SKILL.md
+++ b/.skills/wiki-capture/SKILL.md
@@ -16,10 +16,11 @@ description: >
 
 You are preserving knowledge from the current conversation as a permanent wiki note. The goal is to extract the *substance* — the knowledge itself — not a summary of what was said.
 
-This skill has two modes:
+This skill has three modes:
 
 - **Full mode (default)** — classify the content and write a finished, cross-linked wiki page directly into the right category. This is the rest of this document (Steps 1–7).
 - **Quick mode (`--quick`)** — zero-friction staging: drop findings to `_raw/` in under 60 seconds with no manifest/index/log/QMD writes. Used for mid-session capture and by the session-end Stop hook. See below, then stop — do **not** run the full-mode steps.
+- **Correction mode (`--correction`)** — capture one atomic correction as derived knowledge while leaving the immutable conversation/source untouched. Use the template below, then update only the derived consumers and tracking links.
 
 ## Quick Mode (`--quick`)
 
@@ -28,6 +29,8 @@ Trigger when invoked as `/wiki-capture --quick`, by "quick capture" / "capture t
 **Speed contract:** Inline only. No subagents. No QMD. No manifest/`index.md`/`log.md`/`hot.md` writes. Target: <60 seconds. Promotion to full wiki pages happens later via `/wiki-ingest`.
 
 1. **Resolve config** (Config Resolution Protocol in `llm-wiki/SKILL.md`): get `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_RAW_DIR` (default: `$OBSIDIAN_VAULT_PATH/_raw`). Ensure `$OBSIDIAN_RAW_DIR` exists; create it if not.
+
+   Capture does not independently reinterpret validator schema inputs. When `OBSIDIAN_ALLOWED_LIFECYCLES`, `OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES`, `OBSIDIAN_REQUIRED_TRUST_FIELDS`, or `OBSIDIAN_SCHEMA_SOURCE` is present, preserve it for the downstream lint/trust consumer: CLI values take precedence over environment/config values, which take precedence over framework defaults, and explicit blank or whitespace-only values fail closed. Omit a variable to use defaults.
 
 2. **Gate — KEEP or SKIP?** Before extracting, judge whether this session has capture value. This keeps the skill safe to call automatically without spamming `_raw/`.
    - **SKIP** (exit with "Nothing worth capturing in this session.") if ALL are true: the conversation is purely conversational (planning/Q&A/explanation) with no implementation; no errors, debugging, or problem-solving visible; nothing surprising or undocumented; every finding is already obvious from the docs.
@@ -49,6 +52,46 @@ Trigger when invoked as `/wiki-capture --quick`, by "quick capture" / "capture t
    Run /wiki-ingest to promote these to full wiki pages.
    ```
    Quick mode deliberately does **not** write the manifest, `index.md`, `log.md`, `hot.md`, or refresh QMD — promotion via `/wiki-ingest` handles all of that. **Stop here; do not run the full-mode steps below.**
+
+---
+
+## Correction Mode (`--correction`)
+
+Use this mode when a user or stronger authority corrects a claim derived from an immutable conversation, tool result, or other raw source. Never edit or copy the raw source. Resolve config, read the vault `AGENTS.md`, and update an existing derived page when one owns the claim; otherwise create the smallest owner-compliant derived correction page.
+
+Record exactly one atomic claim pair. `speaker_type` is semantic and must be assessed independently of a serialized message `role` (a tool result may be serialized as `role=user`). Do not include raw transcript excerpts.
+
+```yaml
+correction_id: <stable-id>
+source_locator: <immutable file:line or channel/thread/timestamp>
+source_text_sha256: <64 lowercase hex chars>
+serialized_role: <source role, if present>
+speaker_type: user | assistant | teammate | tool_result | slack_member
+original_claim:
+  subject: <exact entity or capability>
+  assertion: <single atomic value>
+corrected_claim:
+  subject: <same exact entity or capability>
+  assertion: <single atomic value or null>
+authority_class: contract | decision | code | test | deploy | runtime | db | narrative
+verification_state: verified | inferred | unverified | contradicted
+asserted_at: <ISO-8601 timestamp>
+effective_at: <ISO-8601 timestamp or null>
+as_of: <ISO-8601 timestamp>
+supersedes: [<original-claim-id>]
+consumer_propagation:
+  kw: open | not_applicable | complete
+  ob: open | not_applicable | complete
+  requirements: open | not_applicable | complete
+  code: open | not_applicable | complete
+  tests: open | not_applicable | complete
+  ai_memory: open | not_applicable | complete
+corrected_at: <ISO-8601 timestamp>
+```
+
+Before any derived write, compute `source_pre_sha256` directly from the immutable source and require it to equal `source_text_sha256`. After writing the correction and updating derived consumers, recompute `source_post_sha256` from the same locator. Abort and report an immutability violation unless `source_pre_sha256 == source_post_sha256 == source_text_sha256`. This verification is mandatory even when the correction write succeeds.
+
+After writing the derived correction, link the immutable source to the created/updated page through `.manifest.json`, append only the correction ID and affected-page counts to `log.md`, and propagate the atomic correction to every consumer independently. Mark a consumer `complete` only after verifying that consumer; do not collapse mixed results into a single aggregate status. Keep secrets, raw excerpts, and source copies out of the correction record.
 
 ---
 

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -18,9 +18,15 @@ You are performing a health check on an Obsidian wiki. Your goal is to find and 
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`
-2. Read `index.md` for the full page inventory
-3. Read `log.md` for recent activity context
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` plus any `OBSIDIAN_ALLOWED_LIFECYCLES`, `OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES`, `OBSIDIAN_REQUIRED_TRUST_FIELDS`, and `OBSIDIAN_SCHEMA_SOURCE` values.
+2. **Read owner rules** — if `$OBSIDIAN_VAULT_PATH/AGENTS.md` exists, read it before interpreting any schema. Owner rules override framework defaults.
+3. **Form the effective schema** — record the schema source locator plus effective required/optional frontmatter, lifecycle values, relationship types, and provenance markers. Framework values are defaults; preserve owner extensions and relaxed requiredness exactly. Never coerce an owner type to a framework type.
+4. Read `index.md` for the full page inventory
+5. Read `log.md` for recent activity context
+
+Pass the effective schema to deterministic checks explicitly. For example, add each owner extension with `--allow-lifecycle` / `--allow-relationship-type`, replace trust requiredness with repeatable `--required-trust-field`, and identify the authority with `--schema-source "$OBSIDIAN_VAULT_PATH/AGENTS.md"`. The JSON report's `schema` block must match the schema you formed before findings are accepted.
+
+Schema precedence is CLI flags > resolved environment/config values > framework defaults; lifecycle and relationship extensions remain additive. Strip every override before use. An explicitly configured empty or whitespace-only value—and any empty comma-separated list entry—fails closed; never treat it as a valid lifecycle, relationship type, required field, or authority locator. Remove the variable instead when defaults are intended.
 
 ## Lint Checks
 
@@ -182,13 +188,13 @@ Confidence is a semantic judgment. A deterministic tool cannot infer independent
 
 #### Rule 12a — `lifecycle` enum validation
 
-**How to check:** Grep frontmatter for `^lifecycle:` across all pages. Flag any value not in `{draft, reviewed, verified, disputed, archived}`.
+**How to check:** Grep frontmatter for `^lifecycle:` across all pages. Flag any value outside the effective lifecycle set (framework default: `{draft, reviewed, verified, disputed, archived}`).
 
 **How to fix:** n/a (only a human should set lifecycle state)
 
 #### Rule 12b — `base_confidence` range
 
-**How to check:** Grep frontmatter for `^base_confidence:` across all pages. Flag any value outside `[0.0, 1.0]` or any page missing the field entirely.
+**How to check:** Grep frontmatter for `^base_confidence:` across all pages. Flag any present value outside `[0.0, 1.0]`; flag absence only when the effective owner schema requires the field.
 
 **How to fix:** n/a (wrong value means the skill computed it wrong — surface for manual correction)
 
@@ -269,8 +275,9 @@ merely to silence warnings.
 
 #### Current enforcement
 
-Full enforcement is active. Every non-reserved content page must contain a
+Under framework defaults, every non-reserved content page must contain a
 finite `base_confidence` in `[0.0, 1.0]` and a documented lifecycle value.
+An owner schema may relax either field; present values remain validated.
 Missing or malformed trust fields, malformed ledger data, and a missing required
 ledger are hard errors. New pages with valid trust fields but no approved ledger
 entry are `unreviewed`; material changes to approved pages are `stale`.
@@ -300,7 +307,7 @@ Append to the `LINT` log entry:
 
 Validate `relationships:` frontmatter blocks. Skip pages that have no `relationships:` block — the field is optional.
 
-**Allowed types:** `extends`, `implements`, `contradicts`, `derived_from`, `uses`, `replaces`, `related_to`
+**Framework-default types:** `extends`, `implements`, `contradicts`, `derived_from`, `uses`, `replaces`, `related_to`. Validate against the effective set after applying owner extensions.
 
 **How to check:**
 - Grep frontmatter for `^relationships:` across all vault pages
@@ -311,7 +318,7 @@ Validate `relationships:` frontmatter blocks. Skip pages that have no `relations
   3. **Self-reference** — flag any entry where the resolved target equals the page's own node id
 
 **How to fix:**
-- Invalid type: correct the value to the nearest allowed type, or use `related_to` when the type is ambiguous
+- Invalid type: report the value and effective schema source. Correct it only if it is absent from both framework defaults and owner extensions; never replace a valid owner type with `related_to`.
 - Broken target: update or remove the entry; if the target page should exist, create it first
 - Self-reference: remove the entry
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -46,10 +46,13 @@ obsidian-wiki query "rate limiting" --top 12 --max-read 5 --json
 
 obsidian-wiki lint                     # uses the configured vault
 obsidian-wiki lint /path/to/vault --strict
+obsidian-wiki lint @research --json    # uses ~/.obsidian-wiki/config.research only
 obsidian-wiki lint --strict-trust      # fail on trust-ledger problems, not just warn
+obsidian-wiki lint --allow-lifecycle active --allow-relationship-type synthesizes \
+  --required-trust-field updated --schema-source /path/to/vault/AGENTS.md
 ```
 
-Both default to the configured `OBSIDIAN_VAULT_PATH`; pass a path or `--vault` to override. Use these when you want a fast local answer without going through an agent prompt.
+Lint resolves its vault and schema together: explicit path (no config inheritance), positional `@name`, nearest CWD `.env`, then global config. CLI schema flags extend/replace that resolved vault's settings and are recorded in the JSON `schema` block.
 
 ## Context packs
 
@@ -137,9 +140,11 @@ Records and validates human-approved confidence reviews, so you can gate on "a p
 obsidian-wiki trust-record --all --reviewed-at 2026-07-30T10:00:00+00:00 --approved
 obsidian-wiki trust-record --page concepts/rate-limiting.md --reviewed-at <ISO> --approved
 obsidian-wiki trust-check --strict
+obsidian-wiki trust-record @research --all --reviewed-at <ISO> --approved --allow-lifecycle active
+obsidian-wiki trust-check @research --allow-lifecycle active --schema-source /vault/AGENTS.md
 ```
 
-`--reviewed-at` needs a timezone. `--approved` is required and mandatory — it's your assertion that a human approved every confidence value being recorded. `trust-check --strict` is the CI/scheduled gate.
+`--reviewed-at` needs a timezone. `--approved` is required and mandatory — it's your assertion that a human approved every confidence value being recorded. `trust-check --strict` is the CI/scheduled gate. `trust-record` and `trust-check` resolve the same vault-scoped schema as lint; pass the same lifecycle and required-field overrides to record and check. If the owner schema does not require `base_confidence`, pages without it are reported as `not_applicable`, excluded by `trust-record --all`, and any obsolete ledger entry is warned by `trust-check` then removed by `trust-record --page` or a rebuild. Both JSON and human-readable record output list excluded pages and removed obsolete entries; human output also emits a stderr warning when removal occurs. Required-field config accepts only `base_confidence`, `lifecycle`, `lifecycle_changed`, and `updated`; typos fail closed. Lifecycle, relationship-type, and required-field override values are stripped and empty or whitespace-only entries are rejected rather than added to an allowlist. Without an explicit `--schema-source`, CLI overrides on an explicit vault are labeled `cli:explicit-vault`; combined CLI and config overrides use `cli+config:<resolved-config-path>`.
 
 ## Lower-level commands
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,8 @@ After resolving, skills also read `$OBSIDIAN_VAULT_PATH/AGENTS.md` if it exists.
 
 Both `~/.obsidian-wiki/config` and `.env` use the same `KEY=value` format. Start from [`.env.example`](../.env.example).
 
+The deterministic `lint`, `trust-record`, and `trust-check` commands use the same vault-scoped resolution: an explicit path uses no unrelated config, `@name` reads only `~/.obsidian-wiki/config.<name>`, otherwise the nearest CWD `.env` wins before global config. Schema settings are read from that same resolved config only, so one vault's lifecycle extensions cannot leak into another vault.
+
 ## Core
 
 | Variable | What it does | Default |
@@ -47,6 +49,14 @@ Local git repo clones work in `OBSIDIAN_SOURCES_DIR` (public or private, any hos
 |---|---|---|
 | `WIKI_STAGED_WRITES` | When `true`, LLM-written pages land in `_staging/` for human review instead of the live vault. Promote them with `/wiki-stage-commit` | *(unset — direct writes)* |
 | `OBSIDIAN_TRUST_STRICT` | When `1`, `obsidian-wiki lint` treats missing trust fields, ledger errors, stale reviews, and score mismatches as failures rather than warnings. Same as `lint --strict-trust` | *(unset)* |
+| `OBSIDIAN_ALLOWED_LIFECYCLES` | Comma-separated lifecycle extensions for this resolved vault | *(framework defaults only)* |
+| `OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES` | Comma-separated relationship-type extensions for this resolved vault | *(framework defaults only)* |
+| `OBSIDIAN_REQUIRED_TRUST_FIELDS` | Comma-separated effective required trust fields. Allowed values: `base_confidence`, `lifecycle`, `lifecycle_changed`, `updated`; unknown values fail closed | `base_confidence,lifecycle` for lint; also `updated` for standalone trust commands |
+| `OBSIDIAN_SCHEMA_SOURCE` | Owner authority locator emitted in machine reports | `config:<resolved-config-path>` when overrides exist |
+
+Schema resolution precedence is CLI flags > resolved environment/config values > framework defaults. Lifecycle and relationship-type extension lists are additive to framework defaults; CLI required-field values replace environment requiredness. CLI-only schema overrides use a `cli:<context>` source label rather than claiming a config-file provenance. If CLI and resolved config both contribute overrides, reports use `cli+config:<resolved-config-path>` unless `--schema-source` or `OBSIDIAN_SCHEMA_SOURCE` supplies the owner authority explicitly.
+
+The four schema variables are `OBSIDIAN_ALLOWED_LIFECYCLES`, `OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES`, `OBSIDIAN_REQUIRED_TRUST_FIELDS`, and `OBSIDIAN_SCHEMA_SOURCE`. When any is present, its value and every comma-separated entry must be non-empty after trimming whitespace. Empty values, repeated commas, and trailing commas fail closed with exit 1; remove the variable entirely to use framework defaults. The distributable `.env.example` documents safe commented examples for all four.
 
 Staged pages aren't visible in Obsidian's graph until promoted. `wiki-status` lists pending staged writes first when this mode is on — the work is done, it just needs your eyes. The `_staging/` directory is created at setup even when the mode is off.
 

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -12,10 +12,12 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TypedDict
 
 from obsidian_wiki import __version__
 
@@ -27,6 +29,13 @@ GLOBAL_CONFIG = GLOBAL_CONFIG_DIR / "config"
 # config). These are also installed globally for agents that only scope skills
 # per-project, so cross-project sync/query/context work everywhere.
 PORTABLE_SKILLS = ("wiki-update", "wiki-query", "wiki-context-pack")
+
+
+class SchemaOptions(TypedDict):
+    allowed_lifecycles: frozenset[str]
+    allowed_relationship_types: frozenset[str]
+    required_trust_fields: tuple[str, ...]
+    schema_source: str
 
 
 # ── Data resolution ──────────────────────────────────────────────────────────
@@ -1067,25 +1076,200 @@ def _print_lint(report: dict[str, object]) -> None:
         print(f"{name}: {count}")
 
 
+def _schema_csv(config: dict[str, str], key: str) -> list[str]:
+    if key not in config:
+        return []
+    values = [item.strip() for item in config[key].split(",")]
+    if any(not item for item in values):
+        raise ValueError(f"invalid {key} value: entries must not be empty")
+    return values
+
+
+def _schema_cli_values(values: list[str] | None, flag: str) -> list[str]:
+    normalised = [item.strip() for item in values or []]
+    if any(not item for item in normalised):
+        raise ValueError(f"invalid {flag} value: must not be empty")
+    return normalised
+
+
+def _schema_source_value(
+    args: argparse.Namespace,
+    config: dict[str, str],
+) -> str | None:
+    configured_value: str | None = None
+    if "OBSIDIAN_SCHEMA_SOURCE" in config:
+        configured_value = config["OBSIDIAN_SCHEMA_SOURCE"].strip()
+        if not configured_value:
+            raise ValueError("invalid OBSIDIAN_SCHEMA_SOURCE value: must not be empty")
+
+    cli_value = getattr(args, "schema_source", None)
+    if cli_value is not None:
+        value = cli_value.strip()
+        if not value:
+            raise ValueError("invalid --schema-source value: must not be empty")
+        return value
+    return configured_value
+
+
+def _read_config_file(path: Path) -> dict[str, str]:
+    if not path.is_file():
+        return {}
+    values: dict[str, str] = {}
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip("'\"")
+    return values
+
+
+def _resolve_schema_command_context(
+    vault_arg: str | None,
+) -> tuple[Path, dict[str, str], str] | None:
+    config: dict[str, str]
+    config_source: str
+    if vault_arg and vault_arg.startswith("@"):
+        name = vault_arg[1:]
+        if not name or re.fullmatch(r"[A-Za-z0-9_-]+", name) is None:
+            print("error: named vault must use @ followed by letters, digits, _ or -", file=sys.stderr)
+            return None
+        path = GLOBAL_CONFIG_DIR / f"config.{name}"
+        config = _read_config_file(path)
+        config_source = str(path)
+        resolved = config.get("OBSIDIAN_VAULT_PATH", "")
+    elif vault_arg is not None:
+        config = {}
+        config_source = "explicit-vault"
+        resolved = vault_arg
+    else:
+        current = Path.cwd().resolve()
+        config = {}
+        config_source = str(GLOBAL_CONFIG)
+        while True:
+            candidate = current / ".env"
+            local = _read_config_file(candidate)
+            if "OBSIDIAN_VAULT_PATH" in local:
+                config = local
+                config_source = str(candidate)
+                break
+            if current == HOME or current.parent == current:
+                break
+            current = current.parent
+        if not config:
+            config = _read_config_file(GLOBAL_CONFIG)
+        resolved = config.get("OBSIDIAN_VAULT_PATH", "")
+    if not resolved:
+        print("error: vault not configured; pass a path, @name, or run obsidian-wiki setup", file=sys.stderr)
+        return None
+    vault = Path(resolved).expanduser().resolve()
+    if not vault.is_dir():
+        print(f"error: vault not found: {vault}", file=sys.stderr)
+        return None
+    return vault, config, config_source
+
+
+def _schema_options(
+    args: argparse.Namespace,
+    config: dict[str, str],
+    config_source: str,
+    *,
+    default_required_trust_fields: tuple[str, ...] | None = None,
+) -> SchemaOptions:
+    from obsidian_wiki.lint import (
+        ALLOWED_RELATIONSHIP_TYPES,
+        TRUST_REQUIRED_FRONTMATTER,
+    )
+    from obsidian_wiki.trust import (
+        ALLOWED_LIFECYCLES,
+        TRUST_REQUIRED_FIELD_ALLOWLIST,
+    )
+
+    cli_lifecycles = _schema_cli_values(
+        getattr(args, "allow_lifecycle", None), "--allow-lifecycle"
+    )
+    cli_relationships = _schema_cli_values(
+        getattr(args, "allow_relationship_type", None), "--allow-relationship-type"
+    )
+    raw_cli_required = getattr(args, "required_trust_field", None)
+    cli_required = (
+        _schema_cli_values(raw_cli_required, "--required-trust-field")
+        if raw_cli_required is not None
+        else None
+    )
+    configured_lifecycles = _schema_csv(config, "OBSIDIAN_ALLOWED_LIFECYCLES")
+    configured_relationships = _schema_csv(config, "OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES")
+    configured_required = _schema_csv(config, "OBSIDIAN_REQUIRED_TRUST_FIELDS")
+    unknown_required = sorted(
+        set(configured_required).union(cli_required or ()) - TRUST_REQUIRED_FIELD_ALLOWLIST
+    )
+    if unknown_required:
+        allowed = ", ".join(sorted(TRUST_REQUIRED_FIELD_ALLOWLIST))
+        unknown = ", ".join(unknown_required)
+        raise ValueError(
+            "invalid OBSIDIAN_REQUIRED_TRUST_FIELDS value(s): "
+            f"{unknown}; allowed values: {allowed}"
+        )
+    required = tuple(
+        cli_required
+        if cli_required is not None
+        else configured_required
+        or list(default_required_trust_fields or TRUST_REQUIRED_FRONTMATTER)
+    )
+    cli_overrides = bool(
+        cli_lifecycles
+        or cli_relationships
+        or cli_required is not None
+    )
+    configured_overrides = bool(
+        configured_lifecycles
+        or configured_relationships
+        or configured_required
+    )
+    source = _schema_source_value(args, config)
+    if not source:
+        if cli_overrides and configured_overrides:
+            source = f"cli+config:{config_source}"
+        elif cli_overrides:
+            source = f"cli:{config_source}"
+        elif configured_overrides:
+            source = f"config:{config_source}"
+        else:
+            source = "framework-defaults"
+    return {
+        "allowed_lifecycles": ALLOWED_LIFECYCLES.union(configured_lifecycles, cli_lifecycles),
+        "allowed_relationship_types": ALLOWED_RELATIONSHIP_TYPES.union(
+            configured_relationships, cli_relationships
+        ),
+        "required_trust_fields": required,
+        "schema_source": source,
+    }
+
+
 def cmd_lint(args: argparse.Namespace) -> int:
     from obsidian_wiki.lint import lint_vault
 
-    vault_arg = args.vault or _read_config_value("OBSIDIAN_VAULT_PATH")
-    if not vault_arg:
-        print("error: vault not configured; pass a path or run obsidian-wiki setup", file=sys.stderr)
+    context = _resolve_schema_command_context(args.vault)
+    if context is None:
         return 1
+    vault, config, config_source = context
 
-    vault = Path(vault_arg).expanduser().resolve()
-    if not vault.is_dir():
-        print(f"error: vault not found: {vault}", file=sys.stderr)
-        return 1
-
-    strict_trust = args.strict_trust or _read_config_value("OBSIDIAN_TRUST_STRICT").strip().lower() in (
+    strict_trust = args.strict_trust or config.get("OBSIDIAN_TRUST_STRICT", "").strip().lower() in (
         "1",
         "true",
         "yes",
     )
-    report = lint_vault(vault, require_trust_ledger=True, strict_trust=strict_trust)
+    try:
+        schema = _schema_options(args, config, config_source)
+        report = lint_vault(
+            vault,
+            require_trust_ledger=True,
+            strict_trust=strict_trust,
+            **schema,
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     if args.json:
         if args.pretty:
             print(json.dumps(report, indent=2))
@@ -1153,17 +1337,50 @@ def cmd_trust_record(args: argparse.Namespace) -> int:
     from obsidian_wiki.trust import (
         TRUST_LEDGER_RELATIVE_PATH,
         build_trust_ledger,
+        check_trust_ledger,
         update_trust_ledger,
         write_trust_ledger,
     )
 
-    vault = _resolve_command_vault(args.vault)
-    if vault is None:
+    context = _resolve_schema_command_context(args.vault)
+    if context is None:
+        return 1
+    vault, config, config_source = context
+    try:
+        schema = _schema_options(
+            args,
+            config,
+            config_source,
+            default_required_trust_fields=("base_confidence", "lifecycle", "updated"),
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return 1
     path = vault / TRUST_LEDGER_RELATIVE_PATH
     try:
         if args.all:
-            ledger = build_trust_ledger(vault, reviewed_at=args.reviewed_at)
+            removed_not_applicable: list[str] = []
+            if path.is_file():
+                previous = check_trust_ledger(
+                    vault,
+                    path,
+                    allowed_lifecycles=schema["allowed_lifecycles"],
+                    required_trust_keys=schema["required_trust_fields"],
+                    schema_source=schema["schema_source"],
+                )
+                removed_not_applicable = sorted(
+                    item["page"]
+                    for item in previous["stale"]
+                    if item.get("reason")
+                    == "confidence_not_applicable_but_ledger_entry_exists"
+                )
+            ledger = build_trust_ledger(
+                vault,
+                reviewed_at=args.reviewed_at,
+                allowed_lifecycles=schema["allowed_lifecycles"],
+                required_trust_keys=schema["required_trust_fields"],
+            )
+            ledger["removed_not_applicable"] = removed_not_applicable
             recorded_pages = len(ledger["pages"])
         else:
             ledger = update_trust_ledger(
@@ -1171,33 +1388,80 @@ def cmd_trust_record(args: argparse.Namespace) -> int:
                 path,
                 reviewed_at=args.reviewed_at,
                 page_paths=args.page,
+                allowed_lifecycles=schema["allowed_lifecycles"],
+                required_trust_keys=schema["required_trust_fields"],
             )
-            recorded_pages = len(set(args.page))
+            requested = {
+                Path(raw).as_posix().removeprefix("./") for raw in args.page
+            }
+            recorded_pages = len(requested.intersection(ledger["pages"]))
         write_trust_ledger(path, ledger, vault=vault)
-    except ValueError as exc:
+    except (RuntimeError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
     result = {
         "status": "recorded",
         "ledger_path": str(path),
         "recorded_pages": recorded_pages,
+        "not_applicable_pages": list(ledger.get("not_applicable", [])),
+        "removed_not_applicable": list(ledger.get("removed_not_applicable", [])),
         "reviewed_at": args.reviewed_at,
         "method": ledger["method"],
+        "schema": {
+            "source": schema["schema_source"],
+            "allowed_lifecycles": sorted(schema["allowed_lifecycles"]),
+            "required_trust_fields": list(schema["required_trust_fields"]),
+        },
     }
     if args.json:
         print(json.dumps(result, indent=2 if args.pretty else None))
     else:
         print(f"recorded {result['recorded_pages']} reviewed page(s) in {path}")
+        print(
+            "not applicable (excluded from trust review): "
+            f"{len(result['not_applicable_pages'])} page(s)"
+        )
+        for page in result["not_applicable_pages"]:
+            print(f"  - {page}")
+        print(
+            "obsolete ledger entries removed: "
+            f"{len(result['removed_not_applicable'])} page(s)"
+        )
+        for page in result["removed_not_applicable"]:
+            print(f"  - {page}")
+        if result["removed_not_applicable"]:
+            removed = ", ".join(result["removed_not_applicable"])
+            print(
+                "warning: removed obsolete trust ledger entries because "
+                f"base_confidence is not applicable: {removed}",
+                file=sys.stderr,
+            )
     return 0
 
 
 def cmd_trust_check(args: argparse.Namespace) -> int:
     from obsidian_wiki.trust import check_trust_ledger
 
-    vault = _resolve_command_vault(args.vault)
-    if vault is None:
+    context = _resolve_schema_command_context(args.vault)
+    if context is None:
         return 1
-    report = check_trust_ledger(vault)
+    vault, config, config_source = context
+    try:
+        schema = _schema_options(
+            args,
+            config,
+            config_source,
+            default_required_trust_fields=("base_confidence", "lifecycle", "updated"),
+        )
+        report = check_trust_ledger(
+            vault,
+            allowed_lifecycles=schema["allowed_lifecycles"],
+            required_trust_keys=schema["required_trust_fields"],
+            schema_source=schema["schema_source"],
+        )
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
     if args.json:
         print(json.dumps(report, indent=2 if args.pretty else None))
     else:
@@ -1502,7 +1766,7 @@ def build_parser() -> argparse.ArgumentParser:
         "lint",
         help="lint a vault for missing frontmatter, broken links, duplicates, and orphans",
     )
-    lt.add_argument("vault", nargs="?", help="path to the Obsidian vault (defaults to configured OBSIDIAN_VAULT_PATH)")
+    lt.add_argument("vault", nargs="?", help="vault path or @name (defaults via CWD .env, then global config)")
     lt.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     lt.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
     lt.add_argument("--strict", action="store_true", help="exit non-zero on warnings as well as failures")
@@ -1515,13 +1779,35 @@ def build_parser() -> argparse.ArgumentParser:
             "Also settable per-vault via OBSIDIAN_TRUST_STRICT=1 in the config."
         ),
     )
+    lt.add_argument(
+        "--allow-lifecycle",
+        action="append",
+        metavar="VALUE",
+        help="extend the framework lifecycle allowlist (repeatable)",
+    )
+    lt.add_argument(
+        "--allow-relationship-type",
+        action="append",
+        metavar="VALUE",
+        help="extend the framework relationship-type allowlist (repeatable)",
+    )
+    lt.add_argument(
+        "--required-trust-field",
+        action="append",
+        choices=("base_confidence", "lifecycle", "lifecycle_changed", "updated"),
+        help="replace default trust-field requiredness (repeatable)",
+    )
+    lt.add_argument(
+        "--schema-source",
+        help="authority locator recorded in the lint report (for example, vault/AGENTS.md)",
+    )
     lt.set_defaults(func=cmd_lint)
 
     tr = sub.add_parser(
         "trust-record",
         help="record explicitly approved manual confidence reviews in the vault trust ledger",
     )
-    tr.add_argument("vault", nargs="?", help="path to the Obsidian vault (defaults to configured OBSIDIAN_VAULT_PATH)")
+    tr.add_argument("vault", nargs="?", help="vault path or @name (defaults via CWD .env, then global config)")
     selection = tr.add_mutually_exclusive_group(required=True)
     selection.add_argument("--all", action="store_true", help="record every current trust-schema page")
     selection.add_argument(
@@ -1539,16 +1825,45 @@ def build_parser() -> argparse.ArgumentParser:
     )
     tr.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     tr.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
+    tr.add_argument(
+        "--allow-lifecycle",
+        action="append",
+        metavar="VALUE",
+        help="extend the resolved vault lifecycle allowlist (repeatable)",
+    )
+    tr.add_argument(
+        "--required-trust-field",
+        action="append",
+        choices=("base_confidence", "lifecycle", "lifecycle_changed", "updated"),
+        help="replace resolved vault trust-field requiredness (repeatable)",
+    )
+    tr.add_argument("--schema-source", help="authority locator recorded in the result")
     tr.set_defaults(func=cmd_trust_record)
 
     tc = sub.add_parser(
         "trust-check",
         help="validate confidence values and material fingerprints against the manual trust ledger",
     )
-    tc.add_argument("vault", nargs="?", help="path to the Obsidian vault (defaults to configured OBSIDIAN_VAULT_PATH)")
+    tc.add_argument("vault", nargs="?", help="vault path or @name (defaults via CWD .env, then global config)")
     tc.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     tc.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
     tc.add_argument("--strict", action="store_true", help="exit non-zero on warnings as well as failures")
+    tc.add_argument(
+        "--allow-lifecycle",
+        action="append",
+        metavar="VALUE",
+        help="extend the framework lifecycle allowlist (repeatable)",
+    )
+    tc.add_argument(
+        "--required-trust-field",
+        action="append",
+        choices=("base_confidence", "lifecycle", "lifecycle_changed", "updated"),
+        help="replace default trust-field requiredness (repeatable)",
+    )
+    tc.add_argument(
+        "--schema-source",
+        help="authority locator recorded in the trust report",
+    )
     tc.set_defaults(func=cmd_trust_check)
 
     qq = sub.add_parser(

--- a/obsidian_wiki/lint.py
+++ b/obsidian_wiki/lint.py
@@ -4,10 +4,16 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
-from obsidian_wiki.trust import TRUST_LEDGER_RELATIVE_PATH, check_trust_ledger
+from obsidian_wiki.trust import (
+    ALLOWED_LIFECYCLES,
+    TRUST_LEDGER_RELATIVE_PATH,
+    check_trust_ledger,
+    validate_trust_metadata,
+)
 
 SKIP_DIRS = frozenset("_raw _archived _staging _archives _bootstrap .obsidian .git".split())
 REQUIRED_FRONTMATTER = (
@@ -180,7 +186,24 @@ def lint_vault(
     *,
     require_trust_ledger: bool = True,
     strict_trust: bool = False,
+    allowed_relationship_types: Collection[str] | None = None,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_fields: Collection[str] | None = None,
+    schema_source: str = "framework-defaults",
 ) -> dict[str, Any]:
+    relationship_types = frozenset(
+        ALLOWED_RELATIONSHIP_TYPES
+        if allowed_relationship_types is None
+        else allowed_relationship_types
+    )
+    lifecycles = frozenset(
+        ALLOWED_LIFECYCLES if allowed_lifecycles is None else allowed_lifecycles
+    )
+    trust_fields = (
+        tuple(required_trust_fields)
+        if required_trust_fields is not None
+        else TRUST_REQUIRED_FRONTMATTER
+    )
     pages = [_parse_page(path, vault) for path in _iter_pages(vault)]
     slug_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
     node_index: dict[str, list[dict[str, Any]]] = defaultdict(list)
@@ -202,15 +225,24 @@ def lint_vault(
 
     missing_frontmatter = []
     confidence_missing_fields = []
+    trust_metadata_errors = []
     for page in pages:
         if page["slug"] in RESERVED_PAGE_STEMS:
             continue
         missing = [field for field in REQUIRED_FRONTMATTER if field not in page["fields"]]
         if missing:
             missing_frontmatter.append({"page": page["path"], "missing": missing})
-        missing_trust = [field for field in TRUST_REQUIRED_FRONTMATTER if field not in page["fields"]]
+        missing_trust = [field for field in trust_fields if field not in page["fields"]]
         if missing_trust:
             confidence_missing_fields.append({"page": page["path"], "missing": missing_trust})
+        try:
+            validate_trust_metadata(
+                vault / page["path"],
+                allowed_lifecycles=lifecycles,
+                required_trust_keys=(),
+            )
+        except ValueError as exc:
+            trust_metadata_errors.append({"page": page["path"], "issue": str(exc)})
 
     title_index: dict[str, list[str]] = defaultdict(list)
     for page in pages:
@@ -251,7 +283,7 @@ def lint_vault(
                 continue
             relation_type = relationship.get("type", "")
             target_raw = relationship.get("target", "")
-            if relation_type not in ALLOWED_RELATIONSHIP_TYPES:
+            if relation_type not in relationship_types:
                 typed_relationship_issues.append(
                     {
                         "page": page["path"],
@@ -295,7 +327,13 @@ def lint_vault(
 
     ledger_path = vault / TRUST_LEDGER_RELATIVE_PATH
     trust_report = (
-        check_trust_ledger(vault, ledger_path)
+        check_trust_ledger(
+            vault,
+            ledger_path,
+            allowed_lifecycles=lifecycles,
+            required_trust_keys=trust_fields,
+            schema_source=schema_source,
+        )
         if ledger_path.is_file() or require_trust_ledger
         else None
     )
@@ -308,6 +346,7 @@ def lint_vault(
         "orphan_pages": sorted(orphan_pages),
         "typed_relationship_issues": typed_relationship_issues,
         "confidence_missing_fields": confidence_missing_fields,
+        "trust_metadata_errors": trust_metadata_errors,
         "confidence_review_stale": trust_report["stale"] if trust_report else [],
         "confidence_unreviewed": trust_report["unreviewed"] if trust_report else [],
         "confidence_mismatches": trust_report["score_mismatches"] if trust_report else [],
@@ -338,7 +377,12 @@ def lint_vault(
         )
     )
 
-    if counts["broken_links"] or counts["missing_frontmatter"] or trust_fails:
+    if (
+        counts["broken_links"]
+        or counts["missing_frontmatter"]
+        or counts["trust_metadata_errors"]
+        or trust_fails
+    ):
         status = "fail"
     elif (
         any(
@@ -353,6 +397,12 @@ def lint_vault(
 
     return {
         "status": status,
+        "schema": {
+            "source": schema_source,
+            "allowed_lifecycles": sorted(lifecycles),
+            "allowed_relationship_types": sorted(relationship_types),
+            "required_trust_fields": list(trust_fields),
+        },
         "stats": {
             "pages": len(pages),
             "link_count": sum(len(page["links"]) for page in pages),

--- a/obsidian_wiki/trust.py
+++ b/obsidian_wiki/trust.py
@@ -16,6 +16,7 @@ import re
 import secrets
 import stat
 import tempfile
+from collections.abc import Collection
 from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -28,6 +29,9 @@ TRUST_SKIP_DIRS = frozenset(
 )
 TRUST_RESERVED_STEMS = frozenset({"index", "log", "hot", "_insights"})
 ALLOWED_LIFECYCLES = frozenset({"draft", "reviewed", "verified", "disputed", "archived"})
+TRUST_REQUIRED_FIELD_ALLOWLIST = frozenset(
+    {"base_confidence", "lifecycle", "lifecycle_changed", "updated"}
+)
 _REQUIRED_TRUST_KEYS = ("base_confidence", "lifecycle", "updated")
 _VOLATILE_CONFIDENCE_KEYS = (
     "updated",
@@ -93,8 +97,32 @@ def _frontmatter_scalar(raw: str) -> str:
     return value
 
 
-def _trust_metadata(path: Path) -> dict[str, Any]:
+def _effective_schema(
+    *,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
+) -> tuple[frozenset[str], tuple[str, ...]]:
+    lifecycles = frozenset(
+        ALLOWED_LIFECYCLES if allowed_lifecycles is None else allowed_lifecycles
+    )
+    required = tuple(required_trust_keys) if required_trust_keys is not None else _REQUIRED_TRUST_KEYS
+    unknown = set(required) - TRUST_REQUIRED_FIELD_ALLOWLIST
+    if unknown:
+        raise ValueError(f"unknown required trust field(s): {', '.join(sorted(unknown))}")
+    return lifecycles, required
+
+
+def _trust_metadata(
+    path: Path,
+    *,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
+) -> dict[str, Any]:
     """Parse and validate trust-sensitive frontmatter without YAML ambiguity."""
+    lifecycles, required = _effective_schema(
+        allowed_lifecycles=allowed_lifecycles,
+        required_trust_keys=required_trust_keys,
+    )
     try:
         text = _normalise_text(path.read_text(encoding="utf-8"))
     except UnicodeError as exc:
@@ -121,7 +149,7 @@ def _trust_metadata(path: Path) -> dict[str, Any]:
         entries = records.get(key, [])
         if len(entries) > 1:
             raise ValueError(f"duplicate top-level field: {key}")
-    for key in _REQUIRED_TRUST_KEYS:
+    for key in required:
         if key not in records:
             raise ValueError(f"missing {key}")
 
@@ -134,27 +162,33 @@ def _trust_metadata(path: Path) -> dict[str, Any]:
         if not scalar or scalar in {">", ">-", "|", "|-"} or children:
             raise ValueError(f"{key} must be a scalar")
 
-    updated = _frontmatter_scalar(records["updated"][0][0])
-    _validate_updated(updated)
+    if "updated" in records:
+        updated = _frontmatter_scalar(records["updated"][0][0])
+        _validate_updated(updated)
 
-    confidence_raw = _frontmatter_scalar(records["base_confidence"][0][0])
-    try:
-        confidence = float(confidence_raw)
-    except ValueError as exc:
-        raise ValueError("base_confidence is not numeric") from exc
-    if not math.isfinite(confidence):
-        raise ValueError("base_confidence is not finite")
-    if not 0.0 <= confidence <= 1.0:
-        raise ValueError("base_confidence is outside [0.0, 1.0]")
+    confidence: float | None = None
+    if "base_confidence" in records:
+        confidence_raw = _frontmatter_scalar(records["base_confidence"][0][0])
+        try:
+            confidence = float(confidence_raw)
+        except ValueError as exc:
+            raise ValueError("base_confidence is not numeric") from exc
+        if not math.isfinite(confidence):
+            raise ValueError("base_confidence is not finite")
+        if not 0.0 <= confidence <= 1.0:
+            raise ValueError("base_confidence is outside [0.0, 1.0]")
 
-    lifecycle = _frontmatter_scalar(records["lifecycle"][0][0])
-    if lifecycle not in ALLOWED_LIFECYCLES:
-        raise ValueError(f"invalid lifecycle: {lifecycle}")
+    lifecycle: str | None = None
+    if "lifecycle" in records:
+        lifecycle = _frontmatter_scalar(records["lifecycle"][0][0])
+        if lifecycle not in lifecycles:
+            raise ValueError(f"invalid lifecycle: {lifecycle}")
     return {
         "text": text,
         "frontmatter": frontmatter,
         "confidence": confidence,
         "lifecycle": lifecycle,
+        "review_status": "reviewable" if confidence is not None else "not_applicable",
     }
 
 
@@ -171,9 +205,18 @@ def _strip_volatile_confidence_fields(frontmatter: str) -> str:
     return "\n".join(kept).strip()
 
 
-def page_fingerprint(path: Path) -> str:
+def page_fingerprint(
+    path: Path,
+    *,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
+) -> str:
     """Hash material claims and evidence, excluding validated volatile bookkeeping."""
-    metadata = _trust_metadata(path)
+    metadata = _trust_metadata(
+        path,
+        allowed_lifecycles=allowed_lifecycles,
+        required_trust_keys=required_trust_keys,
+    )
     text = metadata["text"]
     match = _FRONTMATTER_RE.match(text)
     assert match is not None
@@ -183,8 +226,34 @@ def page_fingerprint(path: Path) -> str:
     return "sha256:" + hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
-def _parse_confidence(path: Path) -> float:
-    return float(_trust_metadata(path)["confidence"])
+def validate_trust_metadata(
+    path: Path,
+    *,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
+) -> dict[str, Any]:
+    """Validate present trust fields even when no review ledger is configured."""
+    return _trust_metadata(
+        path,
+        allowed_lifecycles=allowed_lifecycles,
+        required_trust_keys=required_trust_keys,
+    )
+
+
+def _parse_confidence(
+    path: Path,
+    *,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
+) -> float:
+    value = _trust_metadata(
+        path,
+        allowed_lifecycles=allowed_lifecycles,
+        required_trust_keys=required_trust_keys,
+    )["confidence"]
+    if value is None:
+        raise ValueError("missing base_confidence for trust review")
+    return float(value)
 
 
 def iter_trust_pages(vault: Path) -> list[Path]:
@@ -200,25 +269,67 @@ def iter_trust_pages(vault: Path) -> list[Path]:
     return sorted(pages, key=lambda item: item.relative_to(vault).as_posix())
 
 
-def build_trust_ledger(vault: Path, *, reviewed_at: str) -> dict[str, Any]:
+def build_trust_ledger(
+    vault: Path,
+    *,
+    reviewed_at: str,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
+) -> dict[str, Any]:
     """Capture explicitly approved confidence values and material fingerprints."""
     reviewed_at = _validate_reviewed_at(reviewed_at)
     pages: dict[str, dict[str, Any]] = {}
+    not_applicable: list[str] = []
     for path in iter_trust_pages(vault):
         rel = path.relative_to(vault).as_posix()
-        pages[rel] = _review_entry(path, reviewed_at)
+        metadata = _trust_metadata(
+            path,
+            allowed_lifecycles=allowed_lifecycles,
+            required_trust_keys=required_trust_keys,
+        )
+        if metadata["review_status"] == "not_applicable":
+            not_applicable.append(rel)
+            continue
+        pages[rel] = _review_entry(
+            path,
+            reviewed_at,
+            allowed_lifecycles=allowed_lifecycles,
+            required_trust_keys=required_trust_keys,
+        )
     return {
         "schema_version": TRUST_LEDGER_SCHEMA_VERSION,
         "method": TRUST_REVIEW_METHOD,
         "reviewed_at": reviewed_at,
         "pages": pages,
+        "not_applicable": not_applicable,
     }
 
 
-def _review_entry(path: Path, reviewed_at: str) -> dict[str, Any]:
+def _review_entry(
+    path: Path,
+    reviewed_at: str,
+    *,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
+) -> dict[str, Any]:
+    metadata = _trust_metadata(
+        path,
+        allowed_lifecycles=allowed_lifecycles,
+        required_trust_keys=required_trust_keys,
+    )
+    if metadata["review_status"] == "not_applicable":
+        raise ValueError("trust review is not applicable: base_confidence is absent")
     return {
-        "reviewed_confidence": _parse_confidence(path),
-        "material_fingerprint": page_fingerprint(path),
+        "reviewed_confidence": _parse_confidence(
+            path,
+            allowed_lifecycles=allowed_lifecycles,
+            required_trust_keys=required_trust_keys,
+        ),
+        "material_fingerprint": page_fingerprint(
+            path,
+            allowed_lifecycles=allowed_lifecycles,
+            required_trust_keys=required_trust_keys,
+        ),
         "reviewed_at": reviewed_at,
     }
 
@@ -260,8 +371,10 @@ def update_trust_ledger(
     *,
     reviewed_at: str,
     page_paths: list[str],
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
 ) -> dict[str, Any]:
-    """Update only explicitly reviewed pages while preserving every other entry."""
+    """Update reviewed pages and remove entries whose confidence is not applicable."""
     reviewed_at = _validate_reviewed_at(reviewed_at)
     if ledger_path.is_file():
         try:
@@ -294,6 +407,19 @@ def update_trust_ledger(
         }
 
     current = {path.relative_to(vault).as_posix(): path for path in iter_trust_pages(vault)}
+    not_applicable: list[str] = []
+    for rel, page in current.items():
+        metadata = _trust_metadata(
+            page,
+            allowed_lifecycles=allowed_lifecycles,
+            required_trust_keys=required_trust_keys,
+        )
+        if metadata["review_status"] == "not_applicable":
+            not_applicable.append(rel)
+    removed_not_applicable = sorted(set(ledger["pages"]) & set(not_applicable))
+    for rel in removed_not_applicable:
+        del ledger["pages"][rel]
+
     selected: list[str] = []
     for raw in page_paths:
         candidate = Path(raw)
@@ -305,8 +431,17 @@ def update_trust_ledger(
             raise RuntimeError(f"trust page is missing or lacks the trust schema: {raw}")
         if rel not in selected:
             selected.append(rel)
-            ledger["pages"][rel] = _review_entry(page, reviewed_at)
+            if rel in not_applicable:
+                continue
+            ledger["pages"][rel] = _review_entry(
+                page,
+                reviewed_at,
+                allowed_lifecycles=allowed_lifecycles,
+                required_trust_keys=required_trust_keys,
+            )
     ledger["reviewed_at"] = reviewed_at
+    ledger["not_applicable"] = sorted(not_applicable)
+    ledger["removed_not_applicable"] = removed_not_applicable
     return ledger
 
 
@@ -411,11 +546,23 @@ def write_trust_ledger(
         raise RuntimeError(f"cannot write trust ledger: {exc}") from exc
 
 
-def _empty_report(ledger_path: Path) -> dict[str, Any]:
+def _empty_report(
+    ledger_path: Path,
+    *,
+    allowed_lifecycles: Collection[str],
+    required_trust_keys: Collection[str],
+    schema_source: str,
+) -> dict[str, Any]:
     return {
         "status": "pass",
         "ledger_path": str(ledger_path),
+        "schema": {
+            "source": schema_source,
+            "allowed_lifecycles": sorted(allowed_lifecycles),
+            "required_trust_fields": list(required_trust_keys),
+        },
         "reviewed": [],
+        "not_applicable": [],
         "stale": [],
         "unreviewed": [],
         "score_mismatches": [],
@@ -425,10 +572,26 @@ def _empty_report(ledger_path: Path) -> dict[str, Any]:
     }
 
 
-def check_trust_ledger(vault: Path, ledger_path: Path | None = None) -> dict[str, Any]:
+def check_trust_ledger(
+    vault: Path,
+    ledger_path: Path | None = None,
+    *,
+    allowed_lifecycles: Collection[str] | None = None,
+    required_trust_keys: Collection[str] | None = None,
+    schema_source: str = "framework-defaults",
+) -> dict[str, Any]:
     """Validate current pages against an approved manual review ledger."""
+    lifecycles, required = _effective_schema(
+        allowed_lifecycles=allowed_lifecycles,
+        required_trust_keys=required_trust_keys,
+    )
     path = ledger_path or vault / TRUST_LEDGER_RELATIVE_PATH
-    report = _empty_report(path)
+    report = _empty_report(
+        path,
+        allowed_lifecycles=lifecycles,
+        required_trust_keys=required,
+        schema_source=schema_source,
+    )
     try:
         ledger = json.loads(
             path.read_text(encoding="utf-8"),
@@ -486,16 +649,36 @@ def check_trust_ledger(vault: Path, ledger_path: Path | None = None) -> dict[str
     }
     for rel, page in current.items():
         try:
-            page_metadata = _trust_metadata(page)
-            stored_confidence = float(page_metadata["confidence"])
+            page_metadata = _trust_metadata(
+                page,
+                allowed_lifecycles=lifecycles,
+                required_trust_keys=required,
+            )
         except ValueError as exc:
             report["errors"].append({"page": rel, "issue": str(exc)})
             continue
+        if page_metadata["review_status"] == "not_applicable":
+            report["not_applicable"].append(
+                {"page": rel, "reason": "base_confidence_absent_by_owner_schema"}
+            )
+            if rel in validated_entries:
+                report["stale"].append(
+                    {
+                        "page": rel,
+                        "reason": "confidence_not_applicable_but_ledger_entry_exists",
+                    }
+                )
+            continue
+        stored_confidence = float(page_metadata["confidence"])
         if rel not in validated_entries:
             report["unreviewed"].append({"page": rel, "reason": "not_in_manual_ledger"})
             continue
         fingerprint, reviewed_value, reviewed_at = validated_entries[rel]
-        if page_fingerprint(page) != fingerprint:
+        if page_fingerprint(
+            page,
+            allowed_lifecycles=lifecycles,
+            required_trust_keys=required,
+        ) != fingerprint:
             report["stale"].append({"page": rel, "reason": "material_fingerprint_changed"})
             continue
         if abs(stored_confidence - reviewed_value) > 1e-9:
@@ -521,7 +704,15 @@ def check_trust_ledger(vault: Path, ledger_path: Path | None = None) -> dict[str
 
 
 def _finalise_report(report: dict[str, Any]) -> dict[str, Any]:
-    keys = ("reviewed", "stale", "unreviewed", "score_mismatches", "missing_pages", "errors")
+    keys = (
+        "reviewed",
+        "not_applicable",
+        "stale",
+        "unreviewed",
+        "score_mismatches",
+        "missing_pages",
+        "errors",
+    )
     report["counts"] = {key: len(report[key]) for key in keys}
     if report["errors"] or report["score_mismatches"]:
         report["status"] = "fail"

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import subprocess
@@ -59,8 +60,23 @@ def _run(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [sys.executable, "-m", "obsidian_wiki.cli", *args],
         capture_output=True,
+        check=False,
         text=True,
         env=env,
+    )
+
+
+def _run_at(home: Path, cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env["PYTHONPATH"] = str(Path(__file__).parents[1])
+    return subprocess.run(
+        [sys.executable, "-m", "obsidian_wiki.cli", *args],
+        capture_output=True,
+        check=False,
+        text=True,
+        env=env,
+        cwd=cwd,
     )
 
 
@@ -188,3 +204,417 @@ def test_lint_cli_strict_trust_flag_fails_legacy_vault(tmp_path: Path) -> None:
     strict_proc = _run(home, "lint", "--json", "--strict-trust")
     assert strict_proc.returncode == 1
     assert json.loads(strict_proc.stdout)["status"] == "fail"
+
+
+def test_owner_schema_accepts_extensions_optional_trust_and_reports_source(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    extensions = [
+        ("active", "synthesizes"),
+        ("confirmed", "builds_on"),
+        ("stub", "complements"),
+        ("active", "refines"),
+        ("confirmed", "contrasts_with"),
+    ]
+    names = [f"page-{index}" for index in range(len(extensions))]
+    for index, ((lifecycle, relationship), name) in enumerate(zip(extensions, names)):
+        target = names[(index + 1) % len(names)]
+        page = _page(vault, f"concepts/{name}.md", links=[target])
+        text = page.read_text()
+        text = text.replace("base_confidence: 0.80\n", "")
+        text = text.replace(
+            "lifecycle: reviewed",
+            f'lifecycle: {lifecycle}\nrelationships:\n  - type: {relationship}\n    target: "[[concepts/{target}]]"',
+        )
+        page.write_text(text)
+
+    report = lint_vault(
+        vault,
+        require_trust_ledger=False,
+        allowed_lifecycles={"active", "confirmed", "stub"},
+        allowed_relationship_types={item[1] for item in extensions},
+        required_trust_fields=("updated",),
+        schema_source="wiki/AGENTS.md",
+    )
+
+    assert report["findings"]["confidence_missing_fields"] == []
+    assert report["findings"]["typed_relationship_issues"] == []
+    assert report["schema"] == {
+        "source": "wiki/AGENTS.md",
+        "allowed_lifecycles": ["active", "confirmed", "stub"],
+        "allowed_relationship_types": sorted(item[1] for item in extensions),
+        "required_trust_fields": ["updated"],
+    }
+
+
+def test_invalid_configured_required_trust_field_fails_closed_for_all_cli_paths(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    project = tmp_path / "project"
+    vault = tmp_path / "vault"
+    project.mkdir()
+    _page(vault, "concepts/alpha.md")
+    (project / ".env").write_text(
+        f'OBSIDIAN_VAULT_PATH="{vault}"\n'
+        "OBSIDIAN_REQUIRED_TRUST_FIELDS=updated,base_confidnce\n",
+        encoding="utf-8",
+    )
+    expected = (
+        "error: invalid OBSIDIAN_REQUIRED_TRUST_FIELDS value(s): base_confidnce; "
+        "allowed values: base_confidence, lifecycle, lifecycle_changed, updated"
+    )
+    commands = (
+        ("lint", "--json"),
+        (
+            "trust-record",
+            "--all",
+            "--reviewed-at",
+            "2026-08-05T12:00:00+09:00",
+            "--approved",
+            "--json",
+        ),
+        ("trust-check", "--json"),
+    )
+
+    for command in commands:
+        proc = _run_at(home, project, *command)
+        assert proc.returncode == 1, (command, proc.stdout, proc.stderr)
+        assert proc.stdout == ""
+        assert expected in proc.stderr
+        assert "Traceback" not in proc.stderr
+
+    assert not (vault / "_meta" / "trust-ledger.json").exists()
+
+
+def test_empty_relationship_cli_extension_cannot_hide_missing_relation_type(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    alpha = _page(vault, "concepts/alpha.md", links=["beta"])
+    _page(vault, "concepts/beta.md", links=["alpha"])
+    alpha.write_text(
+        alpha.read_text().replace(
+            "summary: Short summary.",
+            'summary: Short summary.\nrelationships:\n  - type:\n    target: "[[concepts/beta]]"',
+        )
+    )
+
+    baseline = _run(home, "lint", str(vault), "--json")
+    assert baseline.returncode == 0
+    assert json.loads(baseline.stdout)["findings"]["typed_relationship_issues"] == [
+        {"page": "concepts/alpha.md", "index": 0, "issue": "invalid_type", "type": ""}
+    ]
+
+    for value in ("", "   "):
+        invalid = _run(
+            home,
+            "lint",
+            str(vault),
+            "--json",
+            "--allow-relationship-type",
+            value,
+        )
+        assert invalid.returncode == 1
+        assert invalid.stdout == ""
+        assert "error: invalid --allow-relationship-type value: must not be empty" in invalid.stderr
+        assert "Traceback" not in invalid.stderr
+
+
+def test_empty_cli_lifecycle_and_required_field_overrides_fail_closed(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+
+    for value in ("", "   "):
+        lifecycle = _run(
+            home,
+            "lint",
+            str(vault),
+            "--json",
+            "--allow-lifecycle",
+            value,
+        )
+        assert lifecycle.returncode == 1
+        assert lifecycle.stdout == ""
+        assert "error: invalid --allow-lifecycle value: must not be empty" in lifecycle.stderr
+        assert "Traceback" not in lifecycle.stderr
+
+    required = _run(
+        home,
+        "lint",
+        str(vault),
+        "--json",
+        "--required-trust-field",
+        "",
+    )
+    assert required.returncode == 2
+    assert required.stdout == ""
+    assert "invalid choice" in required.stderr
+    assert "Traceback" not in required.stderr
+
+    for value in ("", "   "):
+        source = _run(
+            home,
+            "lint",
+            str(vault),
+            "--json",
+            "--schema-source",
+            value,
+        )
+        assert source.returncode == 1
+        assert source.stdout == ""
+        assert "error: invalid --schema-source value: must not be empty" in source.stderr
+        assert "Traceback" not in source.stderr
+
+
+def test_empty_configured_schema_values_fail_closed_for_all_cli_paths(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    commands = (
+        ("lint", "--json"),
+        (
+            "trust-record",
+            "--all",
+            "--reviewed-at",
+            "2026-08-05T12:00:00+09:00",
+            "--approved",
+            "--json",
+        ),
+        ("trust-check", "--json"),
+    )
+
+    for key in (
+        "OBSIDIAN_ALLOWED_LIFECYCLES",
+        "OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES",
+        "OBSIDIAN_REQUIRED_TRUST_FIELDS",
+        "OBSIDIAN_SCHEMA_SOURCE",
+    ):
+        project = tmp_path / key.lower()
+        project.mkdir()
+        (project / ".env").write_text(
+            f'OBSIDIAN_VAULT_PATH="{vault}"\n{key}=   \n',
+            encoding="utf-8",
+        )
+        for command in commands:
+            invalid = _run_at(home, project, *command)
+            assert invalid.returncode == 1, (key, command, invalid.stdout, invalid.stderr)
+            assert invalid.stdout == ""
+            detail = (
+                "must not be empty"
+                if key == "OBSIDIAN_SCHEMA_SOURCE"
+                else "entries must not be empty"
+            )
+            assert f"error: invalid {key} value: {detail}" in invalid.stderr
+            assert "Traceback" not in invalid.stderr
+
+    assert not (vault / "_meta" / "trust-ledger.json").exists()
+
+
+def test_blank_config_schema_source_cannot_be_masked_by_valid_cli_source(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".env").write_text(
+        f'OBSIDIAN_VAULT_PATH="{vault}"\nOBSIDIAN_SCHEMA_SOURCE=   \n',
+        encoding="utf-8",
+    )
+    ledger = vault / "_meta" / "trust-ledger.json"
+    before = {
+        path.relative_to(vault): path.read_bytes()
+        for path in vault.rglob("*")
+        if path.is_file()
+    }
+    commands = (
+        ("lint", "--json", "--schema-source", "owner/AGENTS.md"),
+        (
+            "trust-record",
+            "--all",
+            "--reviewed-at",
+            "2026-08-05T12:00:00+09:00",
+            "--approved",
+            "--json",
+            "--schema-source",
+            "owner/AGENTS.md",
+        ),
+        ("trust-check", "--json", "--schema-source", "owner/AGENTS.md"),
+    )
+
+    for command in commands:
+        invalid = _run_at(home, project, *command)
+        assert invalid.returncode == 1, (command, invalid.stdout, invalid.stderr)
+        assert invalid.stdout == ""
+        assert "error: invalid OBSIDIAN_SCHEMA_SOURCE value: must not be empty" in invalid.stderr
+        assert "Traceback" not in invalid.stderr
+        after = {
+            path.relative_to(vault): path.read_bytes()
+            for path in vault.rglob("*")
+            if path.is_file()
+        }
+        assert after == before
+        assert not ledger.exists()
+
+
+def test_distributed_schema_config_contract_names_all_four_variables(tmp_path: Path) -> None:
+    assert tmp_path.is_dir()
+    root = Path(__file__).parents[1]
+    variables = (
+        "OBSIDIAN_ALLOWED_LIFECYCLES",
+        "OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES",
+        "OBSIDIAN_REQUIRED_TRUST_FIELDS",
+        "OBSIDIAN_SCHEMA_SOURCE",
+    )
+    env_example = (root / ".env.example").read_text(encoding="utf-8")
+    configuration = (root / "docs" / "configuration.md").read_text(encoding="utf-8")
+    lint_skill = (root / ".skills" / "wiki-lint" / "SKILL.md").read_text(encoding="utf-8")
+    llm_skill = (root / ".skills" / "llm-wiki" / "SKILL.md").read_text(encoding="utf-8")
+    capture_skill = (root / ".skills" / "wiki-capture" / "SKILL.md").read_text(encoding="utf-8")
+
+    for variable in variables:
+        assert variable in env_example
+        assert variable in configuration
+        assert variable in lint_skill
+        assert variable in llm_skill
+        assert variable in capture_skill
+    assert "CLI flags > these environment/config values >" in env_example
+    assert "CLI flags > resolved environment/config values > framework defaults" in lint_skill
+    assert "Empty or whitespace-only values fail closed" in env_example
+    assert "fails closed" in lint_skill
+
+
+def test_owner_schema_still_rejects_unknown_typos(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md", links=["beta"])
+    _page(vault, "concepts/beta.md", links=["alpha"])
+    page.write_text(
+        page.read_text()
+        .replace("lifecycle: reviewed", "lifecycle: activ")
+        .replace(
+            "---\n# alpha",
+            'relationships:\n  - type: synthesizez\n    target: "[[concepts/beta]]"\n---\n# alpha',
+        )
+    )
+
+    report = lint_vault(
+        vault,
+        require_trust_ledger=False,
+        allowed_lifecycles={"active", "confirmed", "stub"},
+        allowed_relationship_types={"synthesizes"},
+        required_trust_fields=("updated",),
+        schema_source="wiki/AGENTS.md",
+    )
+
+    assert report["findings"]["typed_relationship_issues"][0]["issue"] == "invalid_type"
+
+
+def test_default_schema_remains_framework_compatible(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/alpha.md")
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["schema"]["source"] == "framework-defaults"
+    assert report["schema"]["required_trust_fields"] == ["base_confidence", "lifecycle"]
+    assert "related_to" in report["schema"]["allowed_relationship_types"]
+
+
+def test_lifecycle_typo_fails_without_ledger_when_ledger_is_not_required(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("lifecycle: reviewed", "lifecycle: reveiwed"))
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["status"] == "fail"
+    assert report["findings"]["trust_metadata_errors"] == [
+        {"page": "concepts/alpha.md", "issue": "invalid lifecycle: reveiwed"}
+    ]
+
+
+def test_present_invalid_confidence_fails_without_ledger_when_not_required(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("base_confidence: 0.80", "base_confidence: 1.4"))
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["status"] == "fail"
+    assert report["findings"]["trust_metadata_errors"] == [
+        {"page": "concepts/alpha.md", "issue": "base_confidence is outside [0.0, 1.0]"}
+    ]
+
+
+def test_schema_config_is_scoped_to_explicit_cwd_and_named_vaults(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    global_vault = tmp_path / "global-vault"
+    local_vault = tmp_path / "local-vault"
+    explicit_vault = tmp_path / "explicit-vault"
+    for vault in (global_vault, local_vault, explicit_vault):
+        page = _page(vault, "concepts/alpha.md")
+        page.write_text(page.read_text().replace("lifecycle: reviewed", "lifecycle: active"))
+
+    config_dir = home / ".obsidian-wiki"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config").write_text(
+        f'OBSIDIAN_VAULT_PATH="{global_vault}"\nOBSIDIAN_ALLOWED_LIFECYCLES=active\n',
+        encoding="utf-8",
+    )
+    (config_dir / "config.owner").write_text(
+        f'OBSIDIAN_VAULT_PATH="{local_vault}"\nOBSIDIAN_ALLOWED_LIFECYCLES=active\n',
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir()
+    (project / ".env").write_text(
+        f'OBSIDIAN_VAULT_PATH="{local_vault}"\nOBSIDIAN_ALLOWED_LIFECYCLES=active\n',
+        encoding="utf-8",
+    )
+
+    explicit = _run_at(home, project, "lint", str(explicit_vault), "--json")
+    assert explicit.returncode == 1
+    assert json.loads(explicit.stdout)["findings"]["trust_metadata_errors"][0]["issue"] == "invalid lifecycle: active"
+
+    local = _run_at(home, project, "lint", "--json")
+    assert local.returncode == 0, local.stderr
+    local_source = json.loads(local.stdout)["schema"]["source"]
+    assert Path(local_source.removeprefix("config:")).resolve() == (project / ".env").resolve()
+
+    named = _run_at(home, tmp_path, "lint", "@owner", "--json")
+    assert named.returncode == 0, named.stderr
+    named_source = json.loads(named.stdout)["schema"]["source"]
+    assert Path(named_source.removeprefix("config:")).resolve() == (config_dir / "config.owner").resolve()
+
+
+def test_correction_contract_requires_temporal_authority_and_immutable_hash_check(tmp_path: Path) -> None:
+    skill = (Path(__file__).parents[1] / ".skills" / "wiki-capture" / "SKILL.md").read_text()
+    for field in (
+        "authority_class:",
+        "verification_state:",
+        "asserted_at:",
+        "effective_at:",
+        "as_of:",
+        "consumer_propagation:",
+        "source_pre_sha256",
+        "source_post_sha256",
+    ):
+        assert field in skill
+
+    source = tmp_path / "immutable.jsonl"
+    source.write_text('{"role":"user","content":"tool result"}\n', encoding="utf-8")
+    before = hashlib.sha256(source.read_bytes()).hexdigest()
+    correction = {
+        "source_text_sha256": before,
+        "speaker_type": "tool_result",
+        "authority_class": "runtime",
+        "verification_state": "verified",
+        "asserted_at": "2026-08-05T10:00:00+09:00",
+        "effective_at": "2026-08-05T10:00:00+09:00",
+        "as_of": "2026-08-05T11:00:00+09:00",
+        "consumer_propagation": {"ob": "complete", "kw": "open"},
+    }
+    assert correction["speaker_type"] != "user"
+    after = hashlib.sha256(source.read_bytes()).hexdigest()
+    assert before == after == correction["source_text_sha256"]

--- a/tests/test_trust.py
+++ b/tests/test_trust.py
@@ -9,7 +9,13 @@ import sys
 from pathlib import Path
 
 from obsidian_wiki.lint import lint_vault
-from obsidian_wiki.trust import build_trust_ledger, check_trust_ledger, write_trust_ledger
+from obsidian_wiki.trust import (
+    build_trust_ledger,
+    check_trust_ledger,
+    page_fingerprint,
+    update_trust_ledger,
+    write_trust_ledger,
+)
 
 
 def _page(
@@ -73,6 +79,7 @@ def test_reviewed_ledger_is_authoritative_instead_of_reclassifying_sources(tmp_p
     assert report["status"] == "pass"
     assert report["counts"] == {
         "reviewed": 2,
+        "not_applicable": 0,
         "stale": 0,
         "unreviewed": 0,
         "score_mismatches": 0,
@@ -169,6 +176,179 @@ def test_invalid_lifecycle_fails_closed(tmp_path: Path) -> None:
     assert report["errors"] == [
         {"page": "concepts/alpha.md", "issue": "invalid lifecycle: totally-invalid"}
     ]
+
+
+def test_owner_trust_schema_accepts_lifecycle_and_optional_fields(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", "").replace("lifecycle: reviewed", "lifecycle: active"))
+
+    report = check_trust_ledger(
+        vault,
+        ledger_path,
+        allowed_lifecycles={"active", "confirmed", "stub"},
+        required_trust_keys=("updated",),
+        schema_source="wiki/AGENTS.md",
+    )
+
+    assert report["status"] == "warn"
+    assert report["errors"] == []
+    assert report["not_applicable"] == [
+        {
+            "page": "concepts/alpha.md",
+            "reason": "base_confidence_absent_by_owner_schema",
+        }
+    ]
+    assert report["stale"] == [
+        {
+            "page": "concepts/alpha.md",
+            "reason": "confidence_not_applicable_but_ledger_entry_exists",
+        }
+    ]
+    assert report["schema"] == {
+        "source": "wiki/AGENTS.md",
+        "allowed_lifecycles": ["active", "confirmed", "stub"],
+        "required_trust_fields": ["updated"],
+    }
+
+
+def test_owner_schema_build_excludes_no_confidence_page_as_not_applicable(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", ""))
+
+    ledger = build_trust_ledger(
+        vault,
+        reviewed_at="2026-08-05T12:00:00+09:00",
+        required_trust_keys=("updated",),
+    )
+
+    assert ledger["pages"] == {}
+    assert ledger["not_applicable"] == ["concepts/alpha.md"]
+    assert page_fingerprint(page, required_trust_keys=("updated",)).startswith("sha256:")
+
+
+def test_owner_schema_update_removes_stale_no_confidence_entry(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", ""))
+
+    before = check_trust_ledger(
+        vault,
+        ledger_path,
+        required_trust_keys=("updated",),
+    )
+    assert before["status"] == "warn"
+    assert before["stale"] == [
+        {
+            "page": "concepts/alpha.md",
+            "reason": "confidence_not_applicable_but_ledger_entry_exists",
+        }
+    ]
+
+    ledger = update_trust_ledger(
+        vault,
+        ledger_path,
+        reviewed_at="2026-08-05T13:00:00+09:00",
+        page_paths=["concepts/alpha.md"],
+        required_trust_keys=("updated",),
+    )
+    assert ledger["pages"] == {}
+    assert ledger["not_applicable"] == ["concepts/alpha.md"]
+    assert ledger["removed_not_applicable"] == ["concepts/alpha.md"]
+    write_trust_ledger(ledger_path, ledger, vault=vault)
+
+    after = check_trust_ledger(
+        vault,
+        ledger_path,
+        required_trust_keys=("updated",),
+    )
+    assert after["status"] == "pass"
+    assert after["counts"]["not_applicable"] == 1
+    assert after["stale"] == []
+
+
+def test_owner_trust_schema_rejects_unknown_lifecycle_typo(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    ledger_path = _write_ledger(vault)
+    page.write_text(page.read_text().replace("lifecycle: reviewed", "lifecycle: activ"))
+
+    report = check_trust_ledger(
+        vault,
+        ledger_path,
+        allowed_lifecycles={"active", "confirmed", "stub"},
+        required_trust_keys=("updated",),
+        schema_source="wiki/AGENTS.md",
+    )
+
+    assert report["status"] == "fail"
+    assert report["errors"] == [
+        {"page": "concepts/alpha.md", "issue": "invalid lifecycle: activ"}
+    ]
+
+
+def test_owner_lifecycle_propagates_through_record_update_and_check(tmp_path: Path) -> None:
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("lifecycle: reviewed", "lifecycle: active"))
+    schema = {
+        "allowed_lifecycles": {"active", "confirmed", "stub"},
+        "required_trust_keys": ("base_confidence", "lifecycle", "updated"),
+    }
+
+    ledger = build_trust_ledger(
+        vault,
+        reviewed_at="2026-08-05T12:00:00+09:00",
+        **schema,
+    )
+    ledger_path = vault / "_meta" / "trust-ledger.json"
+    write_trust_ledger(ledger_path, ledger, vault=vault)
+    assert check_trust_ledger(vault, ledger_path, schema_source="wiki/AGENTS.md", **schema)["status"] == "pass"
+
+    page.write_text(page.read_text().replace("Reviewed material claim.", "Reviewed updated claim."))
+    updated = update_trust_ledger(
+        vault,
+        ledger_path,
+        reviewed_at="2026-08-05T13:00:00+09:00",
+        page_paths=["concepts/alpha.md"],
+        **schema,
+    )
+    write_trust_ledger(ledger_path, updated, vault=vault)
+    assert check_trust_ledger(vault, ledger_path, schema_source="wiki/AGENTS.md", **schema)["status"] == "pass"
+
+
+def test_owner_lifecycle_cli_record_then_check(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("lifecycle: reviewed", "lifecycle: active"))
+    schema_args = (
+        "--allow-lifecycle",
+        "active",
+        "--schema-source",
+        "wiki/AGENTS.md",
+    )
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--all",
+        "--reviewed-at",
+        "2026-08-05T12:00:00+09:00",
+        "--approved",
+        "--json",
+        *schema_args,
+    )
+    assert record.returncode == 0, record.stderr
+    assert json.loads(record.stdout)["schema"]["source"] == "wiki/AGENTS.md"
+
+    check = _run_cli(home, "trust-check", str(vault), "--json", *schema_args)
+    assert check.returncode == 0, check.stderr
+    assert json.loads(check.stdout)["status"] == "pass"
 
 
 def test_mismatched_scalar_quotes_fail_closed(tmp_path: Path) -> None:
@@ -757,6 +937,207 @@ def test_trust_record_and_check_cli_round_trip(tmp_path: Path) -> None:
     payload = json.loads(check.stdout)
     assert payload["status"] == "pass"
     assert payload["counts"]["reviewed"] == 1
+
+
+def test_owner_schema_cli_excludes_then_removes_no_confidence_ledger_entry(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    _write_ledger(vault)
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", ""))
+    schema_args = ("--required-trust-field", "updated")
+
+    stale = _run_cli(home, "trust-check", str(vault), "--json", *schema_args)
+    assert stale.returncode == 0, stale.stderr
+    stale_payload = json.loads(stale.stdout)
+    assert stale_payload["status"] == "warn"
+    assert stale_payload["stale"] == [
+        {
+            "page": "concepts/alpha.md",
+            "reason": "confidence_not_applicable_but_ledger_entry_exists",
+        }
+    ]
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--page",
+        "concepts/alpha.md",
+        "--reviewed-at",
+        "2026-08-05T13:00:00+09:00",
+        "--approved",
+        "--json",
+        *schema_args,
+    )
+    assert record.returncode == 0, record.stderr
+    record_payload = json.loads(record.stdout)
+    assert record_payload["recorded_pages"] == 0
+    assert record_payload["not_applicable_pages"] == ["concepts/alpha.md"]
+    assert record_payload["removed_not_applicable"] == ["concepts/alpha.md"]
+
+    clean = _run_cli(home, "trust-check", str(vault), "--json", *schema_args)
+    assert clean.returncode == 0, clean.stderr
+    clean_payload = json.loads(clean.stdout)
+    assert clean_payload["status"] == "pass"
+    assert clean_payload["counts"]["not_applicable"] == 1
+    assert clean_payload["stale"] == []
+
+    rebuilt = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--all",
+        "--reviewed-at",
+        "2026-08-05T14:00:00+09:00",
+        "--approved",
+        "--json",
+        *schema_args,
+    )
+    assert rebuilt.returncode == 0, rebuilt.stderr
+    rebuilt_payload = json.loads(rebuilt.stdout)
+    assert rebuilt_payload["recorded_pages"] == 0
+    assert rebuilt_payload["not_applicable_pages"] == ["concepts/alpha.md"]
+
+
+def test_trust_record_all_human_output_lists_no_confidence_without_removal(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", ""))
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--all",
+        "--reviewed-at",
+        "2026-08-05T14:00:00+09:00",
+        "--approved",
+        "--required-trust-field",
+        "updated",
+    )
+
+    assert record.returncode == 0
+    assert "removed obsolete trust ledger entries" not in record.stderr
+    assert record.stdout == (
+        f"recorded 0 reviewed page(s) in {vault.resolve() / '_meta' / 'trust-ledger.json'}\n"
+        "not applicable (excluded from trust review): 1 page(s)\n"
+        "  - concepts/alpha.md\n"
+        "obsolete ledger entries removed: 0 page(s)\n"
+    )
+
+
+def test_trust_record_all_human_output_warns_when_rebuild_removes_stale_entry(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    _write_ledger(vault)
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", ""))
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--all",
+        "--reviewed-at",
+        "2026-08-05T14:00:00+09:00",
+        "--approved",
+        "--required-trust-field",
+        "updated",
+    )
+
+    assert record.returncode == 0
+    assert "not applicable (excluded from trust review): 1 page(s)" in record.stdout
+    assert "obsolete ledger entries removed: 1 page(s)\n  - concepts/alpha.md" in record.stdout
+    assert record.stderr.endswith(
+        "warning: removed obsolete trust ledger entries because base_confidence is not "
+        "applicable: concepts/alpha.md\n"
+    )
+    assert record.stderr.count("warning: removed obsolete trust ledger entries") == 1
+    ledger = json.loads((vault / "_meta" / "trust-ledger.json").read_text())
+    assert ledger["pages"] == {}
+    assert ledger["removed_not_applicable"] == ["concepts/alpha.md"]
+
+
+def test_trust_record_page_human_output_warns_when_stale_entry_is_removed(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    _write_ledger(vault)
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", ""))
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--page",
+        "concepts/alpha.md",
+        "--reviewed-at",
+        "2026-08-05T14:00:00+09:00",
+        "--approved",
+        "--required-trust-field",
+        "updated",
+    )
+
+    assert record.returncode == 0
+    assert "not applicable (excluded from trust review): 1 page(s)\n  - concepts/alpha.md" in record.stdout
+    assert "obsolete ledger entries removed: 1 page(s)\n  - concepts/alpha.md" in record.stdout
+    assert "warning: removed obsolete trust ledger entries" in record.stderr
+    assert "concepts/alpha.md" in record.stderr
+
+
+def test_trust_record_page_human_output_reports_zero_removals_without_warning(
+    tmp_path: Path,
+) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", ""))
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--page",
+        "concepts/alpha.md",
+        "--reviewed-at",
+        "2026-08-05T14:00:00+09:00",
+        "--approved",
+        "--required-trust-field",
+        "updated",
+    )
+
+    assert record.returncode == 0
+    assert "not applicable (excluded from trust review): 1 page(s)\n  - concepts/alpha.md" in record.stdout
+    assert "obsolete ledger entries removed: 0 page(s)" in record.stdout
+    assert "removed obsolete trust ledger entries" not in record.stderr
+
+
+def test_explicit_vault_cli_override_reports_cli_schema_source(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "explicit-vault"
+    page = _page(vault, "concepts/alpha.md")
+    page.write_text(page.read_text().replace("base_confidence: 0.80\n", ""))
+
+    record = _run_cli(
+        home,
+        "trust-record",
+        str(vault),
+        "--all",
+        "--reviewed-at",
+        "2026-08-05T14:00:00+09:00",
+        "--approved",
+        "--required-trust-field",
+        "updated",
+        "--json",
+    )
+
+    assert record.returncode == 0, record.stderr
+    assert "removed obsolete trust ledger entries" not in record.stderr
+    assert json.loads(record.stdout)["schema"]["source"] == "cli:explicit-vault"
 
 
 def test_partial_trust_record_does_not_approve_other_stale_pages(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- make vault-owner lifecycle/relationship/trust schema explicit and configurable
- preserve correction provenance and immutable conversation-source boundaries
- fail closed when configured schema sources or allowlists are blank/invalid
- expose exclusions and stale-ledger removals consistently in human and JSON output

## Verification

- targeted tests: 77 passed
- full current `origin/main` suite: 519 passed
- scoped Pyright delta: base 9, candidate 9, introduced 0
- scoped Ruff delta: base 11, candidate 9, introduced 0
- `git diff --check` and `compileall`: passed
- wheel and sdist build + Twine checks: passed

## Safety

- 11 exact reviewed files only
- no database, vault content, deletion, force-push, tag, or package-registry release
- branch is based on current upstream `main` (`3d39cb491a28cd11c96e13d31349a4a9367b865e`)
