### PR TITLE
Stabilize Windows vault setup

### DIFF
--- a/.claude/hooks/wiki-stop-capture.sh
+++ b/.claude/hooks/wiki-stop-capture.sh
@@ -22,10 +22,18 @@
 
 set -euo pipefail
 
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="python3"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="python"
+else
+  exit 0
+fi
+
 INPUT=$(cat)
 
 # Suppress if already in a stop-hook-triggered turn (prevents infinite loops)
-IS_HOOK_TURN=$(printf '%s' "$INPUT" | python3 -c "
+IS_HOOK_TURN=$(printf '%s' "$INPUT" | "$PYTHON_BIN" -c "
 import json, sys
 d = json.load(sys.stdin)
 print('1' if d.get('stop_hook_active') else '0')
@@ -52,7 +60,7 @@ print('1' if d.get('stop_hook_active') else '0')
 # sentinel; sentinels predating this feature have no count and behave as 0.
 REARM_SECONDS="${WIKI_STOP_REARM_SECONDS:-21600}"   # 6h between nudges
 REARM_EDITS="${WIKI_STOP_REARM_EDITS:-10}"          # new edits required
-SESSION_ID=$(printf '%s' "$INPUT" | python3 -c "
+SESSION_ID=$(printf '%s' "$INPUT" | "$PYTHON_BIN" -c "
 import json, sys; print(json.load(sys.stdin).get('session_id', ''))" 2>/dev/null || echo "")
 SENTINEL=""
 REARM_CANDIDATE=0
@@ -81,7 +89,7 @@ if [[ -n "$SESSION_ID" ]]; then
   fi
 fi
 
-TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | python3 -c "
+TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | "$PYTHON_BIN" -c "
 import json, sys
 d = json.load(sys.stdin)
 print(d.get('transcript_path', ''))
@@ -477,7 +485,7 @@ with open(path) as f:
 print(write_edit, bash_count, mutating_bash, suspicious_tools)
 PYEOF
 
-COUNTS=$(python3 "$CLASSIFIER" "$TRANSCRIPT_PATH" 2>/dev/null) || COUNTS="0 0 0"
+COUNTS=$("$PYTHON_BIN" "$CLASSIFIER" "$TRANSCRIPT_PATH" 2>/dev/null) || COUNTS="0 0 0"
 rm -f "$CLASSIFIER"
 
 WRITE_EDIT=$(echo "$COUNTS" | awk '{print $1}')

--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 *.yml text eol=lf
 *.yaml text eol=lf
 *.json text eol=lf
+.gitignore text eol=lf
+.gitattributes text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+* text=auto
+*.sh text eol=lf
+*.py text eol=lf
+*.md text eol=lf
+*.toml text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.json text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ __pycache__/
 /build/
 *.egg-info/
 
+# Local ad-hoc archive generated from this checkout
+/obsidian-wiki.zip
+
 # Local vault — personal knowledge, never published with the framework
 /vault/
 

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -165,6 +165,17 @@ Read the source(s) the user wants to ingest. In append mode, skip files the mani
 
 Note the source path — you'll need it for provenance tracking.
 
+### External office/document libraries
+
+When the user points at an existing SSD, Google Drive, OneDrive, NAS, or business document folder containing PDFs, Office files, HWP/HWPX, images, and markdown together, preserve the original folder structure by default.
+
+- Read `OBSIDIAN_EXTERNAL_FILE_MODE` from config. Default is `link`.
+- `link`: leave every original file in place. Create or update wiki pages and hub notes with source paths, content hashes, and Obsidian links only.
+- `stage-copy`: copy selected source files into `_raw/` for review before ingest, preserving the original. Never overwrite a file already in `_raw/`; suffix duplicates.
+- `move`: do not perform this mode unless the user explicitly approves a one-off migration plan with backup and hash verification. Treat any configured `move` value as `link` and report that moves require explicit approval.
+- For Excel/Word/HWP/HWPX files whose body text cannot be reliably extracted in the current environment, still create a source record/hub link and mark content extraction as pending rather than pretending the contents were indexed.
+- Purpose/project folders beat file-extension folders for navigation, but do not rearrange existing originals. Let the wiki supply the purpose-based graph layer.
+
 ### Unstructured & conversational sources
 
 Not every source is a clean document. When the user points you at raw data — chat exports, logs, CSVs, JSON dumps, transcripts, email/bookmark archives — **figure out the format first, then distill the substance.** When in doubt about a format, just read it: the Read tool shows you what you're dealing with.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -26,9 +26,12 @@ The deterministic `lint`, `trust-record`, and `trust-check` commands use the sam
 | `OBSIDIAN_MAX_PAGES_PER_INGEST` | Max pages created or updated per ingest | `15` |
 | `OBSIDIAN_LINK_FORMAT` | `wikilink` → `[[concepts/foo]]`, or `markdown` → `` [text](path.md) ``. Affects future writes only — existing content is never migrated | `wikilink` |
 | `OBSIDIAN_RAW_DIR` | Staging directory inside the vault for unprocessed drafts | `_raw` |
+| `OBSIDIAN_EXTERNAL_FILE_MODE` | How non-markdown source files outside the vault are handled: `link` keeps originals in place and records links/hashes; `stage-copy` copies into `_raw/` for review; `move` is intentionally unsupported by default | `link` |
 | `LINT_SCHEDULE` | Health-check frequency: `daily` \| `weekly` \| `manual` | `weekly` |
 
 Local git repo clones work in `OBSIDIAN_SOURCES_DIR` (public or private, any host). Clone locally, then add the path. Repo directories are auto-detected via a `.git` folder and enumerated with `git ls-files`, so whatever the repo's own `.gitignore` excludes — `node_modules`, build output, venvs, secrets — is skipped automatically rather than relying on a hardcoded skip-list.
+
+For existing SSD, Google Drive, OneDrive, or NAS document libraries, prefer `OBSIDIAN_EXTERNAL_FILE_MODE=link`. The wiki should index, cite, and connect files by path and content hash without rearranging the user's original folders. Use `stage-copy` only when the user explicitly wants a review copy inside the vault. Do not move originals as part of ingest.
 
 ## History ingest
 

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -21,7 +21,13 @@ from typing import TypedDict
 
 from obsidian_wiki import __version__
 
-HOME = Path.home()
+
+def _home_dir() -> Path:
+    """Return the configured home directory, honoring test/portable HOME."""
+    return Path(os.environ.get("HOME") or os.environ.get("USERPROFILE") or Path.home())
+
+
+HOME = _home_dir()
 GLOBAL_CONFIG_DIR = HOME / ".obsidian-wiki"
 GLOBAL_CONFIG = GLOBAL_CONFIG_DIR / "config"
 
@@ -293,10 +299,14 @@ def write_config(vault_path: str) -> None:
     # OBSIDIAN_WIKI_REPO points at the bundled data root so skills that reference
     # framework assets (templates, references) can find them post-install.
     repo_root = skills_dir().parent
+    values = _read_config()
+    values.update({
+        "OBSIDIAN_VAULT_PATH": vault_path,
+        "OBSIDIAN_WIKI_REPO": str(repo_root),
+        "OBSIDIAN_WIKI_VERSION": __version__,
+    })
     GLOBAL_CONFIG.write_text(
-        f'OBSIDIAN_VAULT_PATH="{vault_path}"\n'
-        f'OBSIDIAN_WIKI_REPO="{repo_root}"\n'
-        f'OBSIDIAN_WIKI_VERSION="{__version__}"\n'
+        "".join(f'{key}="{value}"\n' for key, value in values.items())
     )
     print(f"✅  Global config written to {GLOBAL_CONFIG}")
 

--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -130,8 +130,10 @@ def _relative_key_index(sources: dict) -> dict[str, list[tuple[str, dict]]]:
 
 def _match_relative(path: str, index: dict[str, list[tuple[str, dict]]]) -> dict | None:
     """Return the manifest entry whose relative key is a suffix of `path`."""
+    norm_path = path.replace("\\", "/")
     for relkey, entry in index.get(os.path.basename(path), ()):
-        if path == relkey or path.endswith(os.sep + relkey):
+        norm_relkey = relkey.replace("\\", "/")
+        if norm_path == norm_relkey or norm_path.endswith("/" + norm_relkey):
             return entry
     return None
 

--- a/tests/test_config_preservation.py
+++ b/tests/test_config_preservation.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import obsidian_wiki.cli as cli
+
+
+def test_write_config_preserves_existing_custom_values(tmp_path, monkeypatch) -> None:
+    config_dir = tmp_path / ".obsidian-wiki"
+    config = config_dir / "config"
+    config_dir.mkdir()
+    config.write_text(
+        'OBSIDIAN_EXTERNAL_FILE_MODE="link"\n'
+        'OBSIDIAN_ALLOWED_LIFECYCLES="active,reviewed"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(cli, "GLOBAL_CONFIG_DIR", config_dir)
+    monkeypatch.setattr(cli, "GLOBAL_CONFIG", config)
+
+    cli.write_config(str(tmp_path / "vault"))
+
+    written = config.read_text(encoding="utf-8")
+    assert 'OBSIDIAN_VAULT_PATH="' in written
+    assert 'OBSIDIAN_WIKI_REPO="' in written
+    assert 'OBSIDIAN_WIKI_VERSION="' in written
+    assert 'OBSIDIAN_EXTERNAL_FILE_MODE="link"' in written
+    assert 'OBSIDIAN_ALLOWED_LIFECYCLES="active,reviewed"' in written

--- a/tests/test_stop_hook_behavior.py
+++ b/tests/test_stop_hook_behavior.py
@@ -13,6 +13,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 import unittest
@@ -20,6 +21,41 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 HOOK = ROOT / ".claude" / "hooks" / "wiki-stop-capture.sh"
+
+
+def _find_bash() -> str | None:
+    if os.name == "nt":
+        for candidate in (
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+        ):
+            if Path(candidate).is_file():
+                return candidate
+    return shutil.which("bash")
+
+
+BASH = _find_bash()
+
+
+def _bash_path(path: Path) -> str:
+    if os.name != "nt" or BASH is None:
+        return str(path)
+    resolved = path.resolve()
+    drive = resolved.drive.rstrip(":").lower()
+    rest = resolved.parts[1:]
+    return "/" + "/".join((drive, *rest))
+
+
+def _hook_env(tmp: Path, extra_env: dict[str, str] | None = None) -> dict[str, str]:
+    path_parts = ["/usr/bin", "/bin", "/usr/local/bin"]
+    if os.name == "nt":
+        path_parts.insert(0, _bash_path(Path(sys.executable).parent))
+    return {
+        "PATH": ":".join(path_parts),
+        "TMPDIR": _bash_path(tmp),
+        **(extra_env or {}),
+    }
 
 
 def _bash_entry(command):
@@ -57,7 +93,7 @@ _READONLY_BASH = [
 ]
 
 
-@unittest.skipIf(shutil.which("bash") is None, "requires bash")
+@unittest.skipIf(BASH is None, "requires bash")
 class StopHookBehaviorTest(unittest.TestCase):
     def setUp(self):
         self.tmp = Path(tempfile.mkdtemp())
@@ -79,16 +115,16 @@ class StopHookBehaviorTest(unittest.TestCase):
             session_id = f"s{self._session_seq}"
         payload = {
             "session_id": session_id,
-            "transcript_path": str(transcript),
+            "transcript_path": _bash_path(transcript),
             "stop_hook_active": stop_hook_active,
         }
         # Isolated TMPDIR so sentinel state never leaks between tests.
         return subprocess.run(
-            ["bash", str(HOOK)],
+            [BASH, _bash_path(HOOK)],
             input=json.dumps(payload),
             capture_output=True,
             text=True,
-            env={"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(self.tmp), **(extra_env or {})},
+            env=_hook_env(self.tmp, extra_env),
         )
 
     def test_file_edit_triggers_nudge(self):
@@ -545,9 +581,9 @@ class StopHookBehaviorTest(unittest.TestCase):
             self._age_sentinel(sid, 7 * 3600)
             payload_file = self.tmp / f"payload{round_no}.json"
             payload_file.write_text(
-                json.dumps({"session_id": sid, "transcript_path": str(transcript)})
+                json.dumps({"session_id": sid, "transcript_path": _bash_path(transcript)})
             )
-            env = {"PATH": "/usr/bin:/bin:/usr/local/bin", "TMPDIR": str(self.tmp)}
+            env = _hook_env(self.tmp)
             # bash -x: the xtrace on stderr is evidence of WHICH path each
             # process took, asserted on below — outcome checks alone cannot
             # distinguish a genuine race from accidental serialization.
@@ -556,7 +592,7 @@ class StopHookBehaviorTest(unittest.TestCase):
                 with payload_file.open() as stdin_file:
                     procs.append(
                         subprocess.Popen(
-                            ["bash", "-x", str(HOOK)],
+                            [BASH, "-x", _bash_path(HOOK)],
                             stdin=stdin_file,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,


### PR DESCRIPTION
## Summary
- Preserve existing obsidian-wiki config values across setup reruns while still updating the managed vault/repo/version keys.
- Honor HOME/USERPROFILE in portable and test contexts on Windows.
- Stabilize the Claude stop hook when `python3` is unavailable and make stop-hook behavior tests use Git Bash-compatible paths on Windows.
- Normalize manifest relative-key matching across Windows and POSIX separators.
- Document the default external document-library mode: link/index originals by path and hash instead of moving source files.
- Add LF line-ending policy for shell, Python, Markdown, config, and JSON files.

## Why
Windows users can have WSL Bash, Git Bash, and Python launchers on the same machine. The previous setup/test assumptions could miss the intended config, silently skip stop-hook capture, or misclassify relative manifest keys. Existing business document folders also need a non-destructive default ingest policy.

## Validation
- `python -m pytest -q` -> 520 passed, 19 subtests passed
- `python -m obsidian_wiki.cli doctor --json` -> pass
- `git diff --check` -> clean
- `git ls-files --eol` verified LF for touched shell/Python/Markdown files

## Notes
This PR leaves source document libraries in place by default. `stage-copy` is documented as an explicit review-copy mode, while moves require separate user approval and backup/hash verification.