### PR TITLE
feat: improve project ingest with optional code-graph-assisted understanding (#167)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,6 +189,17 @@ PAGEINDEX_MIN_PAGES=30
 # Optional cache dir for *_structure.json (default: <PAGEINDEX_REPO>/results).
 PAGEINDEX_WORKSPACE=
 
+# --- Code understanding (optional) ---
+#
+# How wiki-update understands project structure before distilling knowledge.
+#   auto:    use CodeGraph when available, else the built-in ast-extract + rg (default)
+#   builtin: always use ast-extract + rg (dependency-free)
+#   codegraph: explicitly require CodeGraph; warn/error if unavailable
+CODE_UNDERSTANDING_BACKEND=auto
+# Optional path to the codegraph binary if it isn't on PATH
+# (e.g. CODE_UNDERSTANDING_CODEGRAPH_BIN=/path/to/codegraph)
+CODE_UNDERSTANDING_CODEGRAPH_BIN=
+
 # --- Raw Staging Directory (optional) ---
 #
 # A directory inside OBSIDIAN_VAULT_PATH for unprocessed draft pages.

--- a/.skills/code-understand/SKILL.md
+++ b/.skills/code-understand/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: code-understand
+description: >
+  Build a ranked, citation-backed focus map of a codebase — the files and symbols an
+  architecture actually hangs on — using CodeGraph when available and a dependency-free
+  builtin (regex AST extraction + `rg` cross-file references) otherwise. Use this any time
+  you (the coding agent) need to orient in an unfamiliar or large codebase before making a
+  change: the user says "help me understand this codebase", "what's load-bearing here",
+  "what would break if I change X", "who calls this", "map out this project's architecture",
+  or you're about to touch code you haven't read yet and want to know what matters before
+  scanning everything by hand. This is the same extractor `wiki-update` Step 3b uses
+  internally — this skill exposes it directly so any agent session can call it on demand,
+  not just during a wiki sync.
+---
+
+# Code Understand — On-Demand Architecture Focus Map
+
+You are about to work in a codebase you don't fully know yet. Instead of grepping around or
+reading files at random, ask the local extractor for a **focus map**: the ranked symbols the
+architecture hangs on, each with a `file:line` citation and evidence type. Read only what it
+points at — this is a map, not a substitute for reading the actual code it cites.
+
+## When to reach for this
+
+- Before editing an unfamiliar module — see what calls it and what it calls before changing
+  its shape.
+- The user asks "how does X work", "what's the impact of changing Y", "who else uses this
+  function" for a codebase, not the wiki.
+- You're about to do a large refactor and want a ranked list of load-bearing files instead of
+  reading the whole tree.
+- You already have a diff or a set of changed files and want to know their blast radius before
+  finishing the change.
+
+Not for: summarizing what a project *does* for the wiki (that's `wiki-update` Step 3b, which
+calls this same command as part of a bigger sync flow) — use this skill directly only when you
+need the focus map for your own immediate work, not to persist knowledge.
+
+## Running it
+
+```bash
+obsidian-wiki code-understand --project <dir> [--backend auto|builtin|codegraph] \
+    [--changed <file>...] [--since <sha>] [--max-symbols N] [--pretty]
+```
+
+- `--project` — defaults to the current directory.
+- No `--changed`/`--since` — seeds from every tracked file (full-project scan).
+- `--changed <file>` (repeatable) — seed from specific files you already know are relevant
+  (e.g. files in the diff you're about to make).
+- `--since <sha>` — seed from everything changed since a git ref (e.g. `--since HEAD~5` or a
+  base branch).
+- `--backend` — `auto` (default) uses CodeGraph when installed, falls back to the builtin
+  extractor otherwise; force `builtin` for the dependency-free path, or `codegraph` to require
+  the enhanced backend (fails loudly if it's not installed rather than silently degrading).
+- `--max-symbols` — cap the focus map size (default 50); keep this small for a quick
+  orientation pass, raise it for a thorough one.
+
+**GUARD:** if the command is unavailable or errors, skip it and fall back to your normal
+exploration (grep/read) — this is an accelerant, not a dependency. Don't block work on it.
+
+## Reading the output
+
+1. **Evidence type matters.** When `backend: codegraph`, focus-map entries are structural
+   facts (real call-graph edges) — cite them directly. When `backend: builtin`, `defines`/
+   `imports`/`changed-file` entries are facts, but `rg-reference` entries are text-match
+   evidence only — open the file and confirm before treating it as a real relationship.
+2. **Open what it cites, nothing else first.** The focus map tells you *where* to read; it
+   never contains source bodies. Go read those `file:line` locations before forming an opinion
+   on the architecture.
+3. **Cite it in your own output.** If you explain the architecture back to the user or write
+   it into a PR description/commit message, keep the `(file:lines)` citations from the focus
+   map or from the source you opened — don't assert structure without a pointer to it.
+4. **It's a cache, not a deliverable.** Never write the raw JSON or `.codegraph/` into the
+   wiki vault, a PR description, or committed docs — it's a disposable sidecar in the project
+   repo (git-ignored). Re-run it fresh next time rather than treating old output as durable.
+
+## If CodeGraph isn't installed
+
+`auto`/`builtin` still work with zero setup (uses the regex AST extractor + `rg`). If you want
+the enhanced cross-file call-graph evidence and the user is fine with installing something:
+
+```bash
+npm install -g @colbymchenry/codegraph
+```
+
+or point `CODE_UNDERSTANDING_CODEGRAPH_BIN` at an existing binary. Never install without the
+user's go-ahead — ask first, then re-run the command.
+
+Check `obsidian-wiki doctor --project <dir>` for the `code-understanding.*` capability lines
+(`builtin`, `rg`, `codegraph`, `codegraph-index`, `codegraph-fresh`) to see what's available
+before deciding which backend to request explicitly.

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -590,6 +590,8 @@ The wiki is configured through environment variables (see `.env.example`). The o
 - `OBSIDIAN_LINK_FORMAT` — Internal link syntax: `wikilink` (default) or `markdown`
 - `WIKI_TOKEN_WARN_THRESHOLD` — Emit a warning in `wiki-status` when the full-wiki token estimate exceeds this value (default: `100000`). Set to `0` to disable. See `wiki-status` for the token footprint report.
 - `WIKI_STAGED_WRITES` — When `true`, all LLM-written pages go to `_staging/<category>/` for human review before promotion. See `wiki-setup` and `wiki-stage-commit` for details.
+- `CODE_UNDERSTANDING_BACKEND` — how wiki-update understands a project before distilling: `auto` (CodeGraph when available, else builtin ast-extract + rg; default), `builtin`, or `codegraph` (explicitly require; warn/error if unavailable).
+- `CODE_UNDERSTANDING_CODEGRAPH_BIN` — optional path to the codegraph binary when it isn't on PATH.
 
 No API keys are needed — the agent running these skills already has LLM access built in.
 

--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -69,6 +69,33 @@ Not worth distilling:
 
 The heuristic: **if reading the codebase answers the question, don't wiki it. If you'd have to re-derive the reasoning by reading git blame across 20 commits, wiki it.**
 
+### Step 3b: Build a code-understanding focus map (optional)
+
+**GUARD: If the `obsidian-wiki code-understand` command fails or is unavailable, skip this step and continue — it is an optimisation, not a requirement.**
+
+When this project contains code, run the local code-understanding extractor before distilling. It parses the codebase locally and returns a focus map — the ranked files and symbols the architecture hangs on — so you read the load-bearing parts instead of scanning everything.
+
+```bash
+obsidian-wiki code-understand --project "$(pwd)" --pretty
+```
+
+When this is not the first sync (Step 2 computed `last_commit_synced`), seed the focus map from the delta:
+
+```bash
+obsidian-wiki code-understand --project "$(pwd)" --since <last_commit_synced> --pretty
+```
+
+(First sync: omit `--since`.)
+
+#### What to do with the focus-map output
+
+1. **Read the output selectively** — when `backend: codegraph`, treat focus-map entries as structural facts with `file:line` citations; when `backend: builtin`, treat `defines`/`imports` entries as facts but treat `rg-reference` entries as weaker evidence — open the file and verify before citing. Open only the ranked `files`/`file:lines` the focus map points at; never paste the JSON into the wiki or the vault.
+2. **Cite the evidence** — every architectural claim written to a page references its evidence as `(file:lines)` from the focus map or from the opened source; keep using the existing provenance markers.
+3. **Prune stale relationships (required)** — when updating an existing `projects/<name>/` page, cross-check each previously recorded code relationship against the current focus map (or `obsidian-wiki ast-extract` for a symbol-level recheck). Remove relationships whose target symbol no longer exists or is no longer reachable; update the page and record the removals in `log.md`. This keeps false positives from accumulating.
+4. **Never** write `.codegraph/` or the `code-understand` JSON into `$OBSIDIAN_VAULT_PATH` — the graph is a cache/sidecar in the project repo, not wiki knowledge.
+
+If `obsidian-wiki` is not installed or the command fails, skip this step and proceed to Step 4 as normal — it is an optimisation, not a requirement.
+
 ## Step 4: Distill into Wiki Pages
 
 ### Project-specific knowledge

--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -93,6 +93,7 @@ obsidian-wiki code-understand --project "$(pwd)" --since <last_commit_synced> --
 2. **Cite the evidence** — every architectural claim written to a page references its evidence as `(file:lines)` from the focus map or from the opened source; keep using the existing provenance markers.
 3. **Prune stale relationships (required)** — when updating an existing `projects/<name>/` page, cross-check each previously recorded code relationship against the current focus map (or `obsidian-wiki ast-extract` for a symbol-level recheck). Remove relationships whose target symbol no longer exists or is no longer reachable; update the page and record the removals in `log.md`. This keeps false positives from accumulating.
 4. **Never** write `.codegraph/` or the `code-understand` JSON into `$OBSIDIAN_VAULT_PATH` — the graph is a cache/sidecar in the project repo, not wiki knowledge.
+5. **Offer CodeGraph when it's missing (optional)** — if the output reports `backend: builtin` because codegraph is unavailable and the user wants the enhanced backend, offer to install it for them: `npm install -g @colbymchenry/codegraph` (or set `CODE_UNDERSTANDING_CODEGRAPH_BIN` to an existing binary), then re-run this step so the focus map uses the graph. Never install without the user's go-ahead, and never let a missing codegraph block the sync.
 
 If `obsidian-wiki` is not installed or the command fails, skip this step and proceed to Step 4 as normal — it is an optimisation, not a requirement.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Other paths — `git clone`, Skills CLI, multiple vaults → **[Installation](ht
 
 ```text
 /wiki-ingest ~/research
-/wiki-update                        # distill the repo you're standing in
+/wiki-update                        # distill the repo you're standing in (code-graph aware)
 /wiki-capture                       # save this conversation
 /wiki-history-ingest claude         # mine everything you've ever asked Claude
 ```

--- a/README_TW.md
+++ b/README_TW.md
@@ -55,7 +55,7 @@ https://github.com/Ar9av/obsidian-wiki — set up my wiki
 
 ```text
 /wiki-ingest ~/research
-/wiki-update                        # 蒸餾你目前所在的這個 repo（可感知程式碼結構）
+/wiki-update                        # 蒸餾你目前所在的這個 repo（支持使用 codegraph 增強程式碼結構解析）
 /wiki-capture                       # 把這段對話存下來
 /wiki-history-ingest claude         # 挖出你問過 Claude 的所有東西
 ```

--- a/README_TW.md
+++ b/README_TW.md
@@ -55,7 +55,7 @@ https://github.com/Ar9av/obsidian-wiki — set up my wiki
 
 ```text
 /wiki-ingest ~/research
-/wiki-update                        # 蒸餾你目前所在的這個 repo
+/wiki-update                        # 蒸餾你目前所在的這個 repo（可感知程式碼結構）
 /wiki-capture                       # 把這段對話存下來
 /wiki-history-ingest claude         # 挖出你問過 Claude 的所有東西
 ```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ Running `obsidian-wiki` with no subcommand defaults to `setup`.
 | `setup` | Install skills into your agents and write `~/.obsidian-wiki/config` |
 | `info` | Show install paths, version, and resolved config |
 | `list` | List the bundled skills |
-| `doctor` | Health-check config, vault shape, bootstrap assets, and installed skills |
+| `doctor` | Health-check config, vault shape, bootstrap assets, and installed skills; with `--project`, also reports the code-understanding capability section |
 
 ```bash
 obsidian-wiki setup --vault ~/brain
@@ -159,6 +159,7 @@ Available for automation, scripting, and debugging. Skills call some of these in
 | `cache-update <vault> <source>` | Record a source's SHA-256 in `.manifest.json` after ingest |
 | `cache-hash <path>` | Compute a file or directory hash (no manifest I/O) |
 | `ast-extract <path>` | Extract classes, functions, and imports from code — no LLM, no API calls |
+| `code-understand --project <dir> [--backend auto\|builtin\|codegraph] [--since <sha>] [--changed <file>...] [--max-symbols N] [--pretty]` | Emit a ranked code-understanding focus map (symbols + file:line citations) for a project; CodeGraph when available, built-in AST + rg otherwise. Used by wiki-update Step 3b. |
 
 ```bash
 obsidian-wiki graph-query /path/to/vault "transformer architecture" --pretty
@@ -167,6 +168,7 @@ obsidian-wiki batch-plan /path/to/vault ~/research --max-mb 4 --max-files 30
 obsidian-wiki cache-check /path/to/vault ~/research/*.pdf
 obsidian-wiki cache-update /path/to/vault ~/research/paper.pdf --pages concepts/attention.md
 obsidian-wiki ast-extract ./src --pretty
+obsidian-wiki code-understand --project . --since <last_commit_synced> --pretty
 ```
 
 Most commands accept `--json` and/or `--pretty` for machine-readable output.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -131,6 +131,17 @@ QMD_CLI_SEARCH_MODE=quality
 
 Both degrade gracefully: with the collection names unset, they skip the QMD step silently and use Grep.
 
+## Code understanding (optional)
+
+`wiki-update` distills a project's structure before it writes knowledge into the vault. When a supported code graph backend is available, `wiki-update` uses it to rank the project's most important modules, trace callers and callees, and expand changed files into their impact area before distilling. Without one, the built-in `ast-extract` + `rg` fallback is used — no extra dependency.
+
+Missing CodeGraph never breaks normal `wiki-update` or `doctor` runs. The graph index lives in the project's `.codegraph/` sidecar and is never written into the vault.
+
+| Variable | What it does | Default |
+|---|---|---|
+| `CODE_UNDERSTANDING_BACKEND` | How `wiki-update` understands project structure: `auto` (CodeGraph when available, else the built-in `ast-extract` + `rg`), `builtin` (always the built-in, dependency-free), or `codegraph` (explicitly require CodeGraph; warn/error if unavailable) | `auto` |
+| `CODE_UNDERSTANDING_CODEGRAPH_BIN` | Path to the `codegraph` binary if it isn't on `PATH` | *(empty)* |
+
 ## `_raw/` staging directory
 
 `_raw/` is a staging area inside your vault for unprocessed captures — rough notes, clipboard pastes, quick voice-memo transcripts. Drop files there and the next `wiki-ingest` run promotes them to proper wiki pages and removes the originals, so nothing is processed twice.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,6 +142,19 @@ Missing CodeGraph never breaks normal `wiki-update` or `doctor` runs. The graph 
 | `CODE_UNDERSTANDING_BACKEND` | How `wiki-update` understands project structure: `auto` (CodeGraph when available, else the built-in `ast-extract` + `rg`), `builtin` (always the built-in, dependency-free), or `codegraph` (explicitly require CodeGraph; warn/error if unavailable) | `auto` |
 | `CODE_UNDERSTANDING_CODEGRAPH_BIN` | Path to the `codegraph` binary if it isn't on `PATH` | *(empty)* |
 
+### Setup (optional)
+
+Install the CodeGraph CLI once to enable the enhanced backend:
+
+```bash
+npm install -g @colbymchenry/codegraph
+```
+
+Verify with `obsidian-wiki doctor --project .` — the `code-understanding.codegraph` check should flip to pass. If the binary isn't on your `PATH`, set `CODE_UNDERSTANDING_CODEGRAPH_BIN` to its location instead.
+
+- The first enhanced `wiki-update` run auto-initializes the project's `.codegraph/` index; later runs sync only what changed.
+- Your agent can run the install for you — just ask it to use CodeGraph when running `/wiki-update`.
+
 ## `_raw/` staging directory
 
 `_raw/` is a staging area inside your vault for unprocessed captures — rough notes, clipboard pastes, quick voice-memo transcripts. Drop files there and the next `wiki-ingest` run promotes them to proper wiki pages and removes the originals, so nothing is processed twice.

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -488,6 +488,106 @@ def _doctor_project_check(project_dir: Path) -> dict[str, str]:
     return {"status": "pass", "detail": "bootstrap files and aliases present", "hint": ""}
 
 
+def _doctor_code_understanding_checks(
+    project_dir: Path, backend_setting: str, bin_path: str | None
+) -> list[dict[str, str]]:
+    """Code-understanding readiness checks for a project (issue #167)."""
+    checks: list[dict[str, str]] = []
+
+    from obsidian_wiki.ast_extractor import extract
+
+    try:
+        data = extract(project_dir)
+        if data.get("nodes"):
+            checks.append({
+                "name": "code-understanding.builtin",
+                "status": "pass",
+                "detail": f"found {len(data['nodes'])} AST node(s)",
+                "hint": "",
+            })
+        else:
+            checks.append({
+                "name": "code-understanding.builtin",
+                "status": "warn",
+                "detail": "no code files found",
+                "hint": "code-understand will produce an empty focus map",
+            })
+    except (OSError, ValueError) as exc:
+        checks.append({
+            "name": "code-understanding.builtin",
+            "status": "warn",
+            "detail": f"AST extraction failed: {exc}",
+            "hint": "code-understand may not find any symbols",
+        })
+
+    rg_path = shutil.which("rg")
+    checks.append({
+        "name": "code-understanding.rg",
+        "status": "pass" if rg_path else "warn",
+        "detail": rg_path or "ripgrep (rg) not found on PATH",
+        "hint": "" if rg_path else "install ripgrep for cross-file reference evidence",
+    })
+
+    from obsidian_wiki.code_understanding import index_state
+
+    codegraph_path = bin_path or shutil.which("codegraph")
+    if codegraph_path:
+        checks.append({
+            "name": "code-understanding.codegraph",
+            "status": "pass",
+            "detail": str(codegraph_path),
+            "hint": "",
+        })
+    elif backend_setting == "codegraph":
+        checks.append({
+            "name": "code-understanding.codegraph",
+            "status": "fail",
+            "detail": "codegraph backend requested but binary not found",
+            "hint": "set CODE_UNDERSTANDING_CODEGRAPH_BIN or install codegraph",
+        })
+    else:
+        checks.append({
+            "name": "code-understanding.codegraph",
+            "status": "warn",
+            "detail": "codegraph binary not found (builtin backend will be used)",
+            "hint": "set CODE_UNDERSTANDING_CODEGRAPH_BIN or install codegraph",
+        })
+
+    if codegraph_path:
+        initialized, fresh, detail = index_state(project_dir)
+        checks.append({
+            "name": "code-understanding.codegraph-index",
+            "status": "pass" if initialized else "warn",
+            "detail": detail,
+            "hint": "" if initialized else "run: codegraph index <project>",
+        })
+        if initialized:
+            if not (project_dir / ".git").exists():
+                # index_state's freshness heuristic needs git-tracked files;
+                # without git it cannot see a stale index — compare mtimes directly.
+                db = project_dir / ".codegraph" / "codegraph.db"
+                codegraph_prefix = str((project_dir / ".codegraph").resolve())
+                try:
+                    newest = max(
+                        p.stat().st_mtime
+                        for p in project_dir.rglob("*")
+                        if p.is_file()
+                        and not str(p.resolve()).startswith(codegraph_prefix)
+                    )
+                except OSError:
+                    newest = 0.0
+                if db.stat().st_mtime < newest:
+                    fresh = False
+                    detail = "stale (codegraph.db older than sources)"
+            checks.append({
+                "name": "code-understanding.codegraph-fresh",
+                "status": "pass" if fresh else "warn",
+                "detail": detail,
+                "hint": "" if fresh else "re-run: codegraph index <project>",
+            })
+    return checks
+
+
 def run_doctor(*, vault_override: str | None = None, project_dir: str | None = None) -> dict[str, object]:
     checks: list[dict[str, str]] = []
 
@@ -663,6 +763,20 @@ def run_doctor(*, vault_override: str | None = None, project_dir: str | None = N
                 detail=project_check["detail"],
                 hint=project_check["hint"],
             )
+            backend_setting = (
+                os.environ.get("CODE_UNDERSTANDING_BACKEND")
+                or config.get("CODE_UNDERSTANDING_BACKEND")
+                or "auto"
+            )
+            bin_path = os.environ.get("CODE_UNDERSTANDING_CODEGRAPH_BIN")
+            for check in _doctor_code_understanding_checks(project, backend_setting, bin_path):
+                _doctor_add(
+                    checks,
+                    name=check["name"],
+                    status=check["status"],
+                    detail=check["detail"],
+                    hint=check.get("hint", ""),
+                )
         else:
             _doctor_add(
                 checks,
@@ -1050,6 +1164,46 @@ def cmd_ast_extract(args: argparse.Namespace) -> int:
         print(json.dumps(result, indent=2))
     else:
         print(json.dumps(result))
+    return 0
+
+
+def cmd_code_understand(args: argparse.Namespace) -> int:
+    from obsidian_wiki.code_understanding import ProviderError, code_understand
+
+    project = Path(args.project or os.getcwd())
+    try:
+        result = code_understand(
+            project,
+            # "auto" must pass through as None so CODE_UNDERSTANDING_BACKEND can win (flag > env > auto).
+            backend_flag=None if args.backend == "auto" else args.backend,
+            changed=args.changed,
+            since=args.since,
+            max_symbols=args.max_symbols,
+        )
+    except ProviderError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if args.pretty:
+        print(f"backend: {result['backend']}")
+        print(f"project: {result['project']}")
+        print(f"focus map: {len(result['focus_map'])} symbol(s)")
+        for item in result["focus_map"]:
+            lines = item.get("lines") or []
+            span = str(lines[0]) if lines else ""
+            if len(lines) > 1:
+                span += f"-{lines[-1]}"
+            print(
+                f"  {item.get('rank', '?')}. {item['symbol']} "
+                f"({item['kind']}) {item['file']}:{span} [{item.get('evidence', '')}]"
+            )
+        if result["warnings"]:
+            print("warnings:")
+            for warning in result["warnings"]:
+                print(f"  - {warning}")
+        else:
+            print("warnings: none")
+    else:
+        print(json.dumps(result, indent=2))
     return 0
 
 
@@ -1751,9 +1905,42 @@ def build_parser() -> argparse.ArgumentParser:
     ap.add_argument("--pretty", action="store_true", help="pretty-print JSON output")
     ap.set_defaults(func=cmd_ast_extract)
 
+    cdu = sub.add_parser(
+        "code-understand",
+        help="build a ranked code-understanding focus map for a project — CodeGraph when available, builtin AST + rg otherwise",
+    )
+    cdu.add_argument("--project", default=None, help="project directory (defaults to the current directory)")
+    cdu.add_argument(
+        "--backend",
+        choices=["auto", "builtin", "codegraph"],
+        default="auto",
+        help="code-understanding backend (default: auto)",
+    )
+    cdu.add_argument(
+        "--changed",
+        action="append",
+        default=None,
+        metavar="FILE",
+        help="treat FILE as a seed file (repeatable; overrides --since)",
+    )
+    cdu.add_argument(
+        "--since",
+        default=None,
+        metavar="SHA",
+        help="seed files changed since this git ref",
+    )
+    cdu.add_argument(
+        "--max-symbols",
+        type=int,
+        default=50,
+        help="maximum focus-map entries (default: 50)",
+    )
+    cdu.add_argument("--pretty", action="store_true", help="print a human-readable summary instead of JSON")
+    cdu.set_defaults(func=cmd_code_understand)
+
     dr = sub.add_parser(
         "doctor",
-        help="check config, vault shape, bootstrap assets, and installed skills",
+        help="check config, vault shape, bootstrap assets, installed skills, and code-understanding readiness",
     )
     dr.add_argument("--vault", help="override OBSIDIAN_VAULT_PATH for this health check")
     dr.add_argument("--project", help="also check project-local bootstrap files in this directory")

--- a/obsidian_wiki/code_understanding.py
+++ b/obsidian_wiki/code_understanding.py
@@ -1,0 +1,270 @@
+"""Optional code-graph-assisted ingest support (issue #167).
+
+``code_understand()`` produces a *focus map*: the symbols defined in a
+project's seed files (changed files, files changed since a git ref, or all
+tracked files) plus the cross-file references around them, ranked by
+importance. Two backends:
+
+- ``builtin`` — regex AST extraction (obsidian_wiki.ast_extractor) plus
+  ripgrep for cross-file references; zero dependencies. Implemented in
+  obsidian_wiki.code_understanding_builtin.
+- ``codegraph`` — the optional codegraph CLI (https://github.com/ar9av/codegraph)
+  when installed and explicitly requested (or auto-selected when available).
+  Implemented in obsidian_wiki.code_understanding_codegraph.
+
+Backend precedence: explicit flag > CODE_UNDERSTANDING_BACKEND env > 'auto'.
+Only an explicitly selected codegraph backend is validated eagerly
+(resolve_backend); the auto -> builtin fallback happens inside
+code_understand() so the warning can be reported in the output dict.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+_SUBPROCESS_TIMEOUT = 60
+
+
+class ProviderError(Exception):
+    """Raised when a requested backend cannot be used."""
+
+
+# ---------------------------------------------------------------------------
+# Mode selection (pure; 'auto' is resolved by code_understand)
+# ---------------------------------------------------------------------------
+
+
+def resolve_backend(
+    *,
+    flag: str | None = None,
+    env_backend: str | None = None,
+    env_bin: str | None = None,
+) -> tuple[str, list[str]]:
+    """Select the backend mode. Returns (mode, warnings).
+
+    Precedence: flag > env_backend > 'auto'. An explicit 'codegraph'
+    selection validates that the binary is resolvable (env_bin, else
+    shutil.which) and raises ProviderError otherwise; every other mode is
+    returned unresolved with no warnings.
+    """
+    mode = flag or env_backend or "auto"
+    if mode == "codegraph":
+        if not (env_bin or shutil.which("codegraph")):
+            raise ProviderError(
+                "codegraph backend requested but the codegraph binary was not found"
+            )
+    return mode, []
+
+
+# ---------------------------------------------------------------------------
+# Index freshness heuristic
+# ---------------------------------------------------------------------------
+
+
+def index_state(project: Path) -> tuple[bool, bool, str]:
+    """Return (initialized, fresh, detail) for project/.codegraph.
+
+    initialized: codegraph.db exists AND source.json parses with a sourceDir
+    resolving to *project*. fresh: codegraph.db mtime >= the newest
+    git-tracked source file (no git or no files counts as fresh).
+    """
+    db = project / ".codegraph" / "codegraph.db"
+    src = project / ".codegraph" / "source.json"
+    if not (db.exists() and src.exists()):
+        return False, False, "no index (missing .codegraph/codegraph.db or source.json)"
+    try:
+        data = json.loads(src.read_text(encoding="utf-8"))
+        source_dir = Path(str(data.get("sourceDir", ""))).resolve()
+    except (OSError, ValueError, TypeError):
+        return False, False, "source.json is invalid"
+    if source_dir != project.resolve():
+        return False, False, f"sourceDir {source_dir} does not match project"
+    fresh = True
+    try:
+        tracked = _tracked_files_only(project)
+        # Exclude the index's own artifacts — freshness vs committed code only.
+        codegraph_prefix = str((project / ".codegraph").resolve())
+        mtimes = [
+            p.stat().st_mtime
+            for p in (tracked or [])
+            if p.exists() and not str(p.resolve()).startswith(codegraph_prefix)
+        ]
+        if mtimes:
+            fresh = db.stat().st_mtime >= max(mtimes)
+    except OSError:
+        fresh = True
+    return True, fresh, "fresh" if fresh else "stale (codegraph.db older than sources)"
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _tracked_files_only(project: Path) -> list[Path] | None:
+    """Committed files only — unlike batch._git_tracked_files (--cached
+    --others), excludes untracked junk so seeds/freshness stay clean."""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(project), "ls-files", "--cached", "--exclude-standard"],
+            capture_output=True,
+            text=True,
+            timeout=_SUBPROCESS_TIMEOUT,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    return [project / line for line in proc.stdout.splitlines() if line]
+
+
+def _rel(project: Path, path: Path | str) -> str:
+    """Normalize *path* to project-relative posix separators."""
+    p = Path(path)
+    try:
+        return p.relative_to(project).as_posix()
+    except ValueError:
+        pass
+    try:
+        return p.resolve().relative_to(project.resolve()).as_posix()
+    except ValueError:
+        return p.as_posix().lstrip("./")
+
+
+def _seed_files(
+    project: Path,
+    changed: list[str] | None,
+    since: str | None,
+    warnings: list[str],
+) -> list[str]:
+    """Resolve the seed file list: changed list, git diff since, all tracked."""
+    if changed is not None:
+        return [_rel(project, p) for p in changed if p]
+    if since is not None:
+        proc = None
+        try:
+            proc = subprocess.run(
+                ["git", "-C", str(project), "diff", "--name-only", f"{since}..HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=_SUBPROCESS_TIMEOUT,
+            )
+        except (OSError, subprocess.SubprocessError):
+            pass
+        if proc is not None and proc.returncode == 0:
+            return [line for line in proc.stdout.splitlines() if line]
+        warnings.append(
+            f"could not compute git diff since {since} (using all tracked files)"
+        )
+    tracked = _tracked_files_only(project)
+    if tracked is not None:
+        return [_rel(project, p) for p in tracked]
+    # Not a git repo: all code files discovered by ast_extractor.
+    from obsidian_wiki.ast_extractor import extract
+
+    data = extract(project)
+    return sorted({n["file"] for n in data["nodes"] if n["kind"] in ("class", "function")})
+
+
+def _item(symbol: str, kind: str, file: str, lines: list[int]) -> dict:
+    """Base focus-map item; providers patch relation/evidence/via/depth."""
+    return {
+        "symbol": symbol,
+        "kind": kind,
+        "file": file,
+        "lines": lines,
+        "relation": "reference",
+        "via": "",
+        "depth": 0,
+        "evidence": "ast",
+        "signature": "",
+    }
+
+
+def _finalize(items: list[dict], max_symbols: int) -> list[dict]:
+    items = items[:max_symbols]
+    for i, item in enumerate(items):
+        item["rank"] = i + 1
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def code_understand(
+    project: Path,
+    *,
+    backend_flag: str | None = None,
+    changed: list[str] | None = None,
+    since: str | None = None,
+    max_symbols: int = 50,
+    env: dict[str, str] | None = None,
+) -> dict:
+    """Return the focus-map contract dict for *project*.
+
+    *env* supplies CODE_UNDERSTANDING_BACKEND / CODE_UNDERSTANDING_CODEGRAPH_BIN
+    (falling back to os.environ) and is merged into the subprocess environment
+    so test/consumer variables (e.g. FAKE_CODEGRAPH_MODE) reach the binary.
+    Raises ProviderError on hard failure.
+    """
+    project = Path(project)
+    if not project.is_dir():
+        raise ProviderError(f"project directory does not exist: {project}")
+    environ = env if env is not None else os.environ
+    proc_env = dict(os.environ)
+    if env:
+        proc_env.update(env)
+
+    mode, warnings = resolve_backend(
+        flag=backend_flag,
+        env_backend=environ.get("CODE_UNDERSTANDING_BACKEND"),
+        env_bin=environ.get("CODE_UNDERSTANDING_CODEGRAPH_BIN"),
+    )
+    warnings = list(warnings)
+    if mode == "auto":
+        if environ.get("CODE_UNDERSTANDING_CODEGRAPH_BIN") or shutil.which("codegraph"):
+            mode = "codegraph"
+        else:
+            mode = "builtin"
+            warnings.append("codegraph not available; using builtin extractor")
+
+    seed_files = _seed_files(project, changed, since, warnings)
+    origin_files: set[str] = set(seed_files) if (changed is not None or since is not None) else set()
+
+    if mode == "codegraph":
+        from obsidian_wiki.code_understanding_codegraph import CodeGraphProvider
+
+        bin_path = environ.get("CODE_UNDERSTANDING_CODEGRAPH_BIN") or shutil.which("codegraph")
+        provider = CodeGraphProvider(bin_path or "", project, proc_env)
+    else:
+        from obsidian_wiki.code_understanding_builtin import BuiltinProvider
+
+        provider = BuiltinProvider(project)
+
+    focus_map = provider.build_focus_map(seed_files, origin_files, max_symbols, warnings)
+    changed_symbols = list(
+        dict.fromkeys(it["symbol"] for it in focus_map if it["evidence"] == "changed-file")
+    )
+    files: list[str] = []
+    for it in focus_map:
+        if it["file"] and it["file"] not in files:
+            files.append(it["file"])
+    for f in seed_files:
+        if f not in files:
+            files.append(f)
+
+    return {
+        "backend": mode,
+        "project": str(project.resolve()),
+        "seed_files": seed_files,
+        "changed_symbols": changed_symbols,
+        "focus_map": focus_map,
+        "files": files,
+        "warnings": warnings,
+    }

--- a/obsidian_wiki/code_understanding_builtin.py
+++ b/obsidian_wiki/code_understanding_builtin.py
@@ -1,0 +1,150 @@
+"""Builtin focus-map provider: regex AST extraction + ripgrep references.
+
+Zero-dependency backend for obsidian_wiki.code_understanding. Seeds are the
+class/function symbols ast_extractor finds in the seed files; ripgrep adds
+cross-file reference items (best-effort — a missing rg only degrades output).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+from obsidian_wiki.code_understanding import _item, _SUBPROCESS_TIMEOUT
+
+
+class BuiltinProvider:
+    def __init__(self, project: Path) -> None:
+        self.project = project
+
+    def build_focus_map(
+        self,
+        seed_files: list[str],
+        origin_files: set[str],
+        max_symbols: int,
+        warnings: list[str],
+    ) -> list[dict]:
+        from obsidian_wiki.ast_extractor import extract
+        from obsidian_wiki.code_understanding import _finalize
+
+        data = extract(self.project)
+        nodes = data["nodes"]
+        degree: dict[str, int] = {}
+        for e in data["edges"]:
+            degree[e["source"]] = degree.get(e["source"], 0) + 1
+            degree[e["target"]] = degree.get(e["target"], 0) + 1
+
+        seed_set = set(seed_files)
+        defined = [n for n in nodes if n["kind"] in ("class", "function")]
+        items: list[dict] = []
+        seen: set[tuple] = set()
+        for n in defined:
+            if n["file"] not in seed_set:
+                continue
+            if (n["label"], n["file"]) in seen:
+                continue
+            seen.add((n["label"], n["file"]))
+            changed = n["file"] in origin_files
+            item = _item(n["label"], n["kind"], n["file"], [n["line"]])
+            item["evidence"] = "changed-file" if changed else "ast"
+            item["relation"] = "changed-file" if changed else "defines"
+            items.append(item)
+        items = self._rg_references(items, seen, defined, seed_set, warnings)
+        items.sort(
+            key=lambda it: (
+                0 if it["evidence"] == "changed-file" else 1,
+                0 if it["evidence"] in ("changed-file", "ast") else 1,
+                -degree.get(it["symbol"], 0),
+                it["symbol"],
+            )
+        )
+        return _finalize(items, max_symbols)
+
+    def _rg_references(
+        self,
+        items: list[dict],
+        seen: set[tuple],
+        defined: list[dict],
+        seed_set: set[str],
+        warnings: list[str],
+    ) -> list[dict]:
+        """Add cross-file references via ripgrep (best-effort; never crash)."""
+        if shutil.which("rg") is None:
+            warnings.append("rg not available; skipping cross-file reference detection")
+            return items
+        seed_files = sorted(f for f in seed_set if (self.project / f).exists())
+        # References to seed symbols in files other than their defining file.
+        for n in defined:
+            if n["file"] not in seed_set:
+                continue
+            for f, line in self._rg(n["label"], None):
+                if f != n["file"]:
+                    item = _item(n["label"], n["kind"], f, [line])
+                    item["evidence"] = "rg-reference"
+                    item["relation"] = "reference"
+                    item["via"] = n["label"]
+                    self._merge(items, seen, item)
+                    break
+        # External symbols referenced inside seed files.
+        for n in defined:
+            if n["file"] in seed_set or not seed_files:
+                continue
+            if not any(n["label"] in _file_text(self.project / f) for f in seed_files):
+                continue
+            for f, line in self._rg(n["label"], seed_files):
+                if f not in seed_set:
+                    continue
+                via = next((m["label"] for m in defined if m["file"] == f), "")
+                item = _item(n["label"], n["kind"], f, [line])
+                item["evidence"] = "rg-reference"
+                item["relation"] = "reference"
+                item["via"] = via
+                self._merge(items, seen, item)
+                break
+        return items
+
+    def _rg(self, name: str, files: list[str] | None) -> list[tuple[str, int]]:
+        """rg --json matches of \\bname\\b; returns [(file, line), ...]."""
+        args = ["rg", "--json", "-n", "--no-messages", "--no-heading", f"\\b{name}\\b"]
+        if files:
+            args.extend(files)
+        try:
+            proc = subprocess.run(
+                args,
+                cwd=str(self.project),
+                capture_output=True,
+                text=True,
+                timeout=_SUBPROCESS_TIMEOUT,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return []
+        matches: list[tuple[str, int]] = []
+        for raw in proc.stdout.splitlines():
+            try:
+                obj = json.loads(raw)
+            except ValueError:
+                continue
+            if obj.get("type") != "match":
+                continue
+            path = obj.get("data", {}).get("path", {}).get("text", "")
+            line = obj.get("data", {}).get("line_number")
+            if path and isinstance(line, int):
+                matches.append((path, line))
+        return matches
+
+    @staticmethod
+    def _merge(items: list[dict], seen: set[tuple], item: dict) -> None:
+        key = (item["symbol"], item["file"])
+        if key in seen:
+            return
+        seen.add(key)
+        items.append(item)
+
+
+def _file_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""

--- a/obsidian_wiki/code_understanding_codegraph.py
+++ b/obsidian_wiki/code_understanding_codegraph.py
@@ -1,0 +1,145 @@
+"""Codegraph focus-map provider: the optional codegraph CLI (JSON output).
+
+Talks to the codegraph binary (https://github.com/ar9av/codegraph) over
+subprocess. Ensures the project index exists (init) and is current (sync),
+then queries impact/callers/callees per seed symbol. Hard subprocess failure
+raises ProviderError; malformed JSON entries are skipped with a warning.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from obsidian_wiki.code_understanding import (
+    _item,
+    _rel,
+    _SUBPROCESS_TIMEOUT,
+    ProviderError,
+    index_state,
+)
+
+
+class CodeGraphProvider:
+    def __init__(self, bin_path: str, project: Path, proc_env: dict[str, str]) -> None:
+        self.bin_path = bin_path
+        self.project = project
+        self.proc_env = proc_env
+
+    def _run(self, args: list[str]) -> subprocess.CompletedProcess:
+        try:
+            return subprocess.run(
+                [self.bin_path, *args],
+                cwd=str(self.project),
+                capture_output=True,
+                text=True,
+                timeout=_SUBPROCESS_TIMEOUT,
+                env=self.proc_env,
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise ProviderError(f"codegraph command failed: {exc}") from exc
+
+    def _check(self, proc: subprocess.CompletedProcess, command: str) -> None:
+        if proc.returncode != 0:
+            detail = (proc.stderr or proc.stdout).strip()
+            raise ProviderError(f"codegraph {command} failed: {detail}")
+
+    def ensure_index(self) -> None:
+        initialized, fresh, _ = index_state(self.project)
+        if initialized and fresh:
+            return
+        command = "sync" if initialized else "init"
+        self._check(self._run([command, str(self.project)]), command)
+
+    def build_focus_map(
+        self,
+        seed_files: list[str],
+        origin_files: set[str],
+        max_symbols: int,
+        warnings: list[str],
+    ) -> list[dict]:
+        from obsidian_wiki.ast_extractor import extract
+        from obsidian_wiki.code_understanding import _finalize
+
+        self.ensure_index()
+        data = extract(self.project)
+        seed_set = set(seed_files)
+        seeds = sorted(
+            {
+                n["label"]
+                for n in data["nodes"]
+                if n["kind"] in ("class", "function") and n["file"] in seed_set
+            }
+        )
+        items: list[dict] = []
+        seen: set[tuple] = set()
+        for symbol in seeds:
+            payload = self._query("impact", symbol, warnings)
+            if payload is None:
+                continue
+            seed_marked = False
+            for entry in payload.get("affected") or []:
+                item = self._from_entry(entry, symbol, payload.get("depth") or 0)
+                if item is None:
+                    warnings.append(f"codegraph impact entry for {symbol} malformed; skipping")
+                    continue
+                if not seed_marked and item["symbol"] == symbol:
+                    item["evidence"] = "changed-file"
+                    item["relation"] = "changed-file"
+                    item["via"] = ""
+                    item["depth"] = 0
+                    seed_marked = True
+                self._merge(items, seen, item)
+        for symbol in seeds[:5]:
+            for command, relation in (("callers", "caller-of"), ("callees", "callee-of")):
+                payload = self._query(command, symbol, warnings)
+                if payload is None:
+                    continue
+                for entry in payload.get(command) or []:
+                    item = self._from_entry(entry, symbol, 0)
+                    if item is None:
+                        continue
+                    item["relation"] = f"{relation}-{symbol}"
+                    self._merge(items, seen, item)
+        items.sort(
+            key=lambda it: (
+                0 if it["evidence"] == "changed-file" else 1,
+                it["depth"],
+                it["symbol"],
+            )
+        )
+        return _finalize(items, max_symbols)
+
+    def _query(self, command: str, symbol: str, warnings: list[str]) -> dict | None:
+        proc = self._run([command, symbol, "--json"])
+        self._check(proc, command)
+        try:
+            payload = json.loads(proc.stdout)
+        except ValueError:
+            warnings.append(f"codegraph {command} {symbol} returned invalid JSON; skipping")
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def _from_entry(self, entry: dict, seed: str, depth: int) -> dict | None:
+        name = entry.get("name")
+        file_path = entry.get("filePath")
+        start = entry.get("startLine")
+        if not name or not file_path or not isinstance(start, int):
+            return None
+        end = entry.get("endLine")
+        lines = [start, end] if isinstance(end, int) and end >= start else [start]
+        item = _item(name, entry.get("kind") or "symbol", _rel(self.project, file_path), lines)
+        item["evidence"] = "codegraph-edge"
+        item["relation"] = f"affected-by-{seed}"
+        item["via"] = seed
+        item["depth"] = depth
+        return item
+
+    @staticmethod
+    def _merge(items: list[dict], seen: set[tuple], item: dict) -> None:
+        key = (item["symbol"], item["file"], tuple(item["lines"]))
+        if key in seen:
+            return
+        seen.add(key)
+        items.append(item)

--- a/obsidian_wiki/code_understanding_codegraph.py
+++ b/obsidian_wiki/code_understanding_codegraph.py
@@ -74,7 +74,7 @@ class CodeGraphProvider:
         )
         items: list[dict] = []
         seen: set[tuple] = set()
-        for symbol in seeds:
+        for symbol in seeds[:25]:
             payload = self._query("impact", symbol, warnings)
             if payload is None:
                 continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,117 @@
+"""Shared pytest test fixtures for the obsidian-wiki test suite.
+
+These are plain module-level helper functions (not @pytest.fixture) so their
+signatures are explicit and tests call them directly:
+
+    from conftest import make_project, _run_cli
+
+They support the issue #167 code-graph backend tests: building throwaway git
+projects, a fake codegraph CLI binary, and .codegraph index state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def make_project(tmp_path: Path, files: dict[str, str], *, git: bool = True) -> Path:
+    """Write a mini source tree from files (relpath -> content) and, if git,
+    commit it as an initial commit (needed for --since tests)."""
+    project = tmp_path / "project"
+    project.mkdir(parents=True, exist_ok=True)
+    for relpath, content in files.items():
+        path = project / relpath
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    if git:
+        _git(project, "init", "-q")
+        _git(project, "config", "user.email", "test@example.com")
+        _git(project, "config", "user.name", "Wiki Tester")
+        _git(project, "add", "-A")
+        _git(project, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "initial commit")
+    return project
+
+
+def make_fake_codegraph_bin(tmp_path: Path) -> Path:
+    """Copy tests/fixtures/codegraph_fake.py into a bin dir, chmod +x, and
+    return the executable path (to pass as CODE_UNDERSTANDING_CODEGRAPH_BIN)."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    src = Path(__file__).parent / "fixtures" / "codegraph_fake.py"
+    dest = bin_dir / "codegraph"
+    dest.write_text(src.read_text(encoding="utf-8"), encoding="utf-8")
+    dest.chmod(dest.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return dest
+
+
+def build_index_state(project: Path, *, fresh: bool = True) -> None:
+    """Create project/.codegraph/codegraph.db (empty; mtime matters) plus
+    source.json. If fresh=False, backdate codegraph.db to 2000-01-01 so it
+    is older than the tracked source files (stale index)."""
+    codegraph_dir = project / ".codegraph"
+    codegraph_dir.mkdir(parents=True, exist_ok=True)
+    (codegraph_dir / "codegraph.db").write_bytes(b"")
+    (codegraph_dir / "source.json").write_text(
+        json.dumps({"sourceDir": str(project.resolve()), "version": 1}),
+        encoding="utf-8",
+    )
+    if not fresh:
+        stale = time.mktime((2000, 1, 1, 0, 0, 0, 0, 0, -1))
+        os.utime(codegraph_dir / "codegraph.db", (stale, stale))
+
+
+def _run_cli(
+    cwd: Path,
+    *args: str,
+    env_overrides: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run `python -m obsidian_wiki.cli <args>` in cwd with the current
+    environment merged with env_overrides."""
+    env = os.environ.copy()
+    if env_overrides:
+        env.update(env_overrides)
+    return subprocess.run(
+        [sys.executable, "-m", "obsidian_wiki.cli", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+
+
+def make_repo_two_commits(tmp_path: Path) -> tuple[Path, str]:
+    """A project with 2 commits: first adds src/foo.py + src/only_first.py,
+    second modifies foo.py and adds src/bar.py (only_first.py untouched).
+    Returns (project, sha_of_first_commit) for --since delta tests.
+    The untouched third file makes the delta set ({foo, bar}) strictly
+    smaller than the full tracked set ({foo, bar, only_first}), so tests
+    actually prove --since filtering rather than passing vacuously."""
+    project = make_project(
+        tmp_path,
+        {
+            "src/foo.py": "def foo():\n    return 1\n",
+            "src/only_first.py": "x = 1\n",
+        },
+    )
+    sha_first = _git(project, "rev-parse", "HEAD").stdout.strip()
+    (project / "src/foo.py").write_text("def foo():\n    return 2\n", encoding="utf-8")
+    (project / "src/bar.py").write_text("def bar():\n    return 3\n", encoding="utf-8")
+    _git(project, "add", "-A")
+    _git(project, "-c", "commit.gpgsign=false", "commit", "-q", "-m", "second commit")
+    return project, sha_first
+
+
+def _git(project: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        capture_output=True,
+        text=True,
+        cwd=project,
+        check=True,
+    )

--- a/tests/fixtures/codegraph_fake.py
+++ b/tests/fixtures/codegraph_fake.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Fake codegraph CLI for tests.
+
+Mimics the real codegraph v1.5.0 CLI contract (https://github.com/ar9av/codegraph):
+
+    fake-codegraph [options] <command> [args...]
+
+Commands: init, index, sync, status (accept an optional positional target
+path, default CWD) and query <search>, callers <sym>, callees <sym>,
+impact <sym>, affected [files...], files (resolve .codegraph from CWD).
+
+The --json flag is accepted on query/callers/callees/impact/affected and
+mirrors the real CLI's output shapes exactly. Behavior is canned and
+deterministic — the fake never reads the project — driven by one env var:
+
+  FAKE_CODEGRAPH_MODE=broke  -> print an error to stderr and exit 1 for
+                               every command.
+
+Stdlib only; intended to be executed as a binary (shebang + chmod +x).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def _fake_hash(name: str) -> str:
+    return hashlib.sha1(name.encode("utf-8")).hexdigest()[:16]
+
+
+def _affected_entry(name: str, file_path: str = "src/foo.py", start_line: int = 5) -> dict:
+    return {
+        "name": name,
+        "kind": "function",
+        "filePath": file_path,
+        "startLine": start_line,
+    }
+
+
+def _query_result(search: str) -> dict:
+    node = {
+        "id": "function:" + _fake_hash(search),
+        "kind": "function",
+        "name": search,
+        "qualifiedName": f"src.mod.{search}",
+        "filePath": "src/foo.py",
+        "language": "python",
+        "startLine": 10,
+        "endLine": 42,
+        "startColumn": 0,
+        "endColumn": 12,
+        "signature": "(args) -> int",
+        "visibility": None,
+        "isExported": False,
+        "isAsync": False,
+        "isStatic": False,
+        "isAbstract": False,
+    }
+    return {"node": node, "score": 55.49}
+
+
+def _respond(command: str, args: list[str], json_out: bool) -> int:
+    if command == "init":
+        target = _target_dir(args)
+        (target / ".codegraph").mkdir(parents=True, exist_ok=True)
+        (target / ".codegraph" / "codegraph.db").touch()
+        print(f"codegraph: initialized {target}")
+        return 0
+    if command == "index":
+        target = _target_dir(args)
+        (target / ".codegraph").mkdir(parents=True, exist_ok=True)
+        (target / ".codegraph" / "codegraph.db").touch()
+        print(f"codegraph: indexed {target}")
+        return 0
+    if command == "sync":
+        target = _target_dir(args)
+        (target / ".codegraph").mkdir(parents=True, exist_ok=True)
+        (target / ".codegraph" / "codegraph.db").touch()
+        print(f"codegraph: synced {target}")
+        return 0
+    if command == "status":
+        # Human text, never JSON (matches the real CLI).
+        print("index: current")
+        print("nodes: 2, edges: 1")
+        return 0
+    if command == "query":
+        search = args[0]
+        _emit([_query_result(search)], json_out, human_lines=[f"query {search}: 1 result"])
+        return 0
+    if command == "impact":
+        symbol = args[0]
+        payload = {
+            "symbol": symbol,
+            "depth": 2,
+            "nodeCount": 2,
+            "edgeCount": 1,
+            "affected": [
+                _affected_entry(symbol, file_path="src/foo.py", start_line=10),
+                _affected_entry(f"caller_of_{symbol}", file_path="src/foo.py", start_line=5),
+            ],
+        }
+        _emit(payload, json_out, human_lines=[f"impact of {symbol} (depth 2):"])
+        return 0
+    if command == "callers":
+        symbol = args[0]
+        payload = {
+            "symbol": symbol,
+            "callers": [_affected_entry(f"caller_of_{symbol}", start_line=5)],
+        }
+        _emit(payload, json_out, human_lines=[f"callers of {symbol}:"])
+        return 0
+    if command == "callees":
+        symbol = args[0]
+        payload = {
+            "symbol": symbol,
+            "callees": [_affected_entry(f"callee_of_{symbol}", start_line=20)],
+        }
+        _emit(payload, json_out, human_lines=[f"callees of {symbol}:"])
+        return 0
+    if command == "affected":
+        payload = {
+            "changedFiles": list(args),
+            "affectedTests": ["tests/test_utils.py"],
+            "totalDependentsTraversed": 5,
+        }
+        _emit(payload, json_out, human_lines=[f"affected by {', '.join(args)}:"])
+        return 0
+    if command == "files":
+        for path in ("src/foo.py", "src/bar.py"):
+            print(path)
+        return 0
+    print(f"codegraph: unknown command '{command}'", file=sys.stderr)
+    return 2
+
+
+def _target_dir(args: list[str]) -> Path:
+    return Path(args[0]) if args else Path.cwd()
+
+
+def _emit(payload: dict | list, json_out: bool, *, human_lines: list[str]) -> None:
+    if json_out:
+        print(json.dumps(payload))
+    else:
+        for line in human_lines:
+            print(line)
+
+
+def main(argv: list[str]) -> int:
+    if os.environ.get("FAKE_CODEGRAPH_MODE") == "broke":
+        print("codegraph: broken (FAKE_CODEGRAPH_MODE=broke)", file=sys.stderr)
+        return 1
+
+    options: list[str] = []
+    positionals: list[str] = []
+    for arg in argv:
+        if arg.startswith("-"):
+            options.append(arg)
+        else:
+            positionals.append(arg)
+
+    if not positionals:
+        print(
+            "usage: codegraph [--json] <command> [args...]\n"
+            "commands: init, index, sync, status, query, callers, callees,"
+            " impact, affected, files",
+            file=sys.stderr,
+        )
+        return 2
+
+    command = positionals[0]
+    args = positionals[1:]
+
+    valid = ("init", "index", "sync", "status", "query", "callers", "callees",
+             "impact", "affected", "files")
+    if command not in valid:
+        print(f"codegraph: unknown command '{command}'", file=sys.stderr)
+        return 2
+
+    if command == "query" and not args:
+        print("codegraph: query requires a search term", file=sys.stderr)
+        return 2
+    if command in ("callers", "callees", "impact") and not args:
+        print(f"codegraph: {command} requires a symbol", file=sys.stderr)
+        return 2
+
+    json_out = "--json" in options
+    return _respond(command, args, json_out)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/test_code_understand_cli.py
+++ b/tests/test_code_understand_cli.py
@@ -1,0 +1,190 @@
+"""Subprocess tests for the `code-understand` CLI command (issue #167).
+
+The command does not exist yet — these tests are RED by design: argparse must
+reject `code-understand` with an "invalid choice" error (exit 2) until the
+wiring wave registers the subcommand. They pin the exact CLI contract:
+
+    obsidian-wiki code-understand [--project <dir>] [--backend auto|builtin|codegraph]
+        [--changed <file> ...] [--since <sha>] [--max-symbols N] [--pretty]
+
+Every invocation is a real subprocess (`python -m obsidian_wiki.cli`) via the
+conftest `_run_cli` helper, so these tests lock the observable contract — exit
+codes, JSON shape on stdout, and stderr messages — not any internal function.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from conftest import (
+    _run_cli,
+    make_fake_codegraph_bin,
+    make_project,
+    make_repo_two_commits,
+)
+
+# Minimal PATH so the code-understanding provider can never find a real
+# codegraph on the machine running the tests. /usr/bin:/bin keeps `git` (and
+# the absolute sys.executable used to launch the CLI) working while excluding
+# any user/brew/.omo install of codegraph. `which codegraph` fails on the dev
+# machine (vendored bin lives under ~/.omo but not on PATH), so this is belt
+# and suspenders for CI machines that do have codegraph on PATH.
+_NO_CODEGRAPH_PATH = "/usr/bin:/bin"
+
+
+def _no_codegraph_env() -> dict[str, str]:
+    return {"PATH": _NO_CODEGRAPH_PATH, "CODE_UNDERSTANDING_CODEGRAPH_BIN": ""}
+
+
+def _mini_project(tmp_path: Path) -> Path:
+    return make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+
+
+def test_code_understand_builtin_json_shape(tmp_path: Path) -> None:
+    project = _mini_project(tmp_path)
+
+    proc = _run_cli(
+        project, "code-understand", "--backend", "builtin", "--project", str(project)
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["backend"] == "builtin"
+    assert isinstance(data["focus_map"], list)
+    for item in data["focus_map"]:
+        assert "file" in item
+        assert "lines" in item
+
+
+def test_code_understand_accepts_changed_files(tmp_path: Path) -> None:
+    project = _mini_project(tmp_path)
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--backend",
+        "builtin",
+        "--project",
+        str(project),
+        "--changed",
+        "src/foo.py",
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert "src/foo.py" in data["seed_files"]
+
+
+def test_code_understand_since_delta(tmp_path: Path) -> None:
+    project, sha_first = make_repo_two_commits(tmp_path)
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--backend",
+        "builtin",
+        "--project",
+        str(project),
+        "--since",
+        sha_first,
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    # Only src/foo.py (modified) and src/bar.py (added) change after sha_first.
+    assert set(data["seed_files"]) == {"src/foo.py", "src/bar.py"}
+
+
+def test_code_understand_explicit_codegraph_broken_returns_1(tmp_path: Path) -> None:
+    project = _mini_project(tmp_path)
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--project",
+        str(project),
+        env_overrides={
+            "CODE_UNDERSTANDING_BACKEND": "codegraph",
+            **_no_codegraph_env(),
+        },
+    )
+
+    assert proc.returncode == 1
+    assert "codegraph" in proc.stderr.lower()
+
+
+def test_code_understand_auto_falls_back_when_codegraph_absent(tmp_path: Path) -> None:
+    project = _mini_project(tmp_path)
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--project",
+        str(project),
+        env_overrides={
+            "CODE_UNDERSTANDING_BACKEND": "auto",
+            **_no_codegraph_env(),
+        },
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["backend"] == "builtin"
+    assert data["warnings"]
+
+
+def test_code_understand_codegraph_via_bin_env(tmp_path: Path) -> None:
+    project = _mini_project(tmp_path)
+    bin_path = make_fake_codegraph_bin(tmp_path)
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--project",
+        str(project),
+        env_overrides={
+            **_no_codegraph_env(),
+            "CODE_UNDERSTANDING_BACKEND": "codegraph",
+            "CODE_UNDERSTANDING_CODEGRAPH_BIN": str(bin_path),
+        },
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["backend"] == "codegraph"
+
+
+def test_code_understand_bad_project_returns_1(tmp_path: Path) -> None:
+    proc = _run_cli(
+        tmp_path,
+        "code-understand",
+        "--backend",
+        "builtin",
+        "--project",
+        "/nonexistent/xyz",
+    )
+
+    assert proc.returncode == 1
+    assert "project" in proc.stderr.lower()
+
+
+def test_code_understand_pretty_flag(tmp_path: Path) -> None:
+    project = _mini_project(tmp_path)
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--backend",
+        "builtin",
+        "--project",
+        str(project),
+        "--pretty",
+    )
+
+    assert proc.returncode == 0
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(proc.stdout)
+    assert "backend" in proc.stdout

--- a/tests/test_code_understanding.py
+++ b/tests/test_code_understanding.py
@@ -263,3 +263,33 @@ def test_index_state_heuristic(tmp_path: Path) -> None:
     build_index_state(project, fresh=False)
     initialized, fresh, _ = index_state(project)
     assert initialized is True and fresh is False
+
+
+def test_codegraph_caps_impact_queries_on_full_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A full-project scan (no --changed) must not run an unbounded number of
+    codegraph impact subprocesses — regression for the timeout seen on real
+    repos with hundreds of symbols (issue #167 review note N9)."""
+    project = make_project(
+        tmp_path,
+        {f"src/mod{i}.py": f"def f{i}():\n    return {i}\n" for i in range(30)},
+    )
+    bin_path = make_fake_codegraph_bin(tmp_path)
+    env = {"CODE_UNDERSTANDING_CODEGRAPH_BIN": str(bin_path)}
+
+    from obsidian_wiki.code_understanding_codegraph import CodeGraphProvider
+
+    impact_calls: list[str] = []
+    real_query = CodeGraphProvider._query
+
+    def spy_query(self, command: str, symbol: str, warnings: list[str]):
+        if command == "impact":
+            impact_calls.append(symbol)
+        return real_query(self, command, symbol, warnings)
+
+    monkeypatch.setattr(CodeGraphProvider, "_query", spy_query)
+
+    code_understand(project, backend_flag="codegraph", env=env)
+
+    assert len(impact_calls) <= 25

--- a/tests/test_code_understanding.py
+++ b/tests/test_code_understanding.py
@@ -1,0 +1,265 @@
+"""RED unit tests for the optional code-graph-assisted ingest module.
+
+Issue #167: obsidian_wiki/code_understanding.py does not exist yet. Every
+test below fails with ModuleNotFoundError until the implementation wave
+creates the module — that is the TDD contract these tests pin.
+
+Conventions (mirrors tests/conftest.py + tests/test_conftest_smoke.py):
+conftest helpers are plain module-level functions, imported directly — no
+pytest fixtures.
+"""
+
+from __future__ import annotations
+
+import shutil
+import time
+from pathlib import Path
+
+import pytest
+
+from conftest import (
+    build_index_state,
+    make_fake_codegraph_bin,
+    make_project,
+    make_repo_two_commits,
+)
+from obsidian_wiki.code_understanding import (
+    ProviderError,
+    code_understand,
+    index_state,
+    resolve_backend,
+)
+
+# Same backdate used by conftest.build_index_state(fresh=False).
+_STALE_EPOCH = time.mktime((2000, 1, 1, 0, 0, 0, 0, 0, -1))
+
+
+def _which_blocking(monkeypatch: pytest.MonkeyPatch, *names: str) -> None:
+    """Make shutil.which return None for *names, pass through for everything
+    else (so git subprocess lookups inside the provider keep working)."""
+    original = shutil.which
+
+    def _fake(name: str) -> str | None:
+        if name in names:
+            return None
+        return original(name)
+
+    monkeypatch.setattr(shutil, "which", _fake)
+
+
+# ---------------------------------------------------------------------------
+# resolve_backend: mode selection + explicit-codegraph validation.
+# ('auto' is returned unresolved here; the fallback-to-builtin resolution
+# with warning happens inside code_understand — see the auto-fallback tests.)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_backend_defaults_auto(monkeypatch: pytest.MonkeyPatch) -> None:
+    _which_blocking(monkeypatch, "codegraph")
+
+    assert resolve_backend() == ("auto", [])
+
+
+def test_resolve_backend_flag_overrides_env() -> None:
+    assert resolve_backend(flag="builtin", env_backend="codegraph") == ("builtin", [])
+
+
+def test_resolve_backend_explicit_codegraph_missing_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _which_blocking(monkeypatch, "codegraph")
+
+    with pytest.raises(ProviderError):
+        resolve_backend(flag="codegraph")
+
+
+def test_resolve_backend_auto_falls_back_when_bin_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Default 'auto' mode with no resolvable codegraph -> builtin fallback
+    # with a codegraph warning, applied when code_understand resolves 'auto'.
+    project = make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+    _which_blocking(monkeypatch, "codegraph")
+
+    result = code_understand(project, backend_flag=None, env={})
+
+    assert result["backend"] == "builtin"
+    assert any("codegraph" in w.lower() for w in result["warnings"])
+
+
+def test_resolve_backend_codegraph_when_bin_present(tmp_path: Path) -> None:
+    bin_path = make_fake_codegraph_bin(tmp_path)
+
+    assert resolve_backend(flag="codegraph", env_bin=str(bin_path)) == ("codegraph", [])
+
+
+# ---------------------------------------------------------------------------
+# Builtin provider (regex AST extraction; rg for cross-file references)
+# ---------------------------------------------------------------------------
+
+
+def test_builtin_focus_map_shape_and_citations(tmp_path: Path) -> None:
+    project = make_project(
+        tmp_path,
+        {
+            "src/foo.py": "class Foo:\n    pass\n",
+            "src/bar.py": "def helper():\n    return 1\n",
+        },
+    )
+
+    result = code_understand(project, backend_flag="builtin", changed=["src/foo.py"])
+
+    assert result["backend"] == "builtin"
+    assert result["seed_files"] == ["src/foo.py"]
+    assert len(result["focus_map"]) > 0
+    for item in result["focus_map"]:
+        # Citation invariant: every item carries a relative file and lines.
+        assert isinstance(item["file"], str) and item["file"]
+        assert isinstance(item["lines"], list) and item["lines"]
+    first = result["focus_map"][0]
+    assert first["symbol"] == "Foo"
+    assert first["rank"] == 1
+    assert first["evidence"] == "changed-file"
+    assert first["file"] == "src/foo.py"
+
+
+def test_builtin_since_computes_git_diff(tmp_path: Path) -> None:
+    project, sha_first = make_repo_two_commits(tmp_path)
+    # Fixture: commit 1 adds src/foo.py; commit 2 modifies src/foo.py and
+    # adds src/bar.py. The sha_first..HEAD delta is exactly those two files.
+    result = code_understand(project, backend_flag="builtin", since=sha_first)
+
+    assert set(result["seed_files"]) == {"src/foo.py", "src/bar.py"}
+
+
+@pytest.mark.skipif(shutil.which("rg") is None, reason="rg not installed")
+def test_builtin_rg_reference_links(tmp_path: Path) -> None:
+    project = make_project(
+        tmp_path,
+        {
+            "src/foo.py": "class Foo:\n    pass\n\n\nresult = Bar()\n",
+            "src/bar.py": "class Bar:\n    pass\n",
+        },
+    )
+
+    result = code_understand(project, backend_flag="builtin", changed=["src/foo.py"])
+
+    assert any(item["evidence"] == "rg-reference" for item in result["focus_map"])
+
+
+def test_builtin_tolerates_missing_rg(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    project = make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+    _which_blocking(monkeypatch, "rg")
+
+    result = code_understand(project, backend_flag="builtin", changed=["src/foo.py"])
+
+    assert len(result["focus_map"]) > 0
+    assert any("rg" in w.lower() for w in result["warnings"])
+
+
+# ---------------------------------------------------------------------------
+# Codegraph provider (fake CLI injected via CODE_UNDERSTANDING_CODEGRAPH_BIN)
+# ---------------------------------------------------------------------------
+
+
+def test_codegraph_provider_uses_injected_bin(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+    bin_path = make_fake_codegraph_bin(tmp_path)
+
+    result = code_understand(
+        project,
+        backend_flag="codegraph",
+        changed=["src/foo.py"],
+        env={"CODE_UNDERSTANDING_CODEGRAPH_BIN": str(bin_path)},
+    )
+
+    assert result["backend"] == "codegraph"
+    assert len(result["focus_map"]) > 0
+    assert any(item["evidence"] == "codegraph-edge" for item in result["focus_map"])
+    for item in result["focus_map"]:
+        assert "file" in item and "lines" in item
+
+
+def test_codegraph_auto_falls_back_when_bin_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    project = make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+    _which_blocking(monkeypatch, "codegraph")
+
+    result = code_understand(project, env={"CODE_UNDERSTANDING_BACKEND": "auto"})
+
+    assert result["backend"] == "builtin"
+    assert any("codegraph" in w.lower() for w in result["warnings"])
+
+
+def test_codegraph_explicit_broken_raises(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+    bin_path = make_fake_codegraph_bin(tmp_path)
+
+    with pytest.raises(ProviderError):
+        code_understand(
+            project,
+            backend_flag="codegraph",
+            env={
+                "CODE_UNDERSTANDING_CODEGRAPH_BIN": str(bin_path),
+                "FAKE_CODEGRAPH_MODE": "broke",
+            },
+        )
+
+
+def test_codegraph_ensures_index_then_syncs(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+    bin_path = make_fake_codegraph_bin(tmp_path)
+    env = {"CODE_UNDERSTANDING_CODEGRAPH_BIN": str(bin_path)}
+
+    # (a) No .codegraph -> the provider must init before querying.
+    result = code_understand(project, backend_flag="codegraph", changed=["src/foo.py"], env=env)
+    assert (project / ".codegraph" / "codegraph.db").exists()
+    assert len(result["focus_map"]) > 0
+
+    # (b) Stale index -> the provider must sync. The fake answers sync by
+    # touching codegraph.db, so its mtime moves off the 2000 backdate.
+    build_index_state(project, fresh=False)
+    db = project / ".codegraph" / "codegraph.db"
+    assert db.stat().st_mtime == _STALE_EPOCH
+
+    result = code_understand(project, backend_flag="codegraph", changed=["src/foo.py"], env=env)
+
+    assert result["backend"] == "codegraph"
+    assert len(result["focus_map"]) > 0
+    assert db.stat().st_mtime > _STALE_EPOCH
+
+
+# ---------------------------------------------------------------------------
+# Ranking cap and index freshness heuristic
+# ---------------------------------------------------------------------------
+
+
+def test_focus_map_capped_at_max_symbols(tmp_path: Path) -> None:
+    project = make_project(
+        tmp_path,
+        {
+            "src/a.py": "def alpha():\n    return 1\n\ndef beta():\n    return 2\n",
+            "src/b.py": "def gamma():\n    return 3\n\ndef delta():\n    return 4\n",
+            "src/c.py": "def epsilon():\n    return 5\n",
+        },
+    )
+
+    result = code_understand(project, backend_flag="builtin", max_symbols=3)
+
+    assert 1 <= len(result["focus_map"]) <= 3
+
+
+def test_index_state_heuristic(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+
+    initialized, fresh, _ = index_state(project)
+    assert initialized is False and fresh is False
+
+    build_index_state(project, fresh=True)
+    initialized, fresh, _ = index_state(project)
+    assert initialized is True and fresh is True
+
+    build_index_state(project, fresh=False)
+    initialized, fresh, _ = index_state(project)
+    assert initialized is True and fresh is False

--- a/tests/test_conftest_smoke.py
+++ b/tests/test_conftest_smoke.py
@@ -1,0 +1,100 @@
+"""Smoke tests for the shared conftest fixtures (issue #167 wave 1)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+from conftest import (
+    _run_cli,
+    build_index_state,
+    make_fake_codegraph_bin,
+    make_project,
+    make_repo_two_commits,
+)
+
+
+def test_make_project_creates_git_repo_with_commit(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"README.md": "# hi\n"})
+
+    proc = subprocess.run(["git", "log", "--oneline"], capture_output=True, text=True, cwd=project)
+    assert proc.returncode == 0
+    assert "initial commit" in proc.stdout
+    assert (project / "README.md").read_text(encoding="utf-8") == "# hi\n"
+
+
+def test_make_project_without_git(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"src/a.py": "x = 1\n"}, git=False)
+
+    assert (project / "src" / "a.py").read_text(encoding="utf-8") == "x = 1\n"
+    assert not (project / ".git").exists()
+
+
+def test_fake_codegraph_bin_is_executable_and_answers_impact(tmp_path: Path) -> None:
+    bin_path = make_fake_codegraph_bin(tmp_path)
+
+    assert os.access(bin_path, os.X_OK)
+    proc = subprocess.run([str(bin_path), "impact", "Foo", "--json"], capture_output=True, text=True)
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["symbol"] == "Foo"
+    names = [entry["name"] for entry in data["affected"]]
+    assert "Foo" in names
+    assert all("filePath" in entry for entry in data["affected"])
+
+
+def test_fake_codegraph_bin_broke_mode_exits_1(tmp_path: Path) -> None:
+    bin_path = make_fake_codegraph_bin(tmp_path)
+
+    env = os.environ.copy()
+    env["FAKE_CODEGRAPH_MODE"] = "broke"
+    proc = subprocess.run(
+        [str(bin_path), "query", "x", "--json"], capture_output=True, text=True, env=env
+    )
+    assert proc.returncode == 1
+    assert proc.stderr
+
+
+def test_build_index_state_fresh_is_newer_than_sources(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"src/a.py": "x = 1\n"}, git=False)
+
+    build_index_state(project)
+
+    db = project / ".codegraph" / "codegraph.db"
+    src = project / "src" / "a.py"
+    assert db.exists()
+    assert db.stat().st_mtime >= src.stat().st_mtime
+    assert json.loads((project / ".codegraph" / "source.json").read_text())["version"] == 1
+
+
+def test_build_index_state_stale_is_older_than_sources(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"src/a.py": "x = 1\n"}, git=False)
+
+    build_index_state(project, fresh=False)
+
+    db = project / ".codegraph" / "codegraph.db"
+    src = project / "src" / "a.py"
+    assert db.stat().st_mtime < src.stat().st_mtime
+
+
+def test_make_repo_two_commits_returns_sha_of_first(tmp_path: Path) -> None:
+    project, sha_first = make_repo_two_commits(tmp_path)
+
+    count = subprocess.run(
+        ["git", "rev-list", "--count", "HEAD"], capture_output=True, text=True, cwd=project
+    )
+    assert count.stdout.strip() == "2"
+    assert len(sha_first) == 40
+    assert (project / "src" / "foo.py").exists()
+    assert (project / "src" / "bar.py").exists()
+
+
+def test_run_cli_runs_in_cwd_with_env_overrides(tmp_path: Path) -> None:
+    project = make_project(tmp_path, {"src/a.py": "x = 1\n"})
+
+    proc = _run_cli(project, "--version", env_overrides={"FAKE_VAR": "1"})
+
+    assert proc.returncode == 0
+    assert "obsidian-wiki" in proc.stdout

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -10,10 +10,26 @@ from pathlib import Path
 
 from obsidian_wiki.cli import list_skills
 
+from conftest import build_index_state, make_fake_codegraph_bin, make_project
+
 
 def _run(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["HOME"] = str(home)
+    return subprocess.run(
+        [sys.executable, "-m", "obsidian_wiki.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _run_env(
+    home: Path, env_overrides: dict[str, str], *args: str
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env.update(env_overrides)
     return subprocess.run(
         [sys.executable, "-m", "obsidian_wiki.cli", *args],
         capture_output=True,
@@ -102,3 +118,136 @@ def test_doctor_strict_turns_warnings_into_nonzero_exit(tmp_path: Path) -> None:
     assert proc.returncode == 1
     data = json.loads(proc.stdout)
     assert any(check["name"] == "setup-version" and check["status"] == "warn" for check in data["checks"])
+
+
+def test_doctor_without_project_has_no_code_understanding_checks(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+
+    proc = _run(home, "doctor", "--json")
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert not any(check["name"].startswith("code-understanding") for check in data["checks"])
+
+
+def test_doctor_project_shows_builtin_checks(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(tmp_path, {"src/foo.py": "def foo():\n    return 1\n"}, git=False)
+
+    proc = _run(home, "doctor", "--json", "--project", str(project))
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    names = {check["name"] for check in data["checks"]}
+    assert "code-understanding.builtin" in names
+    assert "code-understanding.rg" in names
+    assert data["status"] != "fail"
+
+
+def test_doctor_project_auto_missing_codegraph_is_warn_not_fail(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(tmp_path, {"src/foo.py": "def foo():\n    return 1\n"}, git=False)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(home, {"PATH": str(no_bin), "CODE_UNDERSTANDING_CODEGRAPH_BIN": ""}, "doctor", "--json", "--project", str(project))
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["status"] != "fail"
+    check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph")
+    assert check["status"] == "warn"
+
+
+def test_doctor_project_explicit_codegraph_broken_fails(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(tmp_path, {"src/foo.py": "def foo():\n    return 1\n"}, git=False)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": str(no_bin), "CODE_UNDERSTANDING_BACKEND": "codegraph", "CODE_UNDERSTANDING_CODEGRAPH_BIN": ""},
+        "doctor",
+        "--json",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 1
+    data = json.loads(proc.stdout)
+    assert data["status"] == "fail"
+    check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph")
+    assert check["status"] == "fail"
+
+
+def test_doctor_project_codegraph_enhanced_checks_pass(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(tmp_path, {"src/foo.py": "def foo():\n    return 1\n"}, git=False)
+    codegraph_bin = make_fake_codegraph_bin(tmp_path)
+    build_index_state(project)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": str(no_bin), "CODE_UNDERSTANDING_CODEGRAPH_BIN": str(codegraph_bin)},
+        "doctor",
+        "--json",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    statuses = {check["name"]: check["status"] for check in data["checks"]}
+    assert statuses["code-understanding.codegraph"] == "pass"
+    assert statuses["code-understanding.codegraph-index"] == "pass"
+    assert statuses["code-understanding.codegraph-fresh"] == "pass"
+
+
+def test_doctor_project_index_stale_warns(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(tmp_path, {"src/foo.py": "def foo():\n    return 1\n"}, git=False)
+    codegraph_bin = make_fake_codegraph_bin(tmp_path)
+    build_index_state(project, fresh=False)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": str(no_bin), "CODE_UNDERSTANDING_CODEGRAPH_BIN": str(codegraph_bin)},
+        "doctor",
+        "--json",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph-fresh")
+    assert check["status"] == "warn"


### PR DESCRIPTION
Closes #167

## Summary

Adds an optional **code-graph-assisted understanding** step to `wiki-update` project ingest. Before distilling knowledge into the wiki, the agent can now query a code graph backend to identify important modules, call paths, and impact areas — then read only the load-bearing code, with `file:line` citations on every architectural claim.

**Why it matters:** agents otherwise explore large projects heuristically, reading tens to hundreds of thousands of tokens just to understand structure — and can miss entire components. Measured on two real projects:

| Scenario | [Project 1](https://github.com/mike840609/iiwi)  | [Project 2](https://github.com/mike840609/assets_tracker)  |
|---|---|---|
| **builtin** (no codegraph) — agent explores the project heuristically (status quo) | 1,515,799 chars / **~379k tokens** | 2,312,944 chars / **~578k tokens** |
| **codegraph** — ranked focus map from the real call graph | 2,510 chars / **~627 tokens** | 3,136 chars / **~784 tokens** |
| Selective reads: `file:line` ranges the focus map points at | 10 lines | 11 lines |
| **Context saved per incremental `wiki-update`** | **~378k tokens (~99.8%)** | **~577k tokens (~99.86%)** |
| Cost saved per run (~$2.5–3/M input tokens) | **~$0.95–1.13** | **~$1.44–1.73** |
| Single-file scan latency | <5s | **~0.9s** |

**builtin** is the no-codegraph status quo: it also emits a focus map, but its `rg`-based links are too weak to guide selective reads (they can point at the wrong file/line), so the agent still explores heuristically and the savings shown here are realized with **codegraph**. The 2–3 min full-project index is one-time and only when CodeGraph is enabled.

Beyond tokens, the focus map is **structural, not heuristic**: it is seeded from the real call graph, so high-connectivity modules (hubs) surface even when the agent would have skipped them — reducing the risk of permanently missing a component that `last_commit_synced` would never revisit (the motivation behind #168).

The raw graph is never persisted into the vault. The `.codegraph/` index stays a git-ignored sidecar in the project repo.

### Single-file coverage: builtin vs codegraph

Both outputs below were generated for the **same single file** — they show how much of that file's structure each backend captures.

The difference is **precision, not just coverage**: in the builtin output, `adopt_legacy` is attributed to `history.py:18` (it actually lives in `paths.py:15`), and three `rg-reference` rows all point at the same `cli_actions.py:25` line. The codegraph output resolves the real callees (`_json_default`, `_open_for_append`), the real caller (`resolve` in `services/scan.py`), and the real definition site — so the architecture claims written to the wiki are grounded in fact, not keyword guesses.

#### builtin (rg / grep + regex AST extract)
<img width="988" height="196" alt="Screenshot 2026-08-15 at 3 45 54 AM" src="https://github.com/user-attachments/assets/1eea3c88-36b2-4c8b-8d14-0dc99e52e12c" />

#### codegraph
<img width="989" height="206" alt="Screenshot 2026-08-15 at 3 46 46 AM" src="https://github.com/user-attachments/assets/7a88b75d-1841-446a-8f5b-2b843f0f21cc" />


## What changed

### New: `obsidian-wiki code-understand` command
```
obsidian-wiki code-understand --project <dir> [--backend auto|builtin|codegraph]
    [--changed <file>...] [--since <sha>] [--max-symbols N] [--pretty]
```
Emits a ranked **focus map** (symbols + `file:line` citations + evidence type) — no source bodies, so it guides selective reads instead of dumping context. Seeds from changed files / `--since <sha>` delta / all tracked files.

### Backend abstraction
- `builtin` (default, zero deps): regex AST extraction (`ast-extractor`) + `rg` cross-file references
- `codegraph` (optional): shells out to the codegraph CLI (`impact`/`callers`/`callees`, `--json`), defensive parsing. Because it walks the real call graph, it also answers **impact questions** — "if this file changes, which components and tests are affected" — so wiki-update knows what to re-verify after a delta

Selected via `CODE_UNDERSTANDING_BACKEND=auto|builtin|codegraph` (default `auto` = use codegraph when available, else builtin).

### wiki-update Step 3b (optional, guarded)
- Runs `code-understand --since <last_commit_synced>` between deciding what to distill and distilling
- **GUARD**: command unavailable/fails → skip and continue, normal sync unaffected
- Requires `(file:lines)` citations for architectural claims
- Mandatory **pruning rule**: stale relationships (target symbol gone / unreachable) are removed and logged, so false positives don't accumulate (owner requirement)

### doctor integration
`obsidian-wiki doctor --project .` now reports a code-understanding capability section:
`code-understanding.builtin` / `.rg` / `.codegraph` / `.codegraph-index` / `.codegraph-fresh` (basic vs enhanced mode). Missing codegraph is `warn` (exit 0); only explicit `CODE_UNDERSTANDING_BACKEND=codegraph` with a broken backend is `fail` (exit 1).

### Config & docs
- `CODE_UNDERSTANDING_BACKEND` (default `auto`)
- `CODE_UNDERSTANDING_CODEGRAPH_BIN` (optional path when binary isn't on PATH)
- Documented in `.env.example`, `docs/configuration.md`, `docs/cli.md`, and `llm-wiki` env reference; wiki-update Step 3b can offer to install codegraph for the user (with consent)

## Backward compatibility

No codegraph installed → everything works exactly as before: builtin fallback, doctor `warn` not `fail`, plain `doctor` output unchanged, existing commands untouched, zero new dependencies.

## Test evidence

- 15 new unit tests + 8 new CLI subprocess tests + 6 new doctor tests (fake codegraph CLI fixture — no binary needed in CI)
- Full suite: `552 passed, 19 subtests passed`; 4 failures pre-existing on `main` (env-dependent `test_context_pack_cli` ×2, `test_lint` ×2)
- Verified against real codegraph v1.5.0 (ranked focus map with `codegraph-edge` call-path evidence)

## Screenshots

### 📸 Section 0 — Environment: no codegraph on PATH, new build
<img width="632" height="119" alt="Screenshot 2026-08-15 at 2 39 16 AM" src="https://github.com/user-attachments/assets/d8e897ab-a0e7-4942-bf13-b2b12a5cc235" />


### 📸 Section 1 — `code-understand` auto-falls-back to builtin (exit 0)
<img width="703" height="290" alt="Screenshot 2026-08-15 at 2 41 36 AM" src="https://github.com/user-attachments/assets/c9ca0af7-8b06-4883-b5cb-a6eab649c101" />


### 📸 Section 2 — `doctor --project .` — codegraph check is `warn` not `fail` (exit 0)
<img width="860" height="403" alt="Screenshot 2026-08-15 at 2 42 57 AM" src="https://github.com/user-attachments/assets/0d7a09f1-2ba6-42db-8ef4-276a7d9373aa" />


### 📸 Section 3 — plain `doctor` — no code-understanding section (unchanged)
<img width="781" height="200" alt="Screenshot 2026-08-15 at 2 43 44 AM" src="https://github.com/user-attachments/assets/969fcbac-3259-4b4f-aa33-97160aafc514" />

### 📸 Section 4 — existing `ast-extract` still works
<img width="639" height="173" alt="Screenshot 2026-08-15 at 2 44 13 AM" src="https://github.com/user-attachments/assets/4ff2d19b-47ed-45ce-a462-274078f6bb19" />

### 📸 Section 5 — full pytest suite (`552 passed`)
<img width="582" height="122" alt="Screenshot 2026-08-15 at 2 45 41 AM" src="https://github.com/user-attachments/assets/21ba583d-4a74-4e41-a478-40eb08a844cc" />

>  4 failures are pre-existing (test_context_pack_cli ×2, test_lint ×2).

### 📸 Section 6 — explicit `CODE_UNDERSTANDING_BACKEND=codegraph` without binary → `fail` (by design)
<img width="924" height="404" alt="Screenshot 2026-08-15 at 2 46 37 AM" src="https://github.com/user-attachments/assets/f35a2efc-75f1-4820-ae4b-be5ee6c154c1" />

### 📸 Section 7 — doctor enhanced mode: all five code-understanding checks pass
```
obsidian-wiki doctor --project .
```
Expected:
```
✅ code-understanding.builtin: found 1710 AST node(s)
✅ code-understanding.rg: /opt/homebrew/bin/rg
✅ code-understanding.codegraph: /${PATH_TO_YOUR_CODEGRAPH}/codegraph/bin/codegraph
✅ code-understanding.codegraph-index: fresh
✅ code-understanding.codegraph-fresh: fresh
```
<img width="931" height="350" alt="Screenshot 2026-08-15 at 3 16 48 AM" src="https://github.com/user-attachments/assets/0e65cd8c-6eed-4e28-9411-7a339baa4703" />


### 📸 Section 8 — codegraph focus map with `codegraph-edge` call-path evidence (real project [iiwi](https://github.com/mike840609/iiwi))
```

obsidian-wiki code-understand --project . --backend codegraph \
  --changed ${EXAMPLE_FILE} --max-symbols 10 --pretty
```
Expected: `backend: codegraph` with `changed-file` seeds first, then `codegraph-edge` entries tracing cross-file callers (`resolve` in `services/scan.py`), callees (`_json_default`, `_open_for_append`), and test dependencies (`_entry` in `tests/unit/test_history.py`).

<img width="648" height="306" alt="Screenshot 2026-08-15 at 3 18 03 AM" src="https://github.com/user-attachments/assets/ec945bb3-7067-43ba-afc0-1dbba30854ef" />


### 📸 Section 9 — project without an index ([iiwi](https://github.com/mike840609/iiwi)): auto-initialized on first run, incremental after
```
obsidian-wiki code-understand --project . --backend codegraph --changed src/iiwi/history.py --pretty
```
First run auto-runs `codegraph init` (creates `.codegraph/codegraph.db`) and returns the focus map; second run queries incrementally without re-initializing.
<img width="910" height="305" alt="Screenshot 2026-08-15 at 3 19 34 AM" src="https://github.com/user-attachments/assets/a16c0297-a0d4-43b9-85c6-a82bc65310ba" />
> 50 symbols 


### 📸 Section 10 — builtin vs codegraph side-by-side on the same file
```
# builtin (no env var): AST evidence only
obsidian-wiki code-understand --project . --backend builtin --changed ${EXAMPLE_FILE}  --max-symbols 6 --pretty

# codegraph (with env var): adds cross-file edge evidence
obsidian-wiki code-understand --project . --backend codegraph --changed ${EXAMPLE_FILE}  --max-symbols 6 --pretty
```
<img width="1747" height="494" alt="Screenshot 2026-08-15 at 3 36 03 AM" src="https://github.com/user-attachments/assets/be177697-59cf-44d5-9230-69e220b4d66a" />


## Non-goals (unchanged from the issue)
- No raw symbol graph in the vault · no graph database · no compiler-grade analysis · no full-graph context dumps · no MCP integration · no `ast_extractor` call-edge changes











