### PR TITLE
fix(cli): complete code-understanding config resolution and doctor hardening

### DIFF
--- a/.skills/code-understand/SKILL.md
+++ b/.skills/code-understand/SKILL.md
@@ -86,5 +86,5 @@ or point `CODE_UNDERSTANDING_CODEGRAPH_BIN` at an existing binary. Never install
 user's go-ahead — ask first, then re-run the command.
 
 Check `obsidian-wiki doctor --project <dir>` for the `code-understanding.*` capability lines
-(`builtin`, `rg`, `codegraph`, `codegraph-index`, `codegraph-fresh`) to see what's available
-before deciding which backend to request explicitly.
+(`builtin`, `rg`, `codegraph`, `codegraph-index`, `codegraph-fresh`, `codegraph-gitignore`) to
+see what's available before deciding which backend to request explicitly.

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -612,6 +612,10 @@ The wiki is configured through environment variables (see `.env.example`). The o
 - `WIKI_STAGED_WRITES` — When `true`, all LLM-written pages go to `_staging/<category>/` for human review before promotion. See `wiki-setup` and `wiki-stage-commit` for details.
 - `CODE_UNDERSTANDING_BACKEND` — how wiki-update understands a project before distilling: `auto` (CodeGraph when available, else builtin ast-extract + rg; default), `builtin`, or `codegraph` (explicitly require; warn/error if unavailable).
 - `CODE_UNDERSTANDING_CODEGRAPH_BIN` — optional path to the codegraph binary when it isn't on PATH.
+- `CODE_UNDERSTANDING_CODEGRAPH_BIN` — optional path to the codegraph binary when it isn't on PATH.
+  Both resolve like `OBSIDIAN_VAULT_PATH`: a real environment variable wins (empty counts as
+  unset), then the nearest `.env` walking up from the project directory, then the global config
+  (`$(obsidian_wiki_config_dir)/config`), then the default.
 - `OBSIDIAN_MAX_PAGES_PER_INGEST` — cap on pages created/updated per `wiki-ingest` run (default: `15`). See `wiki-ingest`, Step 4.
 - `LINT_SCHEDULE` — how often `daily-update` also runs `wiki-lint`: `daily` \| `weekly` (default) \| `manual`. See `daily-update`, Step 4a.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -160,7 +160,7 @@ Available for automation, scripting, and debugging. Skills call some of these in
 | `cache-update <vault> <source>` | Record a source's SHA-256 in `.manifest.json` after ingest |
 | `cache-hash <path>` | Compute a file or directory hash (no manifest I/O) |
 | `ast-extract <path>` | Extract classes, functions, and imports from code — no LLM, no API calls |
-| `code-understand --project <dir> [--backend auto\|builtin\|codegraph] [--since <sha>] [--changed <file>...] [--max-symbols N] [--pretty]` | Emit a ranked code-understanding focus map (symbols + file:line citations) for a project; CodeGraph when available, built-in AST + rg otherwise. Used by wiki-update Step 3b. |
+| `code-understand --project <dir> [--backend auto\|builtin\|codegraph] [--since <sha>] [--changed <file>...] [--max-symbols N] [--pretty]` | Emit a ranked code-understanding focus map (symbols + file:line citations) for a project; CodeGraph when available, built-in AST + rg otherwise. `--backend` beats the resolved `CODE_UNDERSTANDING_*` config (env → project `.env` → global config). Used by wiki-update Step 3b. |
 
 ```bash
 obsidian-wiki graph-query /path/to/vault "transformer architecture" --pretty

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -148,6 +148,8 @@ Missing CodeGraph never breaks normal `wiki-update` or `doctor` runs. The graph 
 | `CODE_UNDERSTANDING_BACKEND` | How `wiki-update` understands project structure: `auto` (CodeGraph when available, else the built-in `ast-extract` + `rg`), `builtin` (always the built-in, dependency-free), or `codegraph` (explicitly require CodeGraph; warn/error if unavailable) | `auto` |
 | `CODE_UNDERSTANDING_CODEGRAPH_BIN` | Path to the `codegraph` binary if it isn't on `PATH` | *(empty)* |
 
+Both variables resolve like `OBSIDIAN_VAULT_PATH`: a real environment variable wins (empty counts as unset), then the nearest `.env` walking up from the project directory (stopping at the first one that sets a `CODE_UNDERSTANDING` key), then the global config ([where the global config lives](#where-the-global-config-lives)), then the default.
+
 ### Setup (optional)
 
 Install the CodeGraph CLI once to enable the enhanced backend:

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -886,12 +886,7 @@ def run_doctor(*, vault_override: str | None = None, project_dir: str | None = N
                 detail=project_check["detail"],
                 hint=project_check["hint"],
             )
-            backend_setting = (
-                os.environ.get("CODE_UNDERSTANDING_BACKEND")
-                or config.get("CODE_UNDERSTANDING_BACKEND")
-                or "auto"
-            )
-            bin_path = os.environ.get("CODE_UNDERSTANDING_CODEGRAPH_BIN")
+            backend_setting, bin_path = _resolve_code_understanding_settings(project)
             for check in _doctor_code_understanding_checks(project, backend_setting, bin_path):
                 _doctor_add(
                     checks,
@@ -1316,14 +1311,19 @@ def cmd_code_understand(args: argparse.Namespace) -> int:
     from obsidian_wiki.code_understanding import ProviderError, code_understand
 
     project = Path(args.project or os.getcwd())
+    backend, bin_path = _resolve_code_understanding_settings(project)
+    env = dict(os.environ)
+    env["CODE_UNDERSTANDING_BACKEND"] = backend
+    env["CODE_UNDERSTANDING_CODEGRAPH_BIN"] = bin_path or ""
     try:
         result = code_understand(
             project,
-            # "auto" must pass through as None so CODE_UNDERSTANDING_BACKEND can win (flag > env > auto).
+            # "auto" must pass through as None so the resolved config can win (flag > config > auto).
             backend_flag=None if args.backend == "auto" else args.backend,
             changed=args.changed,
             since=args.since,
             max_symbols=args.max_symbols,
+            env=env,
         )
     except ProviderError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -1630,6 +1630,48 @@ def _resolve_context_pack_vault(vault_arg: str | None) -> Path | None:
             break
         current = current.parent
     return _resolve_command_vault(None)
+
+
+_CODE_UNDERSTANDING_KEYS = ("CODE_UNDERSTANDING_BACKEND", "CODE_UNDERSTANDING_CODEGRAPH_BIN")
+
+
+def _resolve_code_understanding_settings(project: Path) -> tuple[str, str | None]:
+    """Resolve (backend, bin_path) for code-understanding.
+
+    Precedence: os.environ (empty = unset) > nearest walk-up project .env
+    (project dir to HOME, stopping at the first .env setting a
+    CODE_UNDERSTANDING key) > global config > defaults ("auto", None).
+    Mirrors the OBSIDIAN_VAULT_PATH resolution used by the schema/context-pack
+    commands.
+    """
+    backend = os.environ.get("CODE_UNDERSTANDING_BACKEND") or ""
+    bin_path = os.environ.get("CODE_UNDERSTANDING_CODEGRAPH_BIN") or ""
+    if not backend or not bin_path:
+        current = Path(project).resolve()
+        home = HOME.resolve()
+        local: dict[str, str] = {}
+        while True:
+            candidate = _read_config_file(current / ".env")
+            if any(key in candidate for key in _CODE_UNDERSTANDING_KEYS):
+                local = candidate
+                break
+            if current == home or current.parent == current:
+                break
+            current = current.parent
+        global_config = _read_config()
+        if not backend:
+            backend = (
+                local.get("CODE_UNDERSTANDING_BACKEND")
+                or global_config.get("CODE_UNDERSTANDING_BACKEND")
+                or "auto"
+            )
+        if not bin_path:
+            bin_path = (
+                local.get("CODE_UNDERSTANDING_CODEGRAPH_BIN")
+                or global_config.get("CODE_UNDERSTANDING_CODEGRAPH_BIN")
+                or ""
+            )
+    return backend, bin_path or None
 
 
 def cmd_trust_record(args: argparse.Namespace) -> int:

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -652,9 +652,10 @@ def _doctor_code_understanding_checks(
             "hint": "set CODE_UNDERSTANDING_CODEGRAPH_BIN or install codegraph",
         })
     else:
+        # info (not warn): optional backend absent must not fail doctor --strict.
         checks.append({
             "name": "code-understanding.codegraph",
-            "status": "warn",
+            "status": "info",
             "detail": "codegraph binary not found (builtin backend will be used)",
             "hint": "set CODE_UNDERSTANDING_CODEGRAPH_BIN or install codegraph",
         })
@@ -899,7 +900,7 @@ def run_doctor(*, vault_override: str | None = None, project_dir: str | None = N
 
 
 def _print_doctor(report: dict[str, object]) -> None:
-    icon = {"pass": "✅", "warn": "⚠️ ", "fail": "❌"}
+    icon = {"pass": "✅", "info": "ℹ️", "warn": "⚠️ ", "fail": "❌"}
     print(f"obsidian-wiki doctor: {report['status']}")
     for check in report["checks"]:
         name = check["name"]

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -666,7 +666,7 @@ def _doctor_code_understanding_checks(
             "name": "code-understanding.codegraph-index",
             "status": "pass" if initialized else "warn",
             "detail": detail,
-            "hint": "" if initialized else "run: codegraph index <project>",
+            "hint": "" if initialized else "run: obsidian-wiki code-understand --project <project>",
         })
         if initialized:
             if not (project_dir / ".git").exists():
@@ -690,7 +690,7 @@ def _doctor_code_understanding_checks(
                 "name": "code-understanding.codegraph-fresh",
                 "status": "pass" if fresh else "warn",
                 "detail": detail,
-                "hint": "" if fresh else "re-run: codegraph index <project>",
+                "hint": "" if fresh else "re-run: obsidian-wiki code-understand --project <project>",
             })
         gitignore = project_dir / ".gitignore"
         ignored = False

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -692,6 +692,22 @@ def _doctor_code_understanding_checks(
                 "detail": detail,
                 "hint": "" if fresh else "re-run: codegraph index <project>",
             })
+        gitignore = project_dir / ".gitignore"
+        ignored = False
+        if gitignore.is_file():
+            for line in gitignore.read_text(encoding="utf-8").splitlines():
+                pattern = line.strip()
+                if not pattern or pattern.startswith("#"):
+                    continue
+                if pattern in (".codegraph", ".codegraph/"):
+                    ignored = True
+                    break
+        checks.append({
+            "name": "code-understanding.codegraph-gitignore",
+            "status": "pass" if ignored else "warn",
+            "detail": ".codegraph/ is ignored" if ignored else ".codegraph/ is not ignored",
+            "hint": "" if ignored else "add .codegraph/ to .gitignore",
+        })
     return checks
 
 

--- a/tests/test_code_understand_cli.py
+++ b/tests/test_code_understand_cli.py
@@ -187,3 +187,107 @@ def test_code_understand_pretty_flag(tmp_path: Path) -> None:
     with pytest.raises(json.JSONDecodeError):
         json.loads(proc.stdout)
     assert "backend" in proc.stdout
+
+
+def test_code_understand_backend_from_project_env(tmp_path: Path) -> None:
+    """RED: backend resolution must consult <project>/.env, not just os.environ.
+
+    With CODE_UNDERSTANDING_BACKEND explicitly unset in the subprocess env, the
+    resolver should fall through to the project's `.env` (backend=codegraph +
+    fake bin). Current cli.py ignores .env, so the backend auto-falls back to
+    "builtin" and this test fails until the config-resolution chain lands.
+    """
+    project = _mini_project(tmp_path)
+    bin_path = make_fake_codegraph_bin(tmp_path)
+    (project / ".env").write_text(
+        f'CODE_UNDERSTANDING_BACKEND="codegraph"\n'
+        f'CODE_UNDERSTANDING_CODEGRAPH_BIN="{bin_path}"\n',
+        encoding="utf-8",
+    )
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--project",
+        str(project),
+        env_overrides={
+            "PATH": _NO_CODEGRAPH_PATH,
+            "CODE_UNDERSTANDING_BACKEND": "",
+            "CODE_UNDERSTANDING_CODEGRAPH_BIN": "",
+        },
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["backend"] == "codegraph"
+
+
+def test_code_understand_backend_from_global_config(tmp_path: Path) -> None:
+    """RED: backend resolution must consult ~/.obsidian-wiki/config.
+
+    With both env vars unset and no project `.env`, the resolver should fall
+    through to the global config under $HOME/.obsidian-wiki/config (backend
+    "codegraph" + fake bin). Current cli.py ignores the config file, so the
+    backend resolves to "builtin" and this test fails until the chain lands.
+    """
+    project = _mini_project(tmp_path)
+    bin_path = make_fake_codegraph_bin(tmp_path)
+    home = tmp_path / "home"
+    config_dir = home / ".obsidian-wiki"
+    config_dir.mkdir(parents=True)
+    (config_dir / "config").write_text(
+        f'CODE_UNDERSTANDING_BACKEND="codegraph"\n'
+        f'CODE_UNDERSTANDING_CODEGRAPH_BIN="{bin_path}"\n',
+        encoding="utf-8",
+    )
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--project",
+        str(project),
+        env_overrides={
+            "HOME": str(home),
+            "PATH": _NO_CODEGRAPH_PATH,
+            "CODE_UNDERSTANDING_BACKEND": "",
+            "CODE_UNDERSTANDING_CODEGRAPH_BIN": "",
+        },
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["backend"] == "codegraph"
+
+
+def test_code_understand_backend_flag_beats_project_env(tmp_path: Path) -> None:
+    """GREEN regression guard: explicit --backend beats .env config.
+
+    Once the config-resolution chain lands (project .env wins over env
+    fallback), an explicit `--backend builtin` must still take precedence over
+    the project `.env` that would otherwise select codegraph.
+    """
+    project = _mini_project(tmp_path)
+    bin_path = make_fake_codegraph_bin(tmp_path)
+    (project / ".env").write_text(
+        f'CODE_UNDERSTANDING_BACKEND="codegraph"\n'
+        f'CODE_UNDERSTANDING_CODEGRAPH_BIN="{bin_path}"\n',
+        encoding="utf-8",
+    )
+
+    proc = _run_cli(
+        project,
+        "code-understand",
+        "--backend",
+        "builtin",
+        "--project",
+        str(project),
+        env_overrides={
+            "PATH": _NO_CODEGRAPH_PATH,
+            "CODE_UNDERSTANDING_BACKEND": "",
+            "CODE_UNDERSTANDING_CODEGRAPH_BIN": "",
+        },
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["backend"] == "builtin"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -152,7 +152,7 @@ def test_doctor_project_shows_builtin_checks(tmp_path: Path) -> None:
     assert data["status"] != "fail"
 
 
-def test_doctor_project_auto_missing_codegraph_is_warn_not_fail(tmp_path: Path) -> None:
+def test_doctor_project_auto_missing_codegraph_is_info_not_fail(tmp_path: Path) -> None:
     home = tmp_path / "home"
     vault = tmp_path / "vault"
     _make_vault(vault)
@@ -168,7 +168,7 @@ def test_doctor_project_auto_missing_codegraph_is_warn_not_fail(tmp_path: Path) 
     data = json.loads(proc.stdout)
     assert data["status"] != "fail"
     check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph")
-    assert check["status"] == "warn"
+    assert check["status"] == "info"
 
 
 def test_doctor_project_explicit_codegraph_broken_fails(tmp_path: Path) -> None:
@@ -203,7 +203,11 @@ def test_doctor_project_codegraph_enhanced_checks_pass(tmp_path: Path) -> None:
     _make_vault(vault)
     _write_config(home, vault)
     _install_all_skills(home)
-    project = make_project(tmp_path, {"src/foo.py": "def foo():\n    return 1\n"}, git=False)
+    project = make_project(
+        tmp_path,
+        {"src/foo.py": "def foo():\n    return 1\n", ".gitignore": ".codegraph/\n"},
+        git=False,
+    )
     codegraph_bin = make_fake_codegraph_bin(tmp_path)
     build_index_state(project)
     no_bin = tmp_path / "no-bin"
@@ -232,7 +236,11 @@ def test_doctor_project_index_stale_warns(tmp_path: Path) -> None:
     _make_vault(vault)
     _write_config(home, vault)
     _install_all_skills(home)
-    project = make_project(tmp_path, {"src/foo.py": "def foo():\n    return 1\n"}, git=False)
+    project = make_project(
+        tmp_path,
+        {"src/foo.py": "def foo():\n    return 1\n", ".gitignore": ".codegraph/\n"},
+        git=False,
+    )
     codegraph_bin = make_fake_codegraph_bin(tmp_path)
     build_index_state(project, fresh=False)
     no_bin = tmp_path / "no-bin"
@@ -251,3 +259,208 @@ def test_doctor_project_index_stale_warns(tmp_path: Path) -> None:
     data = json.loads(proc.stdout)
     check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph-fresh")
     assert check["status"] == "warn"
+    assert check["hint"] == "re-run: obsidian-wiki code-understand --project <project>"
+
+
+def test_doctor_strict_passes_when_optional_codegraph_missing(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(
+        tmp_path,
+        {
+            "AGENTS.md": "# project\n",
+            ".cursor/rules/obsidian-wiki.mdc": "# r\n",
+            ".windsurf/rules/obsidian-wiki.md": "# r\n",
+            ".kiro/steering/obsidian-wiki.md": "# r\n",
+            ".agent/rules/obsidian-wiki.md": "# r\n",
+            ".agent/workflows/obsidian-wiki.md": "# r\n",
+            ".github/copilot-instructions.md": "# r\n",
+            "CLAUDE.md": "# a\n",
+            "GEMINI.md": "# a\n",
+            ".hermes.md": "# a\n",
+            "src/foo.py": "def foo():\n    return 1\n",
+        },
+        git=False,
+    )
+    rg_bin = tmp_path / "rg-bin"
+    rg_bin.mkdir()
+    rg_script = rg_bin / "rg"
+    rg_script.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    rg_script.chmod(0o755)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": f"{rg_bin}:{no_bin}", "CODE_UNDERSTANDING_BACKEND": "", "CODE_UNDERSTANDING_CODEGRAPH_BIN": ""},
+        "doctor",
+        "--json",
+        "--strict",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    assert data["status"] == "pass"
+
+
+def test_doctor_project_codegraph_gitignore_warns_without_gitignore(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(tmp_path, {"src/foo.py": "def foo():\n    return 1\n"}, git=False)
+    codegraph_bin = make_fake_codegraph_bin(tmp_path)
+    build_index_state(project)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": str(no_bin), "CODE_UNDERSTANDING_CODEGRAPH_BIN": str(codegraph_bin)},
+        "doctor",
+        "--json",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph-gitignore")
+    assert check["status"] == "warn"
+    assert check["detail"] == ".codegraph/ is not ignored"
+    assert check["hint"] == "add .codegraph/ to .gitignore"
+
+
+def test_doctor_project_codegraph_gitignore_ignores_comments(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(
+        tmp_path,
+        {"src/foo.py": "def foo():\n    return 1\n", ".gitignore": "# .codegraph/\n"},
+        git=False,
+    )
+    codegraph_bin = make_fake_codegraph_bin(tmp_path)
+    build_index_state(project)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": str(no_bin), "CODE_UNDERSTANDING_CODEGRAPH_BIN": str(codegraph_bin)},
+        "doctor",
+        "--json",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph-gitignore")
+    assert check["status"] == "warn"
+
+
+def test_doctor_project_codegraph_gitignore_passes_when_ignored(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(
+        tmp_path,
+        {"src/foo.py": "def foo():\n    return 1\n", ".gitignore": ".codegraph/\n"},
+        git=False,
+    )
+    codegraph_bin = make_fake_codegraph_bin(tmp_path)
+    build_index_state(project)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": str(no_bin), "CODE_UNDERSTANDING_CODEGRAPH_BIN": str(codegraph_bin)},
+        "doctor",
+        "--json",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph-gitignore")
+    assert check["status"] == "pass"
+    assert check["detail"] == ".codegraph/ is ignored"
+    assert check["hint"] == ""
+
+
+def test_doctor_project_codegraph_bin_from_project_env(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(
+        tmp_path,
+        {"src/foo.py": "def foo():\n    return 1\n", ".gitignore": ".codegraph/\n"},
+        git=False,
+    )
+    codegraph_bin = make_fake_codegraph_bin(tmp_path)
+    (project / ".env").write_text(
+        f'CODE_UNDERSTANDING_CODEGRAPH_BIN="{codegraph_bin}"\n', encoding="utf-8"
+    )
+    build_index_state(project)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": str(no_bin), "CODE_UNDERSTANDING_BACKEND": "", "CODE_UNDERSTANDING_CODEGRAPH_BIN": ""},
+        "doctor",
+        "--json",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph")
+    assert check["status"] == "pass"
+
+
+def test_doctor_project_codegraph_not_initialized_hints_run_command(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    vault = tmp_path / "vault"
+    _make_vault(vault)
+    _write_config(home, vault)
+    _install_all_skills(home)
+    project = make_project(
+        tmp_path,
+        {"src/foo.py": "def foo():\n    return 1\n", ".gitignore": ".codegraph/\n"},
+        git=False,
+    )
+    codegraph_bin = make_fake_codegraph_bin(tmp_path)
+    no_bin = tmp_path / "no-bin"
+    no_bin.mkdir()
+
+    proc = _run_env(
+        home,
+        {"PATH": str(no_bin), "CODE_UNDERSTANDING_CODEGRAPH_BIN": str(codegraph_bin)},
+        "doctor",
+        "--json",
+        "--project",
+        str(project),
+    )
+
+    assert proc.returncode == 0
+    data = json.loads(proc.stdout)
+    check = next(c for c in data["checks"] if c["name"] == "code-understanding.codegraph-index")
+    assert check["status"] == "warn"
+    assert check["hint"] == "run: obsidian-wiki code-understand --project <project>"


### PR DESCRIPTION
## Summary

Follow-up to #169 (code-graph-assisted understanding). Three correctness/polish gaps from the merge review, plus a hint unification:

1. **Doctor warns when `.codegraph/` is not gitignored** — new `code-understanding.codegraph-gitignore` check (warn-only, as designed; no auto-edit). The sidecar stays a local disposable cache, not wiki knowledge.
2. **`code-understand` + doctor honor resolved config** (the main correctness fix) — `CODE_UNDERSTANDING_BACKEND` / `CODE_UNDERSTANDING_CODEGRAPH_BIN` now resolve through the same chain as `OBSIDIAN_VAULT_PATH`: `os.environ` (empty = unset) → nearest walk-up project `.env` → the global config → defaults (`auto`, none). Previously only `os.environ` was read, so a config-file backend or bin path was silently ignored; the bin path had no config fallback at all. `obsidian_wiki/code_understanding.py` is unchanged — the resolution layer lives in the CLI.
3. **`doctor --strict` no longer fails on optional missing CodeGraph** — under `auto`/unset backend, the missing binary is `info` (not `warn`), so strict stays green; an explicitly requested `codegraph` backend with a missing binary still fails.
4. **Unified doctor hints** — `codegraph-index` / `codegraph-fresh` hints now say `obsidian-wiki code-understand --project <project>` instead of leaking `codegraph index` internals (the provider itself decides init vs sync).

## Changes

| Commit | Change |
|---|---|
| `test(cli)` | RED anchors for all four changes (TDD contract) |
| `fix(cli)` | `doctor --strict` + optional CodeGraph → `info` |
| `feat(cli)` | `code-understanding.codegraph-gitignore` check |
| `fix(cli)` | config resolution chain in CLI + doctor |
| `refactor(cli)` | unified `obsidian-wiki code-understand` hints |
| `docs(configuration)` | document the resolution order |
| `docs(skills)` | list the `codegraph-gitignore` capability; document `CODE_UNDERSTANDING_*` resolution in `llm-wiki` |

## Rebase onto latest main

Rebased onto `upstream/main` (`8a7f6af`). Resolved the `.skills/llm-wiki/SKILL.md` conflict with #172/#173 (XDG-style global config dir) by keeping both sides and aligning the newly added resolution wording with the global-config-dir convention — no hardcoded `~/.obsidian-wiki/config` remains in the skill text, `docs/`, or the resolver docstring. The global config itself still honors the legacy `~/.obsidian-wiki` location via `_resolve_global_config_dir()`, so existing installs are unaffected.

## Verification

- Full suite: **662 passed, 4 skipped, 19 subtests passed** — fresh venv inside an isolated worktree whose ancestor chain contains no `.env`; CI pytest 3.9 / 3.12 both green after the rebase
- TDD RED→GREEN captured per change
- Manual QA on the real CLI: strict-green exit 0 with `info`; gitignore warn→pass flip; bin resolved from project `.env`; `--backend` flag beats `.env`; hint strings; `ℹ️` icon renders
- `code_understanding.py` byte-identical to base

### Note on repo-root `.env`

Running the suite from a checkout whose ancestor chain contains an untracked, gitignored `.env` left by local setup (it sets a real `OBSIDIAN_VAULT_PATH`) shows pre-existing failures (`test_context_pack_cli.py`, `test_lint.py`) — the context-pack/lint walk-up finds that `.env`. Reproduced identically on pristine `fcd9101` with the same `.env` present; the tests pass on this branch from any CWD without a `.env` ancestor. Unrelated to this PR.
