### PR TITLE
feat(config): XDG-style config location, with legacy fallback (#172)

### DIFF
--- a/.agent/rules/obsidian-wiki.md
+++ b/.agent/rules/obsidian-wiki.md
@@ -9,7 +9,7 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 
 ## Quick Orientation
 
-1. Resolve config via `AGENTS.md`: honor an inline `@name` vault override first, then `.env`, then `~/.obsidian-wiki/config`. This gives `OBSIDIAN_VAULT_PATH` — where the wiki lives.
+1. Resolve config via `AGENTS.md`: honor an inline `@name` vault override first, then `.env`, then the global config (`~/.config/obsidian-wiki/config`, XDG-style; legacy `~/.obsidian-wiki/config` still honored). This gives `OBSIDIAN_VAULT_PATH` — where the wiki lives.
 2. Read `.manifest.json` at the vault root to see what's already been ingested.
 3. Skills are in `.skills/` (also at `.agents/skills/`). Each subfolder has a `SKILL.md`.
 

--- a/.cursor/rules/obsidian-wiki.mdc
+++ b/.cursor/rules/obsidian-wiki.mdc
@@ -10,7 +10,7 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 
 ## Quick Orientation
 
-1. Resolve config via `AGENTS.md`: honor an inline `@name` vault override first, then `.env`, then `~/.obsidian-wiki/config`. This gives `OBSIDIAN_VAULT_PATH` — where the wiki lives.
+1. Resolve config via `AGENTS.md`: honor an inline `@name` vault override first, then `.env`, then the global config (`~/.config/obsidian-wiki/config`, XDG-style; legacy `~/.obsidian-wiki/config` still honored). This gives `OBSIDIAN_VAULT_PATH` — where the wiki lives.
 2. Read `.manifest.json` at the vault root to see what's already been ingested.
 3. Skills are in `.skills/` (also at `.cursor/skills/`). Each subfolder has a `SKILL.md`.
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,7 +6,7 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 
 - **Purpose:** Build and maintain an Obsidian wiki using the LLM Wiki pattern (Andrej Karpathy).
 - **Tech Stack:** Markdown only. No code, no dependencies. The AI agent IS the runtime.
-- **Key Config:** Resolve config via `AGENTS.md`: inline `@name` vault override first, then `.env`, then `~/.obsidian-wiki/config`. The resolved config supplies `OBSIDIAN_VAULT_PATH`.
+- **Key Config:** Resolve config via `AGENTS.md`: inline `@name` vault override first, then `.env`, then the global config (`~/.config/obsidian-wiki/config`, XDG-style; legacy `~/.obsidian-wiki/config` still honored). The resolved config supplies `OBSIDIAN_VAULT_PATH`.
 - **Skills:** `.skills/` contains skill folders, each with a `SKILL.md` defining a workflow.
 
 ## Key Concepts

--- a/.kiro/steering/obsidian-wiki.md
+++ b/.kiro/steering/obsidian-wiki.md
@@ -8,7 +8,7 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 
 ## Quick Orientation
 
-1. Resolve config via `AGENTS.md`: honor an inline `@name` vault override first, then `.env`, then `~/.obsidian-wiki/config`. This gives `OBSIDIAN_VAULT_PATH` — where the wiki lives.
+1. Resolve config via `AGENTS.md`: honor an inline `@name` vault override first, then `.env`, then the global config (`~/.config/obsidian-wiki/config`, XDG-style; legacy `~/.obsidian-wiki/config` still honored). This gives `OBSIDIAN_VAULT_PATH` — where the wiki lives.
 2. Read `.manifest.json` at the vault root to see what's already been ingested.
 3. Skills are in `.skills/` (also at `.kiro/skills/`). Each subfolder has a `SKILL.md`.
 

--- a/.skills/claude-history-ingest/SKILL.md
+++ b/.skills/claude-history-ingest/SKILL.md
@@ -16,7 +16,7 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `CLAUDE_HISTORY_PATH` (defaults to `~/.claude`)
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `CLAUDE_HISTORY_PATH` (defaults to `~/.claude`)
 2. Read `.manifest.json` at the vault root to check what's already been ingested
 3. Read `index.md` at the vault root to know what the wiki already contains
 4. **Project Scoping** — read `WIKI_SKIP_PROJECTS` from config (comma-separated substrings). Exclude any project directory whose name contains one of them from **every** step below (scan, delta, sampling, manifest writes). If the user names extra projects to skip this run, add them. Apply the exclusion **once, uniformly** — don't hand-write `grep -v` filters into individual commands, which drifts between the scan and manifest steps.

--- a/.skills/codex-history-ingest/SKILL.md
+++ b/.skills/codex-history-ingest/SKILL.md
@@ -16,7 +16,7 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `CODEX_HISTORY_PATH` (defaults to `~/.codex`)
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `CODEX_HISTORY_PATH` (defaults to `~/.codex`)
 2. Read `.manifest.json` at the vault root to check what has already been ingested
 3. Read `index.md` at the vault root to understand what the wiki already contains
 

--- a/.skills/copilot-history-ingest/SKILL.md
+++ b/.skills/copilot-history-ingest/SKILL.md
@@ -19,7 +19,7 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `COPILOT_HISTORY_PATH` (defaults to `~/.copilot/session-state`), and `COPILOT_VSCODE_STORAGE_PATH` (VS Code `workspaceStorage`; platform-specific — ask the user if absent)
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `COPILOT_HISTORY_PATH` (defaults to `~/.copilot/session-state`), and `COPILOT_VSCODE_STORAGE_PATH` (VS Code `workspaceStorage`; platform-specific — ask the user if absent)
 2. Read `.manifest.json` at the vault root to check what's already been ingested
 3. Read `index.md` at the vault root to know what the wiki already contains
 

--- a/.skills/cross-linker/SKILL.md
+++ b/.skills/cross-linker/SKILL.md
@@ -18,7 +18,7 @@ You are weaving the wiki's knowledge graph tighter by finding and inserting miss
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `index.md` to get the full inventory of pages and their one-line descriptions
 3. Skim `log.md` to see what was recently ingested (focus linking effort on new pages)
 

--- a/.skills/daily-update/SKILL.md
+++ b/.skills/daily-update/SKILL.md
@@ -14,11 +14,11 @@ You run a lightweight maintenance pass over the wiki: check source freshness, re
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_WIKI_REPO`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_WIKI_REPO`.
 2. **Derive vault-scoped state dir** — all runtime state is scoped to the resolved vault, not global:
    ```bash
    VAULT_ID=$(echo "$OBSIDIAN_VAULT_PATH" | md5sum 2>/dev/null | cut -c1-8 || md5 -q - <<< "$OBSIDIAN_VAULT_PATH" | cut -c1-8)
-   STATE_DIR="$HOME/.obsidian-wiki/state/$VAULT_ID"
+   STATE_DIR="$(obsidian_wiki_config_dir)/state/$VAULT_ID"
    mkdir -p "$STATE_DIR"
    ```
 3. Read `$OBSIDIAN_VAULT_PATH/.manifest.json`.
@@ -159,7 +159,7 @@ This initializes `$STATE_DIR/.last_update` so the terminal notification works im
 Tell the user:
 - The cron runs daily at 9 AM (or on next login if missed)
 - Terminal notifications appear when the wiki is >20 hours stale
-- State is stored in `~/.obsidian-wiki/state/<vault-id>/` — supports multiple vaults independently
+- State is stored in `<global config dir>/state/<vault-id>/` (XDG-style `~/.config/obsidian-wiki` by default, or the legacy `~/.obsidian-wiki` if that already exists) — supports multiple vaults independently
 - They can run `/daily-update` anytime to force a sync
 - Logs go to `/tmp/obsidian-wiki-daily.log`
 

--- a/.skills/graph-colorize/SKILL.md
+++ b/.skills/graph-colorize/SKILL.md
@@ -18,7 +18,7 @@ Obsidian stores graph settings in `<vault>/.obsidian/graph.json`. The `colorGrou
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Confirm `$OBSIDIAN_VAULT_PATH/.obsidian/` exists. If it doesn't, the vault has never been opened in Obsidian — tell the user to open the vault once in Obsidian, then re-run.
 3. **Warn the user if Obsidian is likely open**: Obsidian overwrites `graph.json` on close. Tell them to close the vault first, or be ready to reload (Cmd/Ctrl+R) and not touch the graph settings until they reload.
 

--- a/.skills/hermes-history-ingest/SKILL.md
+++ b/.skills/hermes-history-ingest/SKILL.md
@@ -16,7 +16,7 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `HERMES_HISTORY_PATH` (defaults to `~/.hermes`)
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `HERMES_HISTORY_PATH` (defaults to `~/.hermes`)
 2. Read `.manifest.json` at the vault root to check what has already been ingested
 3. Read `index.md` at the vault root to understand what the wiki already contains
 

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -531,13 +531,31 @@ Every write skill reads `OBSIDIAN_LINK_FORMAT` from config before generating lin
 
 ## Config Resolution Protocol
 
-**All skills must resolve config using this algorithm — do not hard-code `.env` or `~/.obsidian-wiki/config` directly.** This ensures single-vault, multi-vault, project-local, and VPS setups all work correctly.
+**All skills must resolve config using this algorithm — do not hard-code `.env` or the global config path directly.** This ensures single-vault, multi-vault, project-local, and VPS setups all work correctly.
+
+### Global config directory
+
+The global config directory is **XDG-style**: `$XDG_CONFIG_HOME/obsidian-wiki` (default `~/.config/obsidian-wiki`). Installs that already have a `~/.obsidian-wiki` directory keep using it — so an existing setup never breaks — but any **new** install lands under the XDG path. Resolve it with:
+
+```
+obsidian_wiki_config_dir() {
+  local xdg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-wiki"
+  local legacy_dir="$HOME/.obsidian-wiki"
+  if [[ -d "$legacy_dir" && ! -e "$xdg_dir" ]]; then
+    echo "$legacy_dir"
+  else
+    echo "$xdg_dir"
+  fi
+}
+```
+
+Everywhere below, "the global config dir" means `$(obsidian_wiki_config_dir)`, and "the global config" means `$(obsidian_wiki_config_dir)/config`.
 
 ### Resolution order
 
-0. **Inline vault override (`@name`)** — if the user's request contains an `@<name>` token (e.g. `@work save this`, `query @personal about X`), resolve `~/.obsidian-wiki/config.<name>` directly and use its `OBSIDIAN_VAULT_PATH`. This **overrides** both the CWD `.env` walk-up and the active symlink, and applies to **that invocation only** — never run `ln -sf` or otherwise change the active vault for an `@name` request. If `~/.obsidian-wiki/config.<name>` doesn't exist, tell the user it doesn't exist and list the available vaults (the `wiki-switch` **List** logic), then stop — do **not** silently fall back to the default. The `@name` is a routing directive, not content: strip it out before treating the rest of the request as the actual instruction or page text.
+0. **Inline vault override (`@name`)** — if the user's request contains an `@<name>` token (e.g. `@work save this`, `query @personal about X`), resolve `<global config dir>/config.<name>` directly and use its `OBSIDIAN_VAULT_PATH`. This **overrides** both the CWD `.env` walk-up and the active symlink, and applies to **that invocation only** — never run `ln -sf` or otherwise change the active vault for an `@name` request. If `<global config dir>/config.<name>` doesn't exist, tell the user it doesn't exist and list the available vaults (the `wiki-switch` **List** logic), then stop — do **not** silently fall back to the default. The `@name` is a routing directive, not content: strip it out before treating the rest of the request as the actual instruction or page text.
 1. **Walk up from CWD** — look for a `.env` file in the current directory, then each parent, up to `$HOME`. Stop at the first `.env` that contains `OBSIDIAN_VAULT_PATH`.
-2. **Global config** — if no local `.env` found, read `~/.obsidian-wiki/config`.
+2. **Global config** — if no local `.env` found, read the global config (`$(obsidian_wiki_config_dir)/config`).
 3. **Prompt setup** — if neither exists, tell the user: "No config found. Run `wiki-setup` to initialize your wiki."
 
 `@name` is a **per-invocation override** — it targets one vault for one request. `/wiki-switch <name>` is the **persistent default** — it re-points the active symlink for all future requests. Use `@name` to touch the other vault from anywhere without disturbing your default ("brain") vault.
@@ -545,8 +563,10 @@ Every write skill reads `OBSIDIAN_LINK_FORMAT` from config before generating lin
 ```
 find_config() {
   # $1 = parsed @name from the request, if any (else empty)
+  local config_dir
+  config_dir="$(obsidian_wiki_config_dir)"
   if [[ -n "$1" ]]; then
-    [[ -f "$HOME/.obsidian-wiki/config.$1" ]] && { echo "$HOME/.obsidian-wiki/config.$1"; return; }
+    [[ -f "$config_dir/config.$1" ]] && { echo "$config_dir/config.$1"; return; }
     echo ""; return   # named vault missing → caller reports + lists, no fallback
   fi
   dir="$PWD"
@@ -554,7 +574,7 @@ find_config() {
     [[ -f "$dir/.env" ]] && grep -q "OBSIDIAN_VAULT_PATH" "$dir/.env" && { echo "$dir/.env"; return; }
     dir="$(dirname "$dir")"
   done
-  [[ -f "$HOME/.obsidian-wiki/config" ]] && { echo "$HOME/.obsidian-wiki/config"; return; }
+  [[ -f "$config_dir/config" ]] && { echo "$config_dir/config"; return; }
   echo ""
 }
 ```
@@ -565,14 +585,14 @@ Skills that write runtime state (e.g. `daily-update`) must scope that state to t
 
 ```
 VAULT_ID=$(echo "$OBSIDIAN_VAULT_PATH" | md5sum 2>/dev/null || md5 -q - <<< "$OBSIDIAN_VAULT_PATH" | cut -c1-8)
-STATE_DIR="$HOME/.obsidian-wiki/state/$VAULT_ID"
+STATE_DIR="$(obsidian_wiki_config_dir)/state/$VAULT_ID"
 ```
 
 ### Standard "Before You Start" block
 
 Every skill's setup section should read:
 
-> **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md`. Honor an inline `@name` override first, then walk up from CWD for `.env`, fall back to `~/.obsidian-wiki/config`, else prompt setup. This gives `OBSIDIAN_VAULT_PATH` and any tool-specific path overrides.
+> **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md`. Honor an inline `@name` override first, then walk up from CWD for `.env`, fall back to the global config, else prompt setup. This gives `OBSIDIAN_VAULT_PATH` and any tool-specific path overrides.
 
 ## Environment Variables
 

--- a/.skills/memory-bridge/SKILL.md
+++ b/.skills/memory-bridge/SKILL.md
@@ -15,7 +15,7 @@ You are helping the user browse and compare their Obsidian wiki knowledge filter
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Read `$OBSIDIAN_VAULT_PATH/.manifest.json` — this is the source-of-truth for what tool produced what.
 3. Read `$OBSIDIAN_VAULT_PATH/index.md` for page titles and one-line descriptions.
 

--- a/.skills/openclaw-history-ingest/SKILL.md
+++ b/.skills/openclaw-history-ingest/SKILL.md
@@ -16,7 +16,7 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OPENCLAW_HISTORY_PATH` (defaults to `~/.openclaw`)
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OPENCLAW_HISTORY_PATH` (defaults to `~/.openclaw`)
 2. Read `.manifest.json` at the vault root to check what has already been ingested
 3. Read `index.md` at the vault root to understand what the wiki already contains
 

--- a/.skills/pi-history-ingest/SKILL.md
+++ b/.skills/pi-history-ingest/SKILL.md
@@ -18,7 +18,7 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `PI_HISTORY_PATH` (defaults to `~/.pi/agent/sessions`)
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `PI_HISTORY_PATH` (defaults to `~/.pi/agent/sessions`)
 2. Read `.manifest.json` at the vault root to check what has already been ingested
 3. Read `index.md` at the vault root to understand what the wiki already contains
 

--- a/.skills/tag-taxonomy/SKILL.md
+++ b/.skills/tag-taxonomy/SKILL.md
@@ -15,7 +15,7 @@ You are enforcing consistent tagging across the wiki by normalizing tags to a co
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`
 2. Read `$OBSIDIAN_VAULT_PATH/_meta/taxonomy.md` — this is the canonical tag list
 3. Read `index.md` to understand the wiki's scope
 

--- a/.skills/wiki-agent/SKILL.md
+++ b/.skills/wiki-agent/SKILL.md
@@ -34,7 +34,7 @@ If no query is given, default to **recent sessions mode**: ingest the last 5 unp
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Read `$OBSIDIAN_VAULT_PATH/.manifest.json` → know what's already ingested.
 3. Read `$OBSIDIAN_VAULT_PATH/hot.md` if it exists → warm context on recent wiki activity.
 

--- a/.skills/wiki-capture/SKILL.md
+++ b/.skills/wiki-capture/SKILL.md
@@ -99,7 +99,7 @@ After writing the derived correction, link the immutable source to the created/u
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand existing wiki content (avoid duplicates)
 3. Read `$OBSIDIAN_VAULT_PATH/hot.md` if it exists — it gives context on recent activity
 

--- a/.skills/wiki-context-pack/SKILL.md
+++ b/.skills/wiki-context-pack/SKILL.md
@@ -16,7 +16,7 @@ This is a read-only skill. It must not modify the vault, including `log.md`,
 
 1. Resolve config using the Config Resolution Protocol in
    `llm-wiki/SKILL.md`: inline `@name`, then walk up from CWD for `.env`,
-   then `~/.obsidian-wiki/config`.
+   then the global config.
 2. If `$OBSIDIAN_VAULT_PATH/AGENTS.md` exists, read it as trusted owner
    conventions. Do not include that file as a knowledge excerpt.
 3. Canonicalize the configured vault to a physical absolute path before

--- a/.skills/wiki-dashboard/SKILL.md
+++ b/.skills/wiki-dashboard/SKILL.md
@@ -14,7 +14,7 @@ Two tools available: **Obsidian Bases** (native, GUI-driven, no plugin) and **Da
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand what categories and pages exist.
 3. Ask the user what they want to view if not specified — folder, tag, category, date range?
 4. Ask if they have Dataview installed if you're unsure which tool to use.

--- a/.skills/wiki-dedup/SKILL.md
+++ b/.skills/wiki-dedup/SKILL.md
@@ -17,7 +17,7 @@ You are finding and merging wiki pages that cover the same concept under differe
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT`.
 2. Read `index.md` to get the full page inventory with one-line descriptions and tags.
 3. Read `log.md` briefly — if a dedup run just happened, note what was already merged.
 

--- a/.skills/wiki-digest/SKILL.md
+++ b/.skills/wiki-digest/SKILL.md
@@ -15,7 +15,7 @@ You are generating a human-readable digest of recent wiki activity: what was lea
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT`.
 2. **Parse the period** from the user's request:
    - "daily" / "today" / "yesterday" → last 24 hours
    - "weekly" / "this week" / no argument (default) → last 7 days

--- a/.skills/wiki-export/SKILL.md
+++ b/.skills/wiki-export/SKILL.md
@@ -16,7 +16,7 @@ You are exporting the wiki's wikilink graph to structured formats so it can be u
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`
 2. Confirm the vault has pages to export — if fewer than 5 pages exist, warn the user and stop
 
 ## Project Filter (optional)

--- a/.skills/wiki-import/SKILL.md
+++ b/.skills/wiki-import/SKILL.md
@@ -19,7 +19,7 @@ Either way, the import writes pages with correct frontmatter and wikilinks, then
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Read `$OBSIDIAN_VAULT_PATH/AGENTS.md` if it exists — apply any owner-specific conventions.
 
 ## Step 1: Locate and Detect Source Type

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -20,7 +20,7 @@ You are ingesting source documents into an Obsidian wiki. Your job is not to sum
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `OBSIDIAN_LINK_FORMAT` (default: `wikilink`), and `WIKI_STAGED_WRITES`. Only read the specific variables you need — do not log, echo, or reference any other values from these files.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `OBSIDIAN_LINK_FORMAT` (default: `wikilink`), and `WIKI_STAGED_WRITES`. Only read the specific variables you need — do not log, echo, or reference any other values from these files.
 2. **Check `WIKI_STAGED_WRITES`** — if set to `true`, all new and updated category pages go to `_staging/<category>/` instead of their final location. Tell the user at the start of the ingest: "Staged writes mode is enabled — pages will land in `_staging/` for your review. Run `/wiki-stage-commit` when ready to promote."
 3. Read `.manifest.json` at the vault root to check what's already been ingested
 4. Read `index.md` to understand current wiki content

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -18,7 +18,7 @@ You are performing a health check on an Obsidian wiki. Your goal is to find and 
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` plus any `OBSIDIAN_ALLOWED_LIFECYCLES`, `OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES`, `OBSIDIAN_REQUIRED_TRUST_FIELDS`, and `OBSIDIAN_SCHEMA_SOURCE` values.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` plus any `OBSIDIAN_ALLOWED_LIFECYCLES`, `OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES`, `OBSIDIAN_REQUIRED_TRUST_FIELDS`, and `OBSIDIAN_SCHEMA_SOURCE` values.
 2. **Read owner rules** — if `$OBSIDIAN_VAULT_PATH/AGENTS.md` exists, read it before interpreting any schema. Owner rules override framework defaults.
 3. **Form the effective schema** — record the schema source locator plus effective required/optional frontmatter, lifecycle values, relationship types, and provenance markers. Framework values are defaults; preserve owner extensions and relaxed requiredness exactly. Never coerce an owner type to a framework type.
 4. Read `index.md` for the full page inventory

--- a/.skills/wiki-query/SKILL.md
+++ b/.skills/wiki-query/SKILL.md
@@ -32,7 +32,7 @@ If the user's message contains a new finding, an action request ("save this", "b
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). For cross-project queries without `@name`, prefer `~/.obsidian-wiki/config` when present, even if it is a symlink to the vault `.env`. This gives `OBSIDIAN_VAULT_PATH` and any QMD variables. Works from any project directory.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). For cross-project queries without `@name`, prefer the global config when present, even if it is a symlink to the vault `.env`. This gives `OBSIDIAN_VAULT_PATH` and any QMD variables. Works from any project directory.
 2. **Load QMD settings from the resolved config** before deciding retrieval strategy. If `QMD_WIKI_COLLECTION` is set, treat QMD as available subject only to transport/tool checks below. If it is empty or unset, say briefly why QMD is being skipped before using grep/page reads.
 3. If `$OBSIDIAN_VAULT_PATH/hot.md` exists, read it first — it gives you instant context on recent activity. If the user's question is about something ingested recently, hot.md may answer it before you even open `index.md`.
 4. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand the wiki's scope and structure

--- a/.skills/wiki-rebuild/SKILL.md
+++ b/.skills/wiki-rebuild/SKILL.md
@@ -14,7 +14,7 @@ You are performing a destructive operation on the wiki. Always archive first, al
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and optional QMD settings such as `QMD_WIKI_COLLECTION`
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and optional QMD settings such as `QMD_WIKI_COLLECTION`
 2. Read `.manifest.json` to understand current state
 3. **Confirm the user's intent.** This skill supports three modes:
    - **Archive only** — snapshot current wiki, no rebuild

--- a/.skills/wiki-research/SKILL.md
+++ b/.skills/wiki-research/SKILL.md
@@ -13,7 +13,7 @@ You are running an autonomous research loop on a topic, synthesizing what you fi
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand what's already in the wiki — don't re-research things the wiki covers well
 3. Read `$OBSIDIAN_VAULT_PATH/hot.md` if it exists — it surfaces recent context
 4. Check `$OBSIDIAN_VAULT_PATH/references/research-config.md` if it exists — it may define source preferences, domains to skip, or confidence rules for this vault

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -230,13 +230,16 @@ inconclusive sessions are skipped automatically.
    - `<REPO_PATH>/.claude/hooks/wiki-stop-capture.sh` — source checkout.
 
    If neither exists (e.g. an older wheel that predates bundling the hook), fetch the canonical
-   copy to a stable location and point at that instead:
+   copy to a stable location and point at that instead. Use the global config dir from the
+   Config Resolution Protocol in `llm-wiki/SKILL.md` (XDG-style `~/.config/obsidian-wiki` by
+   default, or the legacy `~/.obsidian-wiki` if that already exists):
 
    ```bash
-   mkdir -p ~/.obsidian-wiki/hooks
+   CONFIG_DIR="$( [[ -d "$HOME/.obsidian-wiki" && ! -e "${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-wiki" ]] && echo "$HOME/.obsidian-wiki" || echo "${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-wiki" )"
+   mkdir -p "$CONFIG_DIR/hooks"
    curl -fsSL https://raw.githubusercontent.com/Ar9av/obsidian-wiki/main/.claude/hooks/wiki-stop-capture.sh \
-     -o ~/.obsidian-wiki/hooks/wiki-stop-capture.sh
-   chmod +x ~/.obsidian-wiki/hooks/wiki-stop-capture.sh
+     -o "$CONFIG_DIR/hooks/wiki-stop-capture.sh"
+   chmod +x "$CONFIG_DIR/hooks/wiki-stop-capture.sh"
    ```
 
    Use the resolved absolute path as `<HOOK_PATH>` below.

--- a/.skills/wiki-status/SKILL.md
+++ b/.skills/wiki-status/SKILL.md
@@ -16,7 +16,7 @@ You are computing the current state of the wiki: what's been ingested, what's ne
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `CLAUDE_HISTORY_PATH`, and `CODEX_HISTORY_PATH`.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `CLAUDE_HISTORY_PATH`, and `CODEX_HISTORY_PATH`.
 2. Read `.manifest.json` at the vault root — this is the ingest tracking ledger
 
 ## The Manifest

--- a/.skills/wiki-switch/SKILL.md
+++ b/.skills/wiki-switch/SKILL.md
@@ -4,20 +4,29 @@ description: >
   Switch between multiple Obsidian wiki vault profiles. Use this skill when the user says
   "/wiki-switch NAME", "switch to my work wiki", "switch vault", "change wiki", "which wiki am I on",
   "list my wikis", "show my vaults", "create a new vault config", or "add a new wiki profile".
-  The skill manages named config files at ~/.obsidian-wiki/config.NAME and activates one by
-  symlinking it to ~/.obsidian-wiki/config.
+  The skill manages named config files at <global config dir>/config.NAME and activates one by
+  symlinking it to <global config dir>/config.
 ---
 
 # Wiki Switch — Manage Multiple Vault Profiles
 
-Each vault is a complete config file at `~/.obsidian-wiki/config.<name>`. The active vault is
-whichever file `~/.obsidian-wiki/config` symlinks to. Switching vaults means re-pointing that symlink.
+**Global config dir.** Every path below is relative to the global config dir, resolved per the
+Config Resolution Protocol in `llm-wiki/SKILL.md`: `$XDG_CONFIG_HOME/obsidian-wiki` (default
+`~/.config/obsidian-wiki`), or the legacy `~/.obsidian-wiki` if that already exists on disk. Resolve
+it once per invocation with:
+
+```bash
+CONFIG_DIR="$( [[ -d "$HOME/.obsidian-wiki" && ! -e "${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-wiki" ]] && echo "$HOME/.obsidian-wiki" || echo "${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-wiki" )"
+```
+
+Each vault is a complete config file at `$CONFIG_DIR/config.<name>`. The active vault is
+whichever file `$CONFIG_DIR/config` symlinks to. Switching vaults means re-pointing that symlink.
 
 **Switch vs. inline targeting.** `/wiki-switch <name>` changes your **persistent default** (re-points
 the symlink, affecting all future requests). To touch a different vault for just one request without
 changing your default, use the inline **`@name`** override in any request (e.g. `@work save this`,
 `wiki-query @personal about X`). The `@name` override is handled by the **Config Resolution Protocol**
-in `llm-wiki/SKILL.md`, not by this skill — it resolves `~/.obsidian-wiki/config.<name>` for that one
+in `llm-wiki/SKILL.md`, not by this skill — it resolves `$CONFIG_DIR/config.<name>` for that one
 invocation and never re-points the symlink.
 
 ## Dispatch
@@ -39,10 +48,10 @@ Parse the invocation and route to the right section:
 
 Activate a named vault profile.
 
-1. Verify `~/.obsidian-wiki/config.<name>` exists. If not, tell the user the vault doesn't exist and list what's available (run **List**).
+1. Verify `$CONFIG_DIR/config.<name>` exists. If not, tell the user the vault doesn't exist and list what's available (run **List**).
 2. Run:
    ```bash
-   ln -sf ~/.obsidian-wiki/config.<name> ~/.obsidian-wiki/config
+   ln -sf "$CONFIG_DIR/config.<name>" "$CONFIG_DIR/config"
    ```
 3. Read `OBSIDIAN_VAULT_PATH` from the newly active config.
 4. Confirm to the user:
@@ -57,8 +66,8 @@ Activate a named vault profile.
 
 Show all registered vault profiles and which is active.
 
-1. Find all files matching `~/.obsidian-wiki/config.*` (exclude `config` itself — that's the symlink).
-2. Resolve the current symlink target: `readlink ~/.obsidian-wiki/config`
+1. Find all files matching `$CONFIG_DIR/config.*` (exclude `config` itself — that's the symlink).
+2. Resolve the current symlink target: `readlink "$CONFIG_DIR/config"`
 3. For each config file, read the first non-empty comment line (lines starting with `#`) as a human description of the vault. Fall back to the file's suffix as the label if no comment exists.
 4. Display:
    ```
@@ -74,8 +83,8 @@ Show all registered vault profiles and which is active.
 
 Print the full config for a vault.
 
-- If a name is given, read `~/.obsidian-wiki/config.<name>`.
-- If no name given, read `~/.obsidian-wiki/config` (the active vault).
+- If a name is given, read `$CONFIG_DIR/config.<name>`.
+- If no name given, read `$CONFIG_DIR/config` (the active vault).
 - If the file doesn't exist, tell the user and list what's available.
 - Print the file contents verbatim (redact any lines containing `API_KEY` or `SECRET` — show `***` instead of the value).
 
@@ -85,10 +94,10 @@ Print the full config for a vault.
 
 Scaffold a new vault config from the current active config as a template.
 
-1. Check `~/.obsidian-wiki/config.<name>` doesn't already exist. Abort if it does.
+1. Check `$CONFIG_DIR/config.<name>` doesn't already exist. Abort if it does.
 2. Copy the active config:
    ```bash
-   cp ~/.obsidian-wiki/config ~/.obsidian-wiki/config.<name>
+   cp "$CONFIG_DIR/config" "$CONFIG_DIR/config.<name>"
    ```
 3. Read the copied config. Config files use `# --- Section name ---` comment headers to group fields into sections (e.g., `# --- Vault-specific ---`, `# --- Vault-independent ---`, `# --- Secrets ---`). Use these sections to determine what to ask about:
    - Fields in sections labeled "vault-specific", "paths", or similar → ask the user for new values
@@ -96,11 +105,11 @@ Scaffold a new vault config from the current active config as a template.
    - Fields in sections labeled "secrets" → ask if the new vault uses the same credentials or different ones
    - If there are no section headers, present all fields and let the user decide which to change
 4. Ask the user for updated values for the vault-specific fields. Use the current values as visible defaults — the user only needs to supply what differs.
-5. Write the updated values into `~/.obsidian-wiki/config.<name>`.
+5. Write the updated values into `$CONFIG_DIR/config.<name>`.
 6. Update the top comment line to describe the new vault (e.g., `# Obsidian Wiki — <name> vault`).
 7. Confirm:
    ```
-   Created: ~/.obsidian-wiki/config.<name>
+   Created: $CONFIG_DIR/config.<name>
    Run `/wiki-switch <name>` to activate it, then run `wiki-setup` to initialise the new vault.
    ```
    Do not switch automatically — let the user decide when to activate.

--- a/.skills/wiki-synthesize/SKILL.md
+++ b/.skills/wiki-synthesize/SKILL.md
@@ -14,7 +14,7 @@ You are scanning the wiki for concepts that co-occur across many pages but have 
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `index.md` to get the full page inventory.
 3. Read `hot.md` if it exists — it surfaces recent activity and active threads that may already point to synthesis opportunities.
 4. Read `_meta/taxonomy.md` to understand the tag vocabulary.

--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -14,7 +14,7 @@ You are distilling knowledge from the current project into the user's Obsidian w
 
 ## Before You Start
 
-1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → `~/.obsidian-wiki/config` → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_WIKI_REPO`, `OBSIDIAN_LINK_FORMAT` (`wikilink` default or `markdown`), and optional QMD settings such as `QMD_WIKI_COLLECTION`. Works from any project directory.
+1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_WIKI_REPO`, `OBSIDIAN_LINK_FORMAT` (`wikilink` default or `markdown`), and optional QMD settings such as `QMD_WIKI_COLLECTION`. Works from any project directory.
 3. Read `$OBSIDIAN_VAULT_PATH/.manifest.json` to check if this project has been synced before.
 4. Read `$OBSIDIAN_VAULT_PATH/index.md` to know what the wiki already contains.
 

--- a/.windsurf/rules/obsidian-wiki.md
+++ b/.windsurf/rules/obsidian-wiki.md
@@ -9,7 +9,7 @@ This project is a **skill-based framework** for building and maintaining an Obsi
 
 ## Quick Orientation
 
-1. Resolve config via `AGENTS.md`: honor an inline `@name` vault override first, then `.env`, then `~/.obsidian-wiki/config`. This gives `OBSIDIAN_VAULT_PATH` — where the wiki lives.
+1. Resolve config via `AGENTS.md`: honor an inline `@name` vault override first, then `.env`, then the global config (`~/.config/obsidian-wiki/config`, XDG-style; legacy `~/.obsidian-wiki/config` still honored). This gives `OBSIDIAN_VAULT_PATH` — where the wiki lives.
 2. Read `.manifest.json` at the vault root to see what's already been ingested.
 3. Skills are in `.skills/` (also at `.windsurf/skills/`). Each subfolder has a `SKILL.md`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,16 +10,18 @@ A **skill-based framework** for building and maintaining an Obsidian knowledge b
 
 Resolve config using the Config Resolution Protocol in `llm-wiki/SKILL.md`:
 
-0. **Inline vault override (`@name`)** — if the request contains an `@<name>` token, resolve `~/.obsidian-wiki/config.<name>` directly, overriding the steps below. See "Targeting a specific vault" right after this list.
+0. **Inline vault override (`@name`)** — if the request contains an `@<name>` token, resolve `<global config dir>/config.<name>` directly, overriding the steps below. See "Targeting a specific vault" right after this list.
 1. **Walk up from CWD** — look for a `.env` file in the current directory, then each parent, up to `$HOME`. Stop at the first `.env` that contains `OBSIDIAN_VAULT_PATH`.
-2. **Global config** — if no local `.env` is found, read `~/.obsidian-wiki/config`.
+2. **Global config** — if no local `.env` is found, read `<global config dir>/config`.
 3. **Prompt setup** — if neither exists, tell the user to run `wiki-setup`.
+
+The **global config dir** is XDG-style: `$XDG_CONFIG_HOME/obsidian-wiki` (default `~/.config/obsidian-wiki`). Installs that already have a `~/.obsidian-wiki` directory keep using it, so existing setups never break; new installs use the XDG path.
 
 The resolved config sets `OBSIDIAN_VAULT_PATH` (where the wiki lives). It may also set `OBSIDIAN_WIKI_REPO` (where this repo is cloned) and other optional variables.
 
 ### Targeting a specific vault
 
-You can maintain multiple vaults (each a `~/.obsidian-wiki/config.<name>` file managed by `wiki-switch`) and reach any of them from any directory:
+You can maintain multiple vaults (each a `<global config dir>/config.<name>` file managed by `wiki-switch`) and reach any of them from any directory:
 
 - **`@name` (per-invocation override)** — prefix or mention `@<name>` anywhere in a request to route that one command to that vault, e.g. `@work save this` or `wiki-query @personal what do I know about X`. It overrides the CWD `.env` and the active symlink **for that invocation only** — it does **not** flip your default vault. If `config.<name>` doesn't exist, the skill reports it and lists available vaults; do **not** silently fall back to the default. The `@name` is stripped before the rest of the request is used as content.
 - **`/wiki-switch <name>` (persistent default)** — re-points the active symlink so all future requests use that vault. This is your default "brain" vault; use `@name` to dip into the other one without switching.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ A `.manifest.json` tracks every source that's been ingested — path, timestamps
 
 ## The loop
 
-1. Agent resolves the vault path (`@name` → `.env` → `~/.obsidian-wiki/config`)
+1. Agent resolves the vault path (`@name` → `.env` → global config)
 2. Agent reads `.manifest.json` to know what's already been done
 3. Agent reads the relevant skill for instructions
 4. Agent uses its built-in tools to do the work

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,7 +14,7 @@ Running `obsidian-wiki` with no subcommand defaults to `setup`.
 
 | Command | What it does |
 |---|---|
-| `setup` | Install skills into your agents and write `~/.obsidian-wiki/config` |
+| `setup` | Install skills into your agents and write the global config |
 | `info` | Show install paths, version, and resolved config |
 | `list` | List the bundled skills |
 | `doctor` | Health-check config, vault shape, bootstrap assets, and installed skills; with `--project`, also reports the code-understanding capability section |
@@ -46,7 +46,7 @@ obsidian-wiki query "rate limiting" --top 12 --max-read 5 --json
 
 obsidian-wiki lint                     # uses the configured vault
 obsidian-wiki lint /path/to/vault --strict
-obsidian-wiki lint @research --json    # uses ~/.obsidian-wiki/config.research only
+obsidian-wiki lint @research --json    # uses <config dir>/config.research only
 obsidian-wiki lint --strict-trust      # fail on trust-ledger problems, not just warn
 obsidian-wiki lint --allow-lifecycle active --allow-relationship-type synthesizes \
   --required-trust-field updated --schema-source /path/to/vault/AGENTS.md

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,16 +4,22 @@
 
 Skills resolve the vault path in this order:
 
-0. **Inline vault override (`@name`)** — an `@<name>` token anywhere in a request resolves `~/.obsidian-wiki/config.<name>` directly, overriding everything below, **for that request only**.
+0. **Inline vault override (`@name`)** — an `@<name>` token anywhere in a request resolves `<config dir>/config.<name>` directly, overriding everything below, **for that request only**.
 1. **Walk up from CWD** — look for a `.env` in the current directory, then each parent, up to `$HOME`. Stop at the first one containing `OBSIDIAN_VAULT_PATH`.
-2. **Global config** — `~/.obsidian-wiki/config`.
+2. **Global config** — `<config dir>/config`.
 3. **Prompt setup** — if neither exists, you'll be told to run setup.
+
+### Where the global config lives
+
+The config directory follows the [XDG Base Directory spec](https://specifications.freedesktop.org/basedir-spec/latest/): `$XDG_CONFIG_HOME/obsidian-wiki`, which defaults to `~/.config/obsidian-wiki`.
+
+Earlier versions used `~/.obsidian-wiki`. That location is still honored: if `~/.obsidian-wiki` exists and the XDG path does not, it is used as-is — upgrading never strands a working config, and no migration is required. New installs use the XDG path. To move an existing install, `mv ~/.obsidian-wiki ~/.config/obsidian-wiki`.
 
 After resolving, skills also read `$OBSIDIAN_VAULT_PATH/AGENTS.md` if it exists. That's where you put owner-specific conventions — domain vocabulary, ingest preferences, writing style, project scoping — which override framework defaults for every skill.
 
-Both `~/.obsidian-wiki/config` and `.env` use the same `KEY=value` format. Start from [`.env.example`](../.env.example).
+Both the global config and `.env` use the same `KEY=value` format. Start from [`.env.example`](../.env.example).
 
-The deterministic `lint`, `trust-record`, and `trust-check` commands use the same vault-scoped resolution: an explicit path uses no unrelated config, `@name` reads only `~/.obsidian-wiki/config.<name>`, otherwise the nearest CWD `.env` wins before global config. Schema settings are read from that same resolved config only, so one vault's lifecycle extensions cannot leak into another vault.
+The deterministic `lint`, `trust-record`, and `trust-check` commands use the same vault-scoped resolution: an explicit path uses no unrelated config, `@name` reads only `<config dir>/config.<name>`, otherwise the nearest CWD `.env` wins before global config. Schema settings are read from that same resolved config only, so one vault's lifecycle extensions cannot leak into another vault.
 
 ## Core
 
@@ -226,7 +232,7 @@ git remote add origin https://github.com/you/my-wiki.git
 **Hourly auto-sync via cron:**
 
 ```
-0 * * * * obsidian-wiki sync --vault /path/to/your/vault >> ~/.obsidian-wiki/sync.log 2>&1
+0 * * * * obsidian-wiki sync --vault /path/to/your/vault >> ~/.config/obsidian-wiki/sync.log 2>&1
 ```
 
 > Keep the repo **private** if your vault contains personal notes. Nothing is sent to any third-party service — your vault lives on your machines and in your GitHub account only.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,6 +1,8 @@
 # Installation
 
-Four ways in. Pick one — they all end at the same place: your vault path in `~/.obsidian-wiki/config` and the skills discoverable by your agent.
+Four ways in. Pick one — they all end at the same place: your vault path in the global config (`~/.config/obsidian-wiki/config`) and the skills discoverable by your agent.
+
+> **Upgrading from an older version?** The config directory used to be `~/.obsidian-wiki`. If you already have it, everything keeps working — that path is still honored and nothing needs to move. See [Where the global config lives](configuration.md#where-the-global-config-lives).
 
 | Path | Best for | Writes global config | Installs into all agents |
 |---|---|---|---|
@@ -16,7 +18,7 @@ pip install obsidian-wiki
 obsidian-wiki setup --vault /path/to/your/digital/brain
 ```
 
-`obsidian-wiki setup` writes the config to `~/.obsidian-wiki/config` and installs every wiki skill into all your AI agents (Claude Code, Cursor, Codex, Gemini, Hermes, Pi, and more). Skills are symlinked to the installed package, so `pip install -U obsidian-wiki` upgrades them everywhere — just re-run `obsidian-wiki setup` to pick up new skills.
+`obsidian-wiki setup` writes the config to `~/.config/obsidian-wiki/config` and installs every wiki skill into all your AI agents (Claude Code, Cursor, Codex, Gemini, Hermes, Pi, and more). Skills are symlinked to the installed package, so `pip install -U obsidian-wiki` upgrades them everywhere — just re-run `obsidian-wiki setup` to pick up new skills.
 
 Then open a project in your agent and say **"set up my wiki"**.
 
@@ -27,7 +29,7 @@ obsidian-wiki setup --project .   # also drop project-local skills + AGENTS.md i
 obsidian-wiki setup --copy        # copy skill files instead of symlinking
 ```
 
-`OBSIDIAN_VAULT_PATH` is just any directory where you want your digital brain to live — a new empty folder or an existing Obsidian vault. Omit `--vault` to be prompted, or set it later in `~/.obsidian-wiki/config`.
+`OBSIDIAN_VAULT_PATH` is just any directory where you want your digital brain to live — a new empty folder or an existing Obsidian vault. Omit `--vault` to be prompted, or set it later in `~/.config/obsidian-wiki/config`.
 
 Run `obsidian-wiki info` to see the resolved paths and `obsidian-wiki doctor` to health-check the result. See the [CLI reference](cli.md) for everything else the package ships.
 
@@ -51,7 +53,7 @@ cd obsidian-wiki
 bash setup.sh
 ```
 
-`setup.sh` asks for your vault path, writes the config to `~/.obsidian-wiki/config`, symlinks skills into all your agents, and installs `wiki-update`, `wiki-query`, and `wiki-context-pack` globally so you can use them from any project.
+`setup.sh` asks for your vault path, writes the config to `~/.config/obsidian-wiki/config`, symlinks skills into all your agents, and installs `wiki-update`, `wiki-query`, and `wiki-context-pack` globally so you can use them from any project.
 
 Open the project in your agent and say **"set up my wiki"**.
 
@@ -59,7 +61,7 @@ For local-only config, copy `.env.example` to `.env` and set `OBSIDIAN_VAULT_PAT
 
 ### What `setup.sh` wires up
 
-1. **Global config** at `~/.obsidian-wiki/config` with your vault path and the repo location. This is how skills know where to read and write.
+1. **Global config** at `~/.config/obsidian-wiki/config` with your vault path and the repo location. This is how skills know where to read and write.
 2. **Portable skills** — `wiki-update`, `wiki-query`, and `wiki-context-pack` symlinked into `~/.claude/skills/` so they're available from any project in Claude Code.
 3. **Global symlinks** for every agent's discovery path:
    - `~/.gemini/skills/` — Gemini CLI (canonical)
@@ -84,7 +86,7 @@ For local-only config, copy `.env.example` to `.env` and set `OBSIDIAN_VAULT_PAT
 npx skills add Ar9av/obsidian-wiki
 ```
 
-This only installs the markdown skills into the current agent. It does **not** write `~/.obsidian-wiki/config`, configure GitHub sync, or wire the global multi-agent bootstrap that `obsidian-wiki setup` / `setup.sh` performs.
+This only installs the markdown skills into the current agent. It does **not** write the global config, configure GitHub sync, or wire the global multi-agent bootstrap that `obsidian-wiki setup` / `setup.sh` performs.
 
 Use this path only if you intentionally want a partial, agent-local install and are prepared to manage config yourself. For a complete setup, use pip or git clone instead.
 
@@ -96,7 +98,7 @@ Open your vault directory in Obsidian (File → Open Vault). The wiki pages, wik
 
 ## Multiple vaults
 
-Keep a default vault active in `~/.obsidian-wiki/config`, or create named configs like `~/.obsidian-wiki/config.work` with `/wiki-switch new work`.
+Keep a default vault active in `~/.config/obsidian-wiki/config`, or create named configs like `~/.config/obsidian-wiki/config.work` with `/wiki-switch new work`.
 
 From any directory, route one request to a named vault with `@name`:
 

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -320,15 +320,45 @@ def resolve_vault_path(cli_vault: str | None) -> str:
 
 
 def write_config(vault_path: str) -> None:
+    """Write the setup-managed keys, preserving everything else in the file.
+
+    Only ``OBSIDIAN_VAULT_PATH``, ``OBSIDIAN_WIKI_REPO`` and
+    ``OBSIDIAN_WIKI_VERSION`` are owned by setup. Any other key the user added
+    (``OBSIDIAN_LINK_FORMAT``, ``QMD_WIKI_COLLECTION``, sync settings, …) is
+    carried over untouched, along with comments and ordering, so re-running
+    setup on an existing install is non-destructive.
+    """
     GLOBAL_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     # OBSIDIAN_WIKI_REPO points at the bundled data root so skills that reference
     # framework assets (templates, references) can find them post-install.
     repo_root = skills_dir().parent
-    GLOBAL_CONFIG.write_text(
-        f'OBSIDIAN_VAULT_PATH="{vault_path}"\n'
-        f'OBSIDIAN_WIKI_REPO="{repo_root}"\n'
-        f'OBSIDIAN_WIKI_VERSION="{__version__}"\n'
-    )
+    managed = {
+        "OBSIDIAN_VAULT_PATH": vault_path,
+        "OBSIDIAN_WIKI_REPO": str(repo_root),
+        "OBSIDIAN_WIKI_VERSION": __version__,
+    }
+
+    existing: list[str] = []
+    if GLOBAL_CONFIG.is_file():
+        existing = GLOBAL_CONFIG.read_text().splitlines()
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in existing:
+        stripped = raw.strip()
+        key = stripped.split("=", 1)[0].strip() if "=" in stripped else ""
+        if key in managed and not stripped.startswith("#"):
+            if key not in seen:
+                out.append(f'{key}="{managed[key]}"')
+                seen.add(key)
+            # Drop duplicate definitions of a managed key.
+            continue
+        out.append(raw)
+    for key, value in managed.items():
+        if key not in seen:
+            out.append(f'{key}="{value}"')
+
+    GLOBAL_CONFIG.write_text("\n".join(out) + "\n")
     print(f"✅  Global config written to {GLOBAL_CONFIG}")
 
 

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -3,8 +3,9 @@
 Python port of ``setup.sh`` for the pip-installed package. The skill content
 lives inside the installed package (``obsidian_wiki/_data/skills``) instead of a
 cloned repo, so this wires the bundled skills into every supported AI agent's
-skills directory and writes ``~/.obsidian-wiki/config`` so the skills resolve
-the vault from any project.
+skills directory and writes the global config (XDG-style, under
+``$XDG_CONFIG_HOME/obsidian-wiki`` by default) so the skills resolve the vault
+from any project.
 """
 
 from __future__ import annotations
@@ -22,7 +23,25 @@ from typing import TypedDict
 from obsidian_wiki import __version__
 
 HOME = Path.home()
-GLOBAL_CONFIG_DIR = HOME / ".obsidian-wiki"
+
+
+def _resolve_global_config_dir() -> Path:
+    """Resolve the global config directory, XDG-first with legacy fallback.
+
+    New installs land under ``$XDG_CONFIG_HOME/obsidian-wiki`` (default
+    ``~/.config/obsidian-wiki``, per the XDG Base Directory spec). Installs that
+    already have a ``~/.obsidian-wiki`` directory keep using it, so upgrading
+    doesn't strand a working config.
+    """
+    xdg_home = os.environ.get("XDG_CONFIG_HOME", "").strip()
+    xdg_dir = (Path(xdg_home).expanduser() if xdg_home else HOME / ".config") / "obsidian-wiki"
+    legacy_dir = HOME / ".obsidian-wiki"
+    if legacy_dir.is_dir() and not xdg_dir.exists():
+        return legacy_dir
+    return xdg_dir
+
+
+GLOBAL_CONFIG_DIR = _resolve_global_config_dir()
 GLOBAL_CONFIG = GLOBAL_CONFIG_DIR / "config"
 
 # Skills usable from any project (no vault context needed beyond the global
@@ -870,7 +889,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     write_config(vault_path)
     if not vault_path:
         print("    → Vault path not set yet. Re-run with `--vault /path/to/vault`")
-        print("      or edit OBSIDIAN_VAULT_PATH in ~/.obsidian-wiki/config.")
+        print(f"      or edit OBSIDIAN_VAULT_PATH in {GLOBAL_CONFIG}.")
     else:
         vault_dir = Path(vault_path).expanduser()
         vault_created = scaffold_vault(vault_dir)

--- a/scripts/daily-update.sh
+++ b/scripts/daily-update.sh
@@ -7,8 +7,20 @@ set -euo pipefail
 #
 # Config resolution order (mirrors llm-wiki/SKILL.md protocol):
 #   1. Walk up from CWD looking for .env with OBSIDIAN_VAULT_PATH
-#   2. Fall back to ~/.obsidian-wiki/config
+#   2. Fall back to the global config (XDG-style; legacy ~/.obsidian-wiki honored)
 #   3. Exit with error if neither found
+
+# XDG-style global config dir, with legacy ~/.obsidian-wiki fallback for
+# installs that already have it (see llm-wiki/SKILL.md Config Resolution Protocol).
+_obsidian_wiki_config_dir() {
+  local xdg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-wiki"
+  local legacy_dir="$HOME/.obsidian-wiki"
+  if [[ -d "$legacy_dir" && ! -e "$xdg_dir" ]]; then
+    echo "$legacy_dir"
+  else
+    echo "$xdg_dir"
+  fi
+}
 
 _find_config() {
   local dir="$PWD"
@@ -19,8 +31,10 @@ _find_config() {
     fi
     dir="$(dirname "$dir")"
   done
-  if [[ -f "$HOME/.obsidian-wiki/config" ]]; then
-    echo "$HOME/.obsidian-wiki/config"
+  local global_config
+  global_config="$(_obsidian_wiki_config_dir)/config"
+  if [[ -f "$global_config" ]]; then
+    echo "$global_config"
     return
   fi
   echo ""
@@ -45,7 +59,7 @@ fi
 VAULT_ID=$(echo "$OBSIDIAN_VAULT_PATH" | md5sum 2>/dev/null | cut -c1-8 || \
            md5 -q - <<< "$OBSIDIAN_VAULT_PATH" 2>/dev/null | cut -c1-8 || \
            echo "default")
-STATE_DIR="$HOME/.obsidian-wiki/state/$VAULT_ID"
+STATE_DIR="$(_obsidian_wiki_config_dir)/state/$VAULT_ID"
 mkdir -p "$STATE_DIR"
 
 # Write vault path so wiki-notify.sh can find this state dir

--- a/scripts/wiki-notify.sh
+++ b/scripts/wiki-notify.sh
@@ -6,11 +6,18 @@
 #   fish:      bass source /path/to/obsidian-wiki/scripts/wiki-notify.sh
 #              (or copy _wiki_notify logic natively using fish syntax)
 #
-# State is vault-scoped under ~/.obsidian-wiki/state/<vault-id>/
+# State is vault-scoped under <global-config-dir>/state/<vault-id>/ — the
+# global config dir is XDG-style (~/.config/obsidian-wiki by default), with
+# the legacy ~/.obsidian-wiki honored if it already exists (see
+# llm-wiki/SKILL.md Config Resolution Protocol).
 # Multiple vaults are supported — all stale vaults are shown.
 
 _wiki_notify() {
-  local state_base="$HOME/.obsidian-wiki/state"
+  local xdg_dir="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-wiki"
+  local legacy_dir="$HOME/.obsidian-wiki"
+  local config_dir="$xdg_dir"
+  [[ -d "$legacy_dir" && ! -e "$xdg_dir" ]] && config_dir="$legacy_dir"
+  local state_base="$config_dir/state"
   [[ -d "$state_base" ]] || return
 
   local now age_s age_h stale last vault_path shown=0

--- a/setup.sh
+++ b/setup.sh
@@ -6,7 +6,9 @@
 #
 # What it does:
 #   1. Creates .env from .env.example (if not present)
-#   2. Writes ~/.obsidian-wiki/config so skills work from any project
+#   2. Writes the global config (XDG-style, under ~/.config/obsidian-wiki by
+#      default; legacy ~/.obsidian-wiki is honored if it already exists) so
+#      skills work from any project
 #   3. Symlinks .skills/* into each agent's expected skills directory:
 #      Project-local:
 #        - .claude/skills/        (Claude Code)
@@ -111,8 +113,16 @@ else
   echo "✅  .env already exists"
 fi
 
-# ── Step 1b: ~/.obsidian-wiki/config ─────────────────────────
-GLOBAL_CONFIG_DIR="$HOME/.obsidian-wiki"
+# ── Step 1b: global config ────────────────────────────────────
+# XDG-style location by default; installs that already have the legacy
+# ~/.obsidian-wiki keep using it so upgrading doesn't strand a working config.
+XDG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/obsidian-wiki"
+LEGACY_DIR="$HOME/.obsidian-wiki"
+if [ -d "$LEGACY_DIR" ] && [ ! -e "$XDG_DIR" ]; then
+  GLOBAL_CONFIG_DIR="$LEGACY_DIR"
+else
+  GLOBAL_CONFIG_DIR="$XDG_DIR"
+fi
 GLOBAL_CONFIG="$GLOBAL_CONFIG_DIR/config"
 mkdir -p "$GLOBAL_CONFIG_DIR"
 
@@ -141,7 +151,7 @@ cat > "$GLOBAL_CONFIG" <<EOF
 OBSIDIAN_VAULT_PATH="$VAULT_PATH"
 OBSIDIAN_WIKI_REPO="$SCRIPT_DIR"
 EOF
-echo "✅  Global config written to ~/.obsidian-wiki/config"
+echo "✅  Global config written to $GLOBAL_CONFIG"
 
 # ── Step 1c: Bootstrap symlinks ──────────────────────────────
 # .hermes.md → AGENTS.md  (Hermes resolves .hermes.md before AGENTS.md;
@@ -267,7 +277,7 @@ if [[ "$SETUP_SYNC" =~ ^[Yy]$ ]]; then
         SYNC_CMD="$(command -v python3 &>/dev/null && echo "env PYTHONPATH=$SCRIPT_DIR python3 -m obsidian_wiki.cli sync" || echo "obsidian-wiki sync")"
         CRON_LINE="0 * * * * $SYNC_CMD --vault $VAULT_PATH >> $GLOBAL_CONFIG_DIR/sync.log 2>&1"
         ( crontab -l 2>/dev/null; echo "$CRON_LINE" ) | sort -u | crontab -
-        echo "✅  Hourly cron installed  (logs: ~/.obsidian-wiki/sync.log)"
+        echo "✅  Hourly cron installed  (logs: $GLOBAL_CONFIG_DIR/sync.log)"
       fi
     fi
   fi

--- a/tests/test_inline_vault_targeting_docs.py
+++ b/tests/test_inline_vault_targeting_docs.py
@@ -17,7 +17,7 @@ class InlineVaultTargetingDocsTest(unittest.TestCase):
 
         self.assertIn("0. **Inline vault override (`@name`)", llm_wiki)
         self.assertIn("0. **Inline vault override (`@name`)", agents)
-        self.assertIn("resolve `~/.obsidian-wiki/config.<name>` directly", llm_wiki)
+        self.assertIn("resolve `<global config dir>/config.<name>` directly", llm_wiki)
         self.assertIn("do **not** silently fall back to the default", agents)
 
     def test_skill_resolution_summaries_include_inline_override(self) -> None:

--- a/tests/test_write_config_preserves_user_keys.py
+++ b/tests/test_write_config_preserves_user_keys.py
@@ -1,0 +1,130 @@
+"""`setup` must not destroy user-added config keys when it re-writes the file."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _setup(home: Path, vault: Path) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env.pop("XDG_CONFIG_HOME", None)
+    # Pin the import to this checkout — a separately installed obsidian_wiki
+    # would otherwise shadow it depending on the working directory.
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [sys.executable, "-m", "obsidian_wiki.cli", "setup", "--vault", str(vault)],
+        capture_output=True,
+        text=True,
+        env=env,
+        cwd=str(home),
+    )
+
+
+def _config_dir(home: Path) -> Path:
+    legacy = home / ".obsidian-wiki"
+    return legacy if legacy.is_dir() else home / ".config" / "obsidian-wiki"
+
+
+def _values(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"')
+    return values
+
+
+def test_rerunning_setup_keeps_user_added_keys(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config_dir = home / ".config" / "obsidian-wiki"
+    config_dir.mkdir(parents=True)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    config = config_dir / "config"
+    config.write_text(
+        "# my notes config\n"
+        'OBSIDIAN_VAULT_PATH="/old/path"\n'
+        'OBSIDIAN_LINK_FORMAT="markdown"\n'
+        'QMD_WIKI_COLLECTION="mybrain"\n'
+        'WIKI_SKIP_PROJECTS="secret-thing"\n',
+        encoding="utf-8",
+    )
+
+    proc = _setup(home, vault)
+    assert proc.returncode == 0, proc.stderr
+
+    values = _values(config)
+    # User keys survive.
+    assert values["OBSIDIAN_LINK_FORMAT"] == "markdown"
+    assert values["QMD_WIKI_COLLECTION"] == "mybrain"
+    assert values["WIKI_SKIP_PROJECTS"] == "secret-thing"
+    # Managed key is updated, not duplicated.
+    assert values["OBSIDIAN_VAULT_PATH"] == str(vault)
+    body = config.read_text()
+    assert body.count("OBSIDIAN_VAULT_PATH=") == 1
+    # Comments are kept.
+    assert "# my notes config" in body
+
+
+def test_setup_on_legacy_config_preserves_keys(tmp_path: Path) -> None:
+    """The same guarantee must hold for the pre-XDG config location."""
+    home = tmp_path / "home"
+    legacy = home / ".obsidian-wiki"
+    legacy.mkdir(parents=True)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    config = legacy / "config"
+    config.write_text('OBSIDIAN_VAULT_PATH="/old"\nOBSIDIAN_LINK_FORMAT="markdown"\n', encoding="utf-8")
+
+    proc = _setup(home, vault)
+    assert proc.returncode == 0, proc.stderr
+
+    assert _config_dir(home) == legacy
+    values = _values(config)
+    assert values["OBSIDIAN_LINK_FORMAT"] == "markdown"
+    assert values["OBSIDIAN_VAULT_PATH"] == str(vault)
+
+
+def test_setup_writes_managed_keys_on_a_fresh_config(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    proc = _setup(home, vault)
+    assert proc.returncode == 0, proc.stderr
+
+    values = _values(_config_dir(home) / "config")
+    assert values["OBSIDIAN_VAULT_PATH"] == str(vault)
+    assert values["OBSIDIAN_WIKI_REPO"]
+    assert values["OBSIDIAN_WIKI_VERSION"]
+
+
+def test_setup_collapses_duplicate_managed_keys(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config_dir = home / ".config" / "obsidian-wiki"
+    config_dir.mkdir(parents=True)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    config = config_dir / "config"
+    config.write_text(
+        'OBSIDIAN_VAULT_PATH="/one"\nOBSIDIAN_LINK_FORMAT="markdown"\nOBSIDIAN_VAULT_PATH="/two"\n',
+        encoding="utf-8",
+    )
+
+    proc = _setup(home, vault)
+    assert proc.returncode == 0, proc.stderr
+
+    body = config.read_text()
+    assert body.count("OBSIDIAN_VAULT_PATH=") == 1
+    assert _values(config)["OBSIDIAN_VAULT_PATH"] == str(vault)
+    assert _values(config)["OBSIDIAN_LINK_FORMAT"] == "markdown"

--- a/tests/test_xdg_config_location.py
+++ b/tests/test_xdg_config_location.py
@@ -1,0 +1,93 @@
+"""Global config directory resolution: XDG-first with legacy fallback."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _resolve(home: Path, xdg_config_home: str | None = None) -> Path:
+    """Resolve GLOBAL_CONFIG_DIR in a subprocess with the given HOME/XDG env."""
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    if xdg_config_home is None:
+        env.pop("XDG_CONFIG_HOME", None)
+    else:
+        env["XDG_CONFIG_HOME"] = xdg_config_home
+    proc = subprocess.run(
+        [sys.executable, "-c", "from obsidian_wiki.cli import GLOBAL_CONFIG_DIR; print(GLOBAL_CONFIG_DIR)"],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=True,
+    )
+    return Path(proc.stdout.strip())
+
+
+def test_fresh_install_uses_xdg_default(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    assert _resolve(home) == home / ".config" / "obsidian-wiki"
+
+
+def test_xdg_config_home_is_honored(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    xdg = tmp_path / "xdg"
+
+    assert _resolve(home, str(xdg)) == xdg / "obsidian-wiki"
+
+
+def test_existing_legacy_dir_keeps_working(tmp_path: Path) -> None:
+    """An install that predates the XDG move must not be stranded."""
+    home = tmp_path / "home"
+    legacy = home / ".obsidian-wiki"
+    legacy.mkdir(parents=True)
+    (legacy / "config").write_text('OBSIDIAN_VAULT_PATH="/tmp/vault"\n', encoding="utf-8")
+
+    assert _resolve(home) == legacy
+
+
+def test_xdg_dir_wins_once_it_exists(tmp_path: Path) -> None:
+    """After migrating, the XDG path takes over even if the legacy dir lingers."""
+    home = tmp_path / "home"
+    legacy = home / ".obsidian-wiki"
+    legacy.mkdir(parents=True)
+    xdg = home / ".config" / "obsidian-wiki"
+    xdg.mkdir(parents=True)
+
+    assert _resolve(home) == xdg
+
+
+def test_empty_xdg_config_home_falls_back_to_default(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+
+    assert _resolve(home, "") == home / ".config" / "obsidian-wiki"
+
+
+def test_legacy_config_is_still_read_end_to_end(tmp_path: Path) -> None:
+    """`info` must report the legacy config when that is the active location."""
+    home = tmp_path / "home"
+    legacy = home / ".obsidian-wiki"
+    legacy.mkdir(parents=True)
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (legacy / "config").write_text(f'OBSIDIAN_VAULT_PATH="{vault}"\n', encoding="utf-8")
+
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    env.pop("XDG_CONFIG_HOME", None)
+    proc = subprocess.run(
+        [sys.executable, "-m", "obsidian_wiki.cli", "info"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert proc.returncode == 0
+    assert str(legacy / "config") in proc.stdout
+    assert "(not written yet)" not in proc.stdout

--- a/tests/test_xdg_config_location.py
+++ b/tests/test_xdg_config_location.py
@@ -8,10 +8,21 @@ import sys
 from pathlib import Path
 
 
-def _resolve(home: Path, xdg_config_home: str | None = None) -> Path:
-    """Resolve GLOBAL_CONFIG_DIR in a subprocess with the given HOME/XDG env."""
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _env(home: Path) -> dict[str, str]:
     env = os.environ.copy()
     env["HOME"] = str(home)
+    # Pin the import to this checkout — a separately installed obsidian_wiki
+    # would otherwise shadow it depending on the working directory.
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return env
+
+
+def _resolve(home: Path, xdg_config_home: str | None = None) -> Path:
+    """Resolve GLOBAL_CONFIG_DIR in a subprocess with the given HOME/XDG env."""
+    env = _env(home)
     if xdg_config_home is None:
         env.pop("XDG_CONFIG_HOME", None)
     else:
@@ -78,8 +89,7 @@ def test_legacy_config_is_still_read_end_to_end(tmp_path: Path) -> None:
     vault.mkdir()
     (legacy / "config").write_text(f'OBSIDIAN_VAULT_PATH="{vault}"\n', encoding="utf-8")
 
-    env = os.environ.copy()
-    env["HOME"] = str(home)
+    env = _env(home)
     env.pop("XDG_CONFIG_HOME", None)
     proc = subprocess.run(
         [sys.executable, "-m", "obsidian_wiki.cli", "info"],


### PR DESCRIPTION
Closes #172.

## 1. XDG-style config location

The global config lived at `~/.obsidian-wiki`, which isn't XDG-compliant. It now resolves to `$XDG_CONFIG_HOME/obsidian-wiki`, defaulting to `~/.config/obsidian-wiki`.

**Existing installs are unaffected.** If `~/.obsidian-wiki` is present and the XDG path is not, the legacy directory is used as-is — no migration, nothing moves on upgrade. Once the XDG path exists it takes precedence, so migrating is just:

```bash
mv ~/.obsidian-wiki ~/.config/obsidian-wiki
```

The rule is implemented identically in all four places that resolve config independently — `obsidian_wiki/cli.py`, `setup.sh`, `scripts/daily-update.sh`, `scripts/wiki-notify.sh` — plus the Config Resolution Protocol in `.skills/llm-wiki/SKILL.md` that the other ~30 skills defer to. This matters because a Python/bash mismatch would put vault-scoped `state/` in one directory and the config in another, silently breaking the daily-update → terminal-notification handoff.

Named `config.<name>` vault profiles (`wiki-switch`, `@name` routing) follow the same directory.

## 2. Drive-by fix: `setup` was wiping user config keys

While testing the above I found a **pre-existing data-loss bug**, present on `main` and unrelated to the XDG change: `write_config` rewrote the config with only the three setup-managed keys, so every `obsidian-wiki setup` — including the one a pip upgrade prompts for — silently destroyed everything else in the file.

Before, on `main`:

```console
$ cat ~/.obsidian-wiki/config          # before setup
# my notes config
OBSIDIAN_VAULT_PATH="/path/to/vault"
OBSIDIAN_LINK_FORMAT="markdown"
QMD_WIKI_COLLECTION="mybrain"

$ obsidian-wiki setup --vault /path/to/vault
$ cat ~/.obsidian-wiki/config          # after setup — comment + 2 keys GONE
OBSIDIAN_VAULT_PATH="/path/to/vault"
OBSIDIAN_WIKI_REPO="..."
OBSIDIAN_WIKI_VERSION="2026.6.8"
```

After, on this branch:

```console
$ cat ~/.obsidian-wiki/config          # after setup — everything preserved
# my notes config
OBSIDIAN_VAULT_PATH="/path/to/vault"
OBSIDIAN_LINK_FORMAT="markdown"
QMD_WIKI_COLLECTION="mybrain"
OBSIDIAN_WIKI_REPO="..."
OBSIDIAN_WIKI_VERSION="2026.6.8"
```

Setup now owns only `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_WIKI_REPO` and `OBSIDIAN_WIKI_VERSION`, updating those in place and carrying every other line — including comments and ordering — over untouched. Duplicate definitions of a managed key collapse to one.

It's fixed here rather than separately because this branch already touches config writing, and making `setup` re-runs more likely is exactly what the XDG work does.

## Verification

Ran end-to-end in throwaway `HOME`s (since deleted). Every scenario passing:

| Scenario | Result |
|---|---|
| Fresh install (`cli setup`) | → `~/.config/obsidian-wiki/`, no legacy dir created |
| Fresh install (`setup.sh`) | same — bash matches Python |
| Existing legacy install | stays at `~/.obsidian-wiki`, settings read intact |
| Re-run setup on legacy (pip upgrade) | stays put — no split-brain, no XDG dir created |
| `XDG_CONFIG_HOME` set to a custom dir | honored |
| Migration (`mv` to XDG) | XDG takes over, settings survive |
| Both dirs exist / neither exists | deterministic; bash == Python |
| `@work` named vault, XDG + legacy | routes to the right vault |
| `wiki-switch` symlinked config | resolves through the symlink |
| Missing `@name` | clean error, no silent fallback |
| `daily-update.sh` → `wiki-notify.sh` state handoff | writer/reader agree in both layouts |
| Stale-vault notification | fires from the XDG state dir |

Bash and Python resolvers were cross-checked against each other on all six layout permutations:

```console
MATCH  fresh       -> A-fresh/.config/obsidian-wiki
MATCH  legacy      -> B-legacy/.obsidian-wiki
MATCH  migrated    -> D-migrate/.config/obsidian-wiki
MATCH  custom-xdg  -> C-xdghome/obsidian-wiki
MATCH  both-exist  -> H-both/.config/obsidian-wiki
MATCH  neither     -> I-none/.config/obsidian-wiki
```

Named-vault routing, proven by giving each vault a distinct page count:

```console
=== @work (work vault)          === pages = 7
=== default/active (personal)   === pages = 4
```

### Tests

10 new tests across two files:

- `tests/test_xdg_config_location.py` — fresh install, `XDG_CONFIG_HOME` override, legacy-still-works, XDG-wins-after-migration, empty-`XDG_CONFIG_HOME`, end-to-end read of a legacy config.
- `tests/test_write_config_preserves_user_keys.py` — user keys survive a re-run (XDG and legacy), managed keys still written on a fresh config, duplicate managed keys collapse.

Both pin `PYTHONPATH` so they exercise this checkout rather than whatever `obsidian_wiki` happens to be pip-installed.

**Suite status:** 550 passed. The 12 remaining failures (`test_code_understand_cli.py`, `test_context_pack_cli.py`) are pre-existing — I ran the same subset on `origin/main` and on this branch in clean clones and the failure set is byte-identical, so this PR introduces no regressions. The `code_understand` ones arrived with the upstream CodeGraph commits and appear environment-dependent (missing `codegraph` binary).

### Docs

`docs/configuration.md` gains a "Where the global config lives" section covering the XDG path, the legacy fallback, and the one-line migration; `docs/installation.md` gets an upgrade note linking to it. `README.md`/`README_TW.md` contain no config-path references, so translation parity is unaffected.

> Note: this is a CLI/config change with no UI surface, so the evidence above is captured terminal output rather than screenshots.
