### PR TITLE
fix(tests): isolate CLI subprocess tests, and actually run the suite in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  pytest:
+    name: pytest (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.12"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install pytest
+        run: python -m pip install --upgrade pip pytest
+
+      - name: Configure git identity
+        # Some tests build throwaway git repos and commit to them.
+        run: |
+          git config --global user.email "test@example.com"
+          git config --global user.name "Wiki Tester"
+          git config --global init.defaultBranch main
+
+      - name: Run test suite
+        run: python -m pytest tests/ -q

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,25 @@ import sys
 import time
 from pathlib import Path
 
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _pin_subprocess_imports_to_this_checkout() -> None:
+    """Make CLI subprocesses import this working tree, not an installed copy.
+
+    Every test helper here spawns ``python -m obsidian_wiki.cli`` with a copy
+    of ``os.environ``. Without this, ``sys.path[0]`` is the subprocess cwd, so a
+    test that runs from a temp dir silently exercises whatever ``obsidian_wiki``
+    happens to be pip-installed — which passes or fails for reasons unrelated to
+    the code under test. Setting PYTHONPATH once here covers every helper.
+    """
+    os.environ["PYTHONPATH"] = os.pathsep.join(
+        [str(REPO_ROOT), *([p] if (p := os.environ.get("PYTHONPATH")) else [])]
+    )
+
 
 def make_project(tmp_path: Path, files: dict[str, str], *, git: bool = True) -> Path:
     """Write a mini source tree from files (relpath -> content) and, if git,

--- a/tests/test_batch.py
+++ b/tests/test_batch.py
@@ -1,4 +1,7 @@
 """Tests for the batch planning module."""
+
+from __future__ import annotations
+
 import json
 import subprocess
 import sys

--- a/tests/test_code_understand_cli.py
+++ b/tests/test_code_understand_cli.py
@@ -1,8 +1,7 @@
 """Subprocess tests for the `code-understand` CLI command (issue #167).
 
-The command does not exist yet — these tests are RED by design: argparse must
-reject `code-understand` with an "invalid choice" error (exit 2) until the
-wiring wave registers the subcommand. They pin the exact CLI contract:
+These were written RED-first, before the subcommand existed; the wiring landed
+in fd30720 and they are green now. They pin the exact CLI contract:
 
     obsidian-wiki code-understand [--project <dir>] [--backend auto|builtin|codegraph]
         [--changed <file> ...] [--since <sha>] [--max-symbols N] [--pretty]

--- a/tests/test_context_pack_cli.py
+++ b/tests/test_context_pack_cli.py
@@ -14,6 +14,12 @@ def run_cli(
 ) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["HOME"] = str(home)
+    if cwd is None:
+        # Default to the fake HOME, not the repo: config resolution walks up
+        # from cwd looking for a `.env`, and a developer's own .env at the repo
+        # root would otherwise override the fixture config.
+        home.mkdir(parents=True, exist_ok=True)
+        cwd = home
     return subprocess.run(
         [sys.executable, "-m", "obsidian_wiki.cli", *args],
         capture_output=True,

--- a/tests/test_graph_analysis.py
+++ b/tests/test_graph_analysis.py
@@ -1,4 +1,7 @@
 """Tests for vault graph analysis: community detection, god nodes, surprising connections."""
+
+from __future__ import annotations
+
 import json
 import subprocess
 import sys

--- a/tests/test_graphrag.py
+++ b/tests/test_graphrag.py
@@ -1,4 +1,7 @@
 """Tests for the GraphRAG query index module."""
+
+from __future__ import annotations
+
 import json
 import subprocess
 import sys

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -57,12 +57,17 @@ def _page(
 def _run(home: Path, *args: str) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["HOME"] = str(home)
+    # Run from the fake HOME, not the repo: config resolution walks up from cwd
+    # looking for a `.env`, and a developer's own .env at the repo root would
+    # otherwise override the fixture config and point at their real vault.
+    home.mkdir(parents=True, exist_ok=True)
     return subprocess.run(
         [sys.executable, "-m", "obsidian_wiki.cli", *args],
         capture_output=True,
         check=False,
         text=True,
         env=env,
+        cwd=home,
     )
 
 


### PR DESCRIPTION
Follow-up to #173. The 12 test failures I flagged there turned out to be **two test-harness isolation bugs**, not product bugs — and the reason they went unnoticed is that **the test suite has never run in CI**.

## 1. Tests were exercising the wrong package

18 test files spawn `python -m obsidian_wiki.cli` as a subprocess. Each builds its env from `os.environ.copy()` and none set `PYTHONPATH`, so `sys.path[0]` was the subprocess cwd. Any test running from a temp dir imported whatever `obsidian_wiki` happened to be **pip-installed globally**, not the working tree.

On my machine that's a stale build predating the `code-understand` subcommand:

```console
$ cd /tmp && python3 -c "import obsidian_wiki; print(obsidian_wiki.__file__)"
/opt/homebrew/lib/python3.14/site-packages/obsidian_wiki/__init__.py

$ cd /tmp && python3 -m obsidian_wiki.cli code-understand --help
obsidian-wiki: error: argument command: invalid choice: 'code-understand'
  (choose from 'setup', 'list', 'info')
```

That killed all 8 `test_code_understand_cli` tests at argparse (exit 2) plus 4 in `test_context_pack_cli`.

Fixed with one autouse session fixture in `tests/conftest.py`, which covers every helper at once since they all copy `os.environ`. (`test_lint._run_at` already pinned `PYTHONPATH` by hand — someone hit this before and patched a single call site.)

This is the more dangerous half: today it fails loudly, but a *subtly* stale install would fail quietly or pass falsely.

## 2. A developer's `.env` was leaking into config resolution

`test_lint._run` and `test_context_pack.run_cli` inherited pytest's cwd (the repo). Config resolution walks up from cwd looking for `.env`, found the developer's own untracked one at the repo root, and pointed the run at their **real vault** instead of the fixture:

```console
E  AssertionError: assert 'auth.md' in '...Included 3 of 10 candidate pages; dropped 7 for budget.'
```

Ten candidate pages, from a fixture vault containing exactly one file. Both helpers now run from the fake `HOME`.

This is why the failure count differed between my machine (12) and a clean clone (4).

## 3. Root cause of the drift: no pytest in CI

The three workflows run `setup.sh`, the wheel publish, and the README-sync checker. Nothing ran `tests/`, and there's no pytest config in `pyproject.toml`. CI was "green" because the suite was never executed.

Adds `.github/workflows/tests.yml` running pytest on PRs and pushes to main, matrixed over 3.9 (the `requires-python` floor) and 3.12.

## Verification

```console
$ python3 -m pytest tests/ -q
566 passed, 1 skipped, 19 subtests passed
```

Was 554 passed / 12 failed. Confirmed the fix isn't just masking failures:

- **Sabotage check** — reverting the config resolver's legacy branch to `if False:` makes `test_xdg_config_location` fail as expected, so the tests genuinely exercise repo code now.
- **Clean-interpreter check** — the full suite passes in a fresh 3.13 venv with `obsidian_wiki` *not installed at all*, proving `PYTHONPATH` is doing the work rather than a happens-to-be-current global install.

## Also

Drops the stale `"""...RED by design: the command does not exist yet..."""` docstring in `test_code_understand_cli.py` — that wiring landed in fd30720, in the same commit that added the tests.