### PR TITLE
docs(vault-skill-factory): resolve skill-creator scripts path for both install layouts

### DIFF
--- a/.skills/vault-skill-factory/SKILL.md
+++ b/.skills/vault-skill-factory/SKILL.md
@@ -109,6 +109,8 @@ checkout, so check both layouts under `$OBSIDIAN_WIKI_REPO` and use the first th
   at the bundled `_data/` dir, which ships the skills under `skills/`).
 - `$OBSIDIAN_WIKI_REPO/.skills/skill-creator/scripts/` — source checkout.
 
+Whichever resolves, it holds:
+
 - `improve_description.py` — tighten the generated `description` for better triggering.
 - `package_skill.py` — bundle the skill dir into a distributable archive.
 - `quick_validate.py` — sanity-check the skill's structure.

--- a/.skills/vault-skill-factory/SKILL.md
+++ b/.skills/vault-skill-factory/SKILL.md
@@ -102,7 +102,13 @@ one-line-install convention) — still **not** an install, just a manifest.
 
 ## Step 4: Optionally lean on skill-creator
 
-`skill-creator` ships reusable scripts (`$OBSIDIAN_WIKI_REPO/.skills/skill-creator/scripts/`):
+`skill-creator` ships reusable scripts. Their path differs between a pip/uv install and a source
+checkout, so check both layouts under `$OBSIDIAN_WIKI_REPO` and use the first that exists:
+
+- `$OBSIDIAN_WIKI_REPO/skills/skill-creator/scripts/` — packaged install (`OBSIDIAN_WIKI_REPO` points
+  at the bundled `_data/` dir, which ships the skills under `skills/`).
+- `$OBSIDIAN_WIKI_REPO/.skills/skill-creator/scripts/` — source checkout.
+
 - `improve_description.py` — tighten the generated `description` for better triggering.
 - `package_skill.py` — bundle the skill dir into a distributable archive.
 - `quick_validate.py` — sanity-check the skill's structure.


### PR DESCRIPTION
## What

`vault-skill-factory` Step 4 points at `$OBSIDIAN_WIKI_REPO/.skills/skill-creator/scripts/`. That
path only exists for a source checkout.

`cli.py` `skills_dir()` resolves to `<pkg>/_data/skills` for a wheel install and
`<repo>/.skills` for a checkout, and `write_config()` sets `OBSIDIAN_WIKI_REPO = skills_dir().parent`.
So the skills root is `$OBSIDIAN_WIKI_REPO/skills` under a wheel (no leading dot — `pyproject.toml`
force-includes `".skills"` to `"obsidian_wiki/_data/skills"`) and `$OBSIDIAN_WIKI_REPO/.skills` from
source. No single literal works for both.

Verified by building the wheel and installing it into a clean venv:

```
$ python -c "from obsidian_wiki.cli import skills_dir; sd=skills_dir(); \
    print((sd.parent/'.skills'/'skill-creator'/'scripts').is_dir(), \
          (sd/'skill-creator'/'scripts').is_dir())"
False True
```

Sibling references like `$OBSIDIAN_WIKI_REPO/scripts/...` (claude-history-ingest, daily-update) are
unaffected — `"scripts"` force-includes to `obsidian_wiki/_data/scripts`, so that literal is correct
in both layouts. This is the same class as #143 and #152, in a file those fixes did not touch.

## How

List both layouts and take the first that exists, mirroring the phrasing `wiki-setup` already uses
for the `wiki-stop-capture.sh` lookup, rather than swapping one broken literal for another.

Docs only, no behaviour change.
