### PR TITLE
docs(env): promoted _raw/ files are archived, not deleted

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -205,5 +205,5 @@ CODE_UNDERSTANDING_CODEGRAPH_BIN=
 # A directory inside OBSIDIAN_VAULT_PATH for unprocessed draft pages.
 # Drop rough notes, clipboard pastes, or quick captures here.
 # wiki-ingest will promote them to proper wiki pages when you run it.
-# Promoted files are deleted from _raw/ after processing.
+# Promoted files are moved into _raw/_archived/ after processing, not deleted.
 OBSIDIAN_RAW_DIR=_raw


### PR DESCRIPTION
## What

`.env.example`'s `OBSIDIAN_RAW_DIR` comment still says:

```
# Promoted files are deleted from _raw/ after processing.
```

That is the pre-#113 behaviour. Three skills now document the opposite:

- `.skills/wiki-ingest/SKILL.md` — "After promoting a file to a proper wiki page, **move the original
  into `_raw/_archived/`** ... instead of deleting it."
- `.skills/wiki-status/SKILL.md` — "excluding the `_archived/` subdirectory (already-promoted drafts
  kept for provenance, not pending work)".
- `.skills/llm-wiki/SKILL.md` — "`wiki-ingest` still moves rather than deletes them on promotion."

`.env.example` is usually the first file someone opens to configure the tool, so it is the worst
place to still promise that a quick-capture draft gets destroyed — which is the outcome #113 was
filed about.

## How

One comment line. Docs only, no behaviour change.
