### PR TITLE
fix(daily-update, wiki-ingest): wire up LINT_SCHEDULE and OBSIDIAN_MAX_PAGES_PER_INGEST

### DIFF
--- a/.skills/daily-update/SKILL.md
+++ b/.skills/daily-update/SKILL.md
@@ -54,6 +54,28 @@ echo "<stale_count>" > "$STATE_DIR/.pending_delta"
 echo "$OBSIDIAN_VAULT_PATH" > "$STATE_DIR/.vault_path"
 ```
 
+**Step 4a: Scheduled health check (wiki-lint)**
+
+`LINT_SCHEDULE` (default `weekly`) controls how often this cycle also runs `wiki-lint`:
+
+- `manual` — never auto-run; skip this step entirely.
+- `daily` — run `wiki-lint` every cycle.
+- `weekly` — run `wiki-lint` only if `$STATE_DIR/.last_lint` is missing or older than 7 days.
+
+```bash
+LINT_SCHEDULE="${LINT_SCHEDULE:-weekly}"
+NOW=$(date +%s)
+LAST_LINT=$(cat "$STATE_DIR/.last_lint" 2>/dev/null || echo 0)
+```
+
+If the schedule says to run, invoke the `wiki-lint` skill, then record the run:
+
+```bash
+date +%s > "$STATE_DIR/.last_lint"
+```
+
+Fold its summary (broken links, orphans, stale pages found) into Step 7's report as a `Health check:` line; omit the line entirely on a cycle where lint didn't run.
+
 **Step 5: Spawn impl-validator**
 
 After the cycle, spawn `impl-validator` as a subagent:
@@ -79,7 +101,7 @@ Apply any FAILs before logging.
 
 Append to `$OBSIDIAN_VAULT_PATH/log.md`:
 ```
-- [TIMESTAMP] DAILY-UPDATE fresh=N stale=N missing=N index_added=N hot_refreshed=true|false
+- [TIMESTAMP] DAILY-UPDATE fresh=N stale=N missing=N index_added=N hot_refreshed=true|false lint=ran|skipped
 ```
 
 **Step 7: Report to user**
@@ -90,6 +112,7 @@ Append to `$OBSIDIAN_VAULT_PATH/log.md`:
 - Sources: N fresh · N stale · N missing
 - Index: N pages (N added, N removed)
 - hot.md: refreshed / up to date
+- Health check: N broken links, N orphans, N stale pages (omit this line if lint didn't run this cycle)
 
 Stale sources (run to sync):
   /wiki-history-ingest claude   — N sessions since last ingest
@@ -158,6 +181,7 @@ This initializes `$STATE_DIR/.last_update` so the terminal notification works im
 
 Tell the user:
 - The cron runs daily at 9 AM (or on next login if missed)
+- `wiki-lint` health checks run on the `LINT_SCHEDULE` cadence (default `weekly`) as part of that cycle — set `LINT_SCHEDULE=daily` or `manual` in `.env` to change it
 - Terminal notifications appear when the wiki is >20 hours stale
 - State is stored in `<global config dir>/state/<vault-id>/` (XDG-style `~/.config/obsidian-wiki` by default, or the legacy `~/.obsidian-wiki` if that already exists) — supports multiple vaults independently
 - They can run `/daily-update` anytime to force a sync

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -612,6 +612,8 @@ The wiki is configured through environment variables (see `.env.example`). The o
 - `WIKI_STAGED_WRITES` — When `true`, all LLM-written pages go to `_staging/<category>/` for human review before promotion. See `wiki-setup` and `wiki-stage-commit` for details.
 - `CODE_UNDERSTANDING_BACKEND` — how wiki-update understands a project before distilling: `auto` (CodeGraph when available, else builtin ast-extract + rg; default), `builtin`, or `codegraph` (explicitly require; warn/error if unavailable).
 - `CODE_UNDERSTANDING_CODEGRAPH_BIN` — optional path to the codegraph binary when it isn't on PATH.
+- `OBSIDIAN_MAX_PAGES_PER_INGEST` — cap on pages created/updated per `wiki-ingest` run (default: `15`). See `wiki-ingest`, Step 4.
+- `LINT_SCHEDULE` — how often `daily-update` also runs `wiki-lint`: `daily` \| `weekly` (default) \| `manual`. See `daily-update`, Step 4a.
 
 No API keys are needed — the agent running these skills already has LLM access built in.
 

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -348,7 +348,7 @@ If the source is not project-specific, put everything in global categories.
 
 ### Step 4: Plan Updates
 
-Before writing anything, plan which pages to update or create. Aim for 10-15 pages per ingest. For each:
+Before writing anything, plan which pages to update or create. Cap the plan at `OBSIDIAN_MAX_PAGES_PER_INGEST` pages (default `15` if unset) — aim for 10 pages up to that cap. If the plan would exceed the cap, prioritize by importance tier (`core` > `supporting` > `peripheral`, see below) and defer the rest to a follow-up ingest; tell the user how many pages were deferred. For each:
 - Does this page already exist? (Check `index.md` and use Glob to search `OBSIDIAN_VAULT_PATH`)
 - If it exists, what new information does this source add?
 - If it's new, which category does it belong in?


### PR DESCRIPTION
## Summary
Closes #179. `LINT_SCHEDULE` and `OBSIDIAN_MAX_PAGES_PER_INGEST` were documented in `.env.example` and `docs/configuration.md` but no skill ever read them.

- `wiki-ingest` Step 4 caps its page plan at `OBSIDIAN_MAX_PAGES_PER_INGEST` (default `15`) instead of the hard-coded "10-15 pages" literal. When the plan exceeds the cap, it prioritizes by importance tier and reports the deferred count.
- `daily-update` gains Step 4a: it runs `wiki-lint` on the `LINT_SCHEDULE` cadence (`daily` / `weekly` / `manual`, default `weekly`), tracked via `$STATE_DIR/.last_lint`, and folds the result into the log line and user report.
- Added both vars to the env-var list in `llm-wiki/SKILL.md` to match `docs/configuration.md`.

## Test plan
- [x] Ran the issue's repro grep against this branch on st3ve; both vars now show hits under `.skills/`
- [x] Exercised the `LINT_SCHEDULE` gating logic on st3ve for `manual`, `daily`, `weekly` with a missing `.last_lint`, a 2-day-old one, and an 8-day-old one — all five gated correctly
- [x] Verified `OBSIDIAN_MAX_PAGES_PER_INGEST` default (15, unset) and override (5, set) on st3ve