### PR TITLE
fix(cache): normalize path separators in sha256_dir

### DIFF
--- a/obsidian_wiki/cache.py
+++ b/obsidian_wiki/cache.py
@@ -166,9 +166,9 @@ def sha256_file(path: Path, chunk: int = 1 << 20) -> str:
 def sha256_dir(path: Path) -> str:
     """Stable SHA-256 over all files in a directory tree (sorted by relative path)."""
     h = hashlib.sha256()
-    for fp in sorted(path.rglob("*")):
+    for fp in sorted(path.rglob("*"), key=lambda p: p.relative_to(path).as_posix()):
         if fp.is_file():
-            rel = str(fp.relative_to(path))
+            rel = fp.relative_to(path).as_posix()
             h.update(rel.encode())
             h.update(sha256_file(fp).encode())
     return h.hexdigest()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -69,6 +69,20 @@ class TestHashing:
         assert len(compute_hash(src_file)) == 64  # hex SHA-256
         assert len(compute_hash(src_dir)) == 64
 
+    def test_sha256_dir_independent_of_path_separator(self, src_dir):
+        """Hash must match hashlib computed with POSIX separators regardless of platform (#178)."""
+        import hashlib
+
+        (src_dir / "sub").mkdir()
+        (src_dir / "sub" / "c.py").write_text("z = 3")
+
+        h = hashlib.sha256()
+        for fp in sorted(src_dir.rglob("*"), key=lambda p: p.relative_to(src_dir).as_posix()):
+            if fp.is_file():
+                h.update(fp.relative_to(src_dir).as_posix().encode())
+                h.update(sha256_file(fp).encode())
+        assert sha256_dir(src_dir) == h.hexdigest()
+
     def test_hash_file_alias(self, src_file):
         assert hash_file(src_file) == sha256_file(src_file)
 


### PR DESCRIPTION
## Summary
- `sha256_dir()` fed the OS-native path separator into the hash (`str(fp.relative_to(path))`), so a directory source hashed differently on Windows vs. macOS/Linux for byte-identical content, and the `sorted()` ordering was separator-sensitive too.
- Now uses `.as_posix()` for both the hash input and the sort key, so directory-source hashes are stable across platforms.
- Fixes #178.

## Test plan
- [x] Added `test_sha256_dir_independent_of_path_separator` to `tests/test_cache.py`
- [x] `python3 -m pytest tests/test_cache.py -q` — 30 passed
- [x] `python3 -m pytest -q` (full suite) — 647 passed, 1 skipped