### PR TITLE
fix(cli): stabilize Windows skill setup

### DIFF
--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -15,6 +15,7 @@ import json
 import os
 import re
 import shutil
+import stat
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -108,6 +109,35 @@ def list_skills() -> list[str]:
 
 
 # ── Skill installation ───────────────────────────────────────────────────────
+def _is_link_or_junction(path: Path) -> bool:
+    """Return whether *path* is a link, including a Windows directory junction."""
+    if path.is_symlink():
+        return True
+
+    is_junction = getattr(path, "is_junction", None)
+    if is_junction is not None:
+        return bool(is_junction())
+
+    if os.name != "nt":
+        return False
+    try:
+        file_info = path.lstat()
+    except OSError:
+        return False
+
+    reparse_tag = getattr(file_info, "st_reparse_tag", None)
+    if reparse_tag is not None:
+        return reparse_tag == getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", 0xA0000003)
+
+    reparse_flag = getattr(stat, "FILE_ATTRIBUTE_REPARSE_POINT", 0x0400)
+    return bool(getattr(file_info, "st_file_attributes", 0) & reparse_flag)
+
+
+def _is_symlink_privilege_error(error: OSError) -> bool:
+    """Return whether Windows rejected link creation for missing privilege."""
+    return os.name == "nt" and getattr(error, "winerror", None) == 1314
+
+
 def install_skills(
     target_dir: Path,
     label: str,
@@ -120,13 +150,15 @@ def install_skills(
     src_root = skills_dir()
     target_dir.mkdir(parents=True, exist_ok=True)
     installed = 0
+    install_mode = mode
+    warned_copy_fallback = False
     for skill in sorted(p for p in src_root.iterdir() if p.is_dir()):
         name = skill.name
         if subset is not None and name not in subset:
             continue
         link_path = target_dir / name
 
-        if link_path.is_symlink() or link_path.is_file():
+        if _is_link_or_junction(link_path) or link_path.is_file():
             link_path.unlink()
         elif link_path.is_dir():
             # A real directory we previously copied here is safe to replace;
@@ -137,8 +169,21 @@ def install_skills(
                 print(f"   ⚠️  {link_path} is not a managed skill, skipping")
                 continue
 
-        if mode == "symlink":
-            link_path.symlink_to(skill, target_is_directory=True)
+        if install_mode == "symlink":
+            try:
+                link_path.symlink_to(skill, target_is_directory=True)
+            except OSError as error:
+                if not _is_symlink_privilege_error(error):
+                    raise
+                install_mode = "copy"
+                if not warned_copy_fallback:
+                    print(
+                        "Warning: symbolic links are unavailable; "
+                        "copying skills instead. Use Developer Mode or "
+                        "--copy to choose this explicitly."
+                    )
+                    warned_copy_fallback = True
+                shutil.copytree(skill, link_path)
         else:  # copy
             shutil.copytree(skill, link_path)
 
@@ -2222,7 +2267,20 @@ def _add_setup_args(sp: argparse.ArgumentParser) -> None:
     )
 
 
+def _configure_console_output() -> None:
+    """Keep status output from aborting when a console encoding lacks Unicode."""
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(errors="replace")
+        except (OSError, ValueError):
+            continue
+
+
 def main(argv: list[str] | None = None) -> int:
+    _configure_console_output()
     parser = build_parser()
     argv = list(sys.argv[1:] if argv is None else argv)
     # No subcommand → default to `setup` (the common case).

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import io
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+import obsidian_wiki.cli as cli
+
+
+def test_configure_console_output_replaces_unencodable_status_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    raw = io.BytesIO()
+    stream = io.TextIOWrapper(raw, encoding="gbk", errors="strict")
+    monkeypatch.setattr(cli.sys, "stdout", stream)
+
+    cli._configure_console_output()
+    print("✅", file=cli.sys.stdout)
+    cli.sys.stdout.flush()
+
+    assert raw.getvalue()
+    stream.detach()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="directory junctions are Windows-only")
+def test_install_skills_replaces_windows_junction(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source_root = tmp_path / "bundled-skills"
+    skill = source_root / "junction-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("---\nname: junction-skill\n---\n", encoding="utf-8")
+
+    target_root = tmp_path / "target-skills"
+    target_root.mkdir()
+    old_root = tmp_path / "old-skills"
+    old_skill = old_root / "junction-skill"
+    old_skill.mkdir(parents=True)
+    (old_skill / "SKILL.md").write_text("old\n", encoding="utf-8")
+
+    junction = target_root / "junction-skill"
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", str(junction), str(old_skill)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"directory junctions unavailable: {result.stderr or result.stdout}")
+
+    monkeypatch.setattr(cli, "skills_dir", lambda: source_root)
+
+    cli.install_skills(target_root, "test", mode="copy")
+
+    assert junction.is_dir()
+    assert (junction / "SKILL.md").read_text(encoding="utf-8") != "old\n"
+    assert (old_skill / "SKILL.md").read_text(encoding="utf-8") == "old\n"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows symlink privileges are Windows-only")
+def test_install_skills_falls_back_to_copy_without_symlink_privilege(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "bundled-skills"
+    skill = source_root / "privilege-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("copied\n", encoding="utf-8")
+    target_root = tmp_path / "target-skills"
+
+    def deny_symlink(self: Path, target: Path, target_is_directory: bool = False) -> None:
+        error = OSError("symbolic links are not permitted")
+        error.winerror = 1314
+        raise error
+
+    monkeypatch.setattr(cli, "skills_dir", lambda: source_root)
+    monkeypatch.setattr(Path, "symlink_to", deny_symlink)
+
+    cli.install_skills(target_root, "test")
+
+    installed = target_root / "privilege-skill"
+    assert installed.is_dir()
+    assert not installed.is_symlink()
+    assert (installed / "SKILL.md").read_text(encoding="utf-8") == "copied\n"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows symlink errors are Windows-only")
+def test_install_skills_keeps_unrelated_symlink_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    source_root = tmp_path / "bundled-skills"
+    skill = source_root / "broken-skill"
+    skill.mkdir(parents=True)
+    (skill / "SKILL.md").write_text("broken\n", encoding="utf-8")
+
+    def fail_symlink(self: Path, target: Path, target_is_directory: bool = False) -> None:
+        error = OSError("access denied")
+        error.winerror = 5
+        raise error
+
+    monkeypatch.setattr(cli, "skills_dir", lambda: source_root)
+    monkeypatch.setattr(Path, "symlink_to", fail_symlink)
+
+    with pytest.raises(OSError, match="access denied"):
+        cli.install_skills(tmp_path / "target-skills", "test")


### PR DESCRIPTION
## Summary

- Fix global skill installation when an existing Windows entry is a directory junction.
- Fall back to copied skills only when Windows rejects symlink creation with `WinError 1314`.
- Make CLI status output replacement-safe for GBK PowerShell consoles.
- Add regression coverage for junction replacement, privilege fallback, unrelated symlink errors, and console encoding.

Fixes #186
Related: #187, #188

## Root Cause

Windows `Path.is_symlink()` does not identify directory junctions, so the installer previously sent a junction to `shutil.rmtree()`. Standard Windows accounts can also lack the privilege required by `Path.symlink_to()`. Finally, strict GBK stdout encoding caused status icons to abort setup before installation.

## Test Plan

- [x] `python -m pytest -q tests/test_cli_install.py tests/test_ast_extractor.py tests/test_cache.py tests/test_graph_analysis.py tests/test_graphrag.py` (196 passed)
- [x] `python -m py_compile obsidian_wiki/cli.py`
- [x] `git diff --check`
- [x] Ran `obsidian-wiki setup --vault C:\Users\lichen\source\repos\TFX-DMS-Wiki\wiki` on Windows; exit code 0 and 40 skills installed per global agent directory
- [ ] Full suite: existing Windows doctor/environment failures remain outside this change