### PR TITLE
fix(graphrag): strip trailing punctuation on the gap and list query paths

### DIFF
--- a/obsidian_wiki/graphrag.py
+++ b/obsidian_wiki/graphrag.py
@@ -326,6 +326,16 @@ _STRUCTURAL = (
 )
 
 
+# Trailing punctuation to strip off extracted terms. A question mark left on a
+# token means it can never match a title, tag or summary.
+_TERM_PUNCT = "?,.'\""
+
+
+def _split_terms(text: str) -> list[str]:
+    """Split on whitespace, strip surrounding punctuation, drop empties."""
+    return [t for t in (w.strip(_TERM_PUNCT) for w in text.split()) if t]
+
+
 def classify_query(question: str) -> tuple[str, list[str]]:
     """Return (answer_type, extracted_terms).
 
@@ -348,16 +358,16 @@ def classify_query(question: str) -> tuple[str, list[str]]:
 
     if _GAP_PATTERNS.search(question):
         # Extract what the gap is about
-        terms = re.sub(r"what (?:do|don't) I (?:not )?know about|what.?s missing", "", question, flags=re.IGNORECASE).strip().split()
+        terms = _split_terms(re.sub(r"what (?:do|don't) I (?:not )?know about|what.?s missing", "", question, flags=re.IGNORECASE))
         return "gap", terms
 
     if _LIST_PATTERNS.search(question):
-        terms = re.sub(r"(?:list|show|find|give me) (?:all|every|pages about)", "", question, flags=re.IGNORECASE).strip().split()
+        terms = _split_terms(re.sub(r"(?:list|show|find|give me) (?:all|every|pages about)", "", question, flags=re.IGNORECASE))
         return "list", terms
 
     # Default: extract meaningful terms (drop stop words)
     stop = {"what", "the", "a", "an", "is", "are", "how", "does", "do", "in", "of", "to", "for", "and", "or"}
-    terms = [w.strip("?,.'\"") for w in question.split() if w.lower().strip("?,.'\"") not in stop and len(w) > 2]
+    terms = [w.strip(_TERM_PUNCT) for w in question.split() if w.lower().strip(_TERM_PUNCT) not in stop and len(w) > 2]
     return "direct", terms
 
 

--- a/tests/test_graphrag.py
+++ b/tests/test_graphrag.py
@@ -243,6 +243,24 @@ class TestClassifyQuery:
         assert "the" not in terms
         assert "is" not in terms
 
+    def test_gap_query_strips_trailing_punctuation(self):
+        # A trailing "?" used to survive on the gap path, leaving a term like
+        # "mise?" that can never match a title, tag or summary.
+        _, terms = classify_query("What do I know about mise?")
+        assert terms == ["mise"]
+
+    def test_list_query_strips_trailing_punctuation(self):
+        _, terms = classify_query("List all pages about transformers?")
+        assert "transformers" in terms
+        assert not any(t.endswith("?") for t in terms)
+
+    def test_gap_and_direct_agree_on_punctuation(self):
+        # Both paths must yield the same term for the same subject.
+        _, gap_terms = classify_query("What do I know about transformers?")
+        _, direct_terms = classify_query("What is transformers?")
+        assert "transformers" in gap_terms
+        assert "transformers" in direct_terms
+
 
 # ---------------------------------------------------------------------------
 # query (integration)


### PR DESCRIPTION
## Problem

`classify_query()` strips punctuation on the `direct` path but not on the `gap`
and `list` paths. Both of those end in `.strip().split()`, and `.strip()` without
arguments removes only whitespace — so a trailing `?` survives on the extracted
term.

The result is that a gap query returns nothing even when the page exists:

```python
from obsidian_wiki.graphrag import classify_query

classify_query("What do I know about mise?")   # ('gap', ['mise?'])   <- matches nothing
classify_query("What do I know about mise")    # ('gap', ['mise'])    <- finds the page
classify_query("What is mise?")                # ('direct', ['mise']) <- direct path is fine
```

`mise?` matches no title, tag or summary, so `query()` comes back with an empty
candidate list. Since gap questions nearly always end in a question mark, this
path was broken for its ordinary input.

## Fix

Both paths now go through a shared `_split_terms()` helper that splits on
whitespace and strips the same punctuation set the `direct` path already used,
now named `_TERM_PUNCT`.

The `direct` path keeps its behaviour unchanged — its `len(w) > 2` guard still
applies to the unstripped token, so only the inline literal is replaced by the
constant.

## Tests

Three regression tests in `TestClassifyQuery` cover the gap path, the list path,
and agreement between the gap and direct paths on the same subject. All three
fail without the fix.

Full suite: 651 passed, 1 skipped (648 before, +3 new).

## Note

While investigating this I ran into a second, larger issue in the same function:
`_score()` matches substrings without word boundaries, and the stop-word set is
English-only, so non-English questions about absent topics return a false
positive flagged `index_only: true` rather than an empty list. That one changes
ranking behaviour, so I left it out of this PR — happy to open a separate issue
with the measurements if that's useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
