### PR TITLE
fix(code-understand): gate codegraph index_state on codegraph.db alone

### DIFF
--- a/obsidian_wiki/code_understanding.py
+++ b/obsidian_wiki/code_understanding.py
@@ -68,21 +68,24 @@ def resolve_backend(
 def index_state(project: Path) -> tuple[bool, bool, str]:
     """Return (initialized, fresh, detail) for project/.codegraph.
 
-    initialized: codegraph.db exists AND source.json parses with a sourceDir
-    resolving to *project*. fresh: codegraph.db mtime >= the newest
+    initialized: codegraph.db exists. If source.json is also present (not
+    guaranteed — codegraph 1.5.0 never writes it), it must parse with a
+    sourceDir resolving to *project*, else the index is treated as
+    uninitialized (mismatch guard). fresh: codegraph.db mtime >= the newest
     git-tracked source file (no git or no files counts as fresh).
     """
     db = project / ".codegraph" / "codegraph.db"
     src = project / ".codegraph" / "source.json"
-    if not (db.exists() and src.exists()):
-        return False, False, "no index (missing .codegraph/codegraph.db or source.json)"
-    try:
-        data = json.loads(src.read_text(encoding="utf-8"))
-        source_dir = Path(str(data.get("sourceDir", ""))).resolve()
-    except (OSError, ValueError, TypeError):
-        return False, False, "source.json is invalid"
-    if source_dir != project.resolve():
-        return False, False, f"sourceDir {source_dir} does not match project"
+    if not db.exists():
+        return False, False, "no index (missing .codegraph/codegraph.db)"
+    if src.exists():
+        try:
+            data = json.loads(src.read_text(encoding="utf-8"))
+            source_dir = Path(str(data.get("sourceDir", ""))).resolve()
+        except (OSError, ValueError, TypeError):
+            return False, False, "source.json is invalid"
+        if source_dir != project.resolve():
+            return False, False, f"sourceDir {source_dir} does not match project"
     fresh = True
     try:
         tracked = _tracked_files_only(project)

--- a/tests/test_code_understanding.py
+++ b/tests/test_code_understanding.py
@@ -265,6 +265,17 @@ def test_index_state_heuristic(tmp_path: Path) -> None:
     assert initialized is True and fresh is False
 
 
+def test_index_state_initialized_without_source_json(tmp_path: Path) -> None:
+    """codegraph 1.5.0 never writes source.json; codegraph.db alone must count (#192)."""
+    project = make_project(tmp_path, {"src/foo.py": "class Foo:\n    pass\n"})
+    codegraph_dir = project / ".codegraph"
+    codegraph_dir.mkdir(exist_ok=True)
+    (codegraph_dir / "codegraph.db").touch()
+
+    initialized, _, _ = index_state(project)
+    assert initialized is True
+
+
 def test_codegraph_caps_impact_queries_on_full_scan(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- `index_state()` required both `.codegraph/codegraph.db` and `.codegraph/source.json` to consider the codegraph index initialized. codegraph 1.5.0 never writes `source.json`, so `initialized` was permanently `False`.
- This made `doctor`'s warning look cosmetic but wasn't: `ensure_index()` picked `init` unconditionally (its `sync` branch was unreachable), so the index silently never updated after the first run.
- `source.json` is now optional — used only as a `sourceDir` mismatch guard when present — and `initialized` is gated on `codegraph.db` alone.

## Test plan
- [x] Added `test_index_state_initialized_without_source_json` reproducing the issue's repro (db only, no source.json)
- [x] `python3 -m pytest tests/test_code_understanding.py tests/test_doctor.py tests/test_conftest_smoke.py -q` — 34 passed, 1 skipped

Fixes #192