### PR TITLE
feat: add global wiki writing profile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 *.pyc
 __pycache__/
+.worktrees/
 
 # Skill creator benchmark/review workspaces and local packages
 .skills/*-workspace/

--- a/.skills/claude-history-ingest/SKILL.md
+++ b/.skills/claude-history-ingest/SKILL.md
@@ -16,6 +16,9 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `CLAUDE_HISTORY_PATH` (defaults to `~/.claude`)
 2. Read `.manifest.json` at the vault root to check what's already been ingested
 3. Read `index.md` at the vault root to know what the wiki already contains

--- a/.skills/codex-history-ingest/SKILL.md
+++ b/.skills/codex-history-ingest/SKILL.md
@@ -16,6 +16,9 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `CODEX_HISTORY_PATH` (defaults to `~/.codex`)
 2. Read `.manifest.json` at the vault root to check what has already been ingested
 3. Read `index.md` at the vault root to understand what the wiki already contains

--- a/.skills/copilot-history-ingest/SKILL.md
+++ b/.skills/copilot-history-ingest/SKILL.md
@@ -19,6 +19,9 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `COPILOT_HISTORY_PATH` (defaults to `~/.copilot/session-state`), and `COPILOT_VSCODE_STORAGE_PATH` (VS Code `workspaceStorage`; platform-specific — ask the user if absent)
 2. Read `.manifest.json` at the vault root to check what's already been ingested
 3. Read `index.md` at the vault root to know what the wiki already contains

--- a/.skills/cross-linker/SKILL.md
+++ b/.skills/cross-linker/SKILL.md
@@ -18,6 +18,9 @@ You are weaving the wiki's knowledge graph tighter by finding and inserting miss
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `index.md` to get the full inventory of pages and their one-line descriptions
 3. Skim `log.md` to see what was recently ingested (focus linking effort on new pages)

--- a/.skills/hermes-history-ingest/SKILL.md
+++ b/.skills/hermes-history-ingest/SKILL.md
@@ -16,6 +16,9 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `HERMES_HISTORY_PATH` (defaults to `~/.hermes`)
 2. Read `.manifest.json` at the vault root to check what has already been ingested
 3. Read `index.md` at the vault root to understand what the wiki already contains

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -594,6 +594,14 @@ Every skill's setup section should read:
 
 > **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md`. Honor an inline `@name` override first, then walk up from CWD for `.env`, fall back to the global config, else prompt setup. This gives `OBSIDIAN_VAULT_PATH` and any tool-specific path overrides.
 
+## Writing Profile Resolution
+
+Before drafting or rewriting natural-language Markdown, resolve the global config directory with the XDG/legacy algorithm above, then read `<global config dir>/WRITING.md` when it exists. A missing or empty `WRITING.md` means there are no custom writing preferences. If that optional read fails, warn and continue with the default framework guidance.
+
+Apply writing guidance from the current project and the resolved vault's `AGENTS.md` over global `WRITING.md` preferences. Framework invariants — including schema, provenance, safety, and operation-specific requirements — always take precedence over all writing preferences.
+
+Writing preferences apply only to newly drafted or rewritten natural-language fields and body content. They do not change YAML frontmatter, JSON, structured logs, or pass-through content, which retain their required formats and source fidelity.
+
 ## Environment Variables
 
 The wiki is configured through environment variables (see `.env.example`). The only required variable is the vault path — everything else has sensible defaults.

--- a/.skills/llm-wiki/SKILL.md
+++ b/.skills/llm-wiki/SKILL.md
@@ -598,9 +598,9 @@ Every skill's setup section should read:
 
 Before drafting or rewriting natural-language Markdown, resolve the global config directory with the XDG/legacy algorithm above, then read `<global config dir>/WRITING.md` when it exists. A missing or empty `WRITING.md` means there are no custom writing preferences. If that optional read fails, warn and continue with the default framework guidance.
 
-Apply writing guidance from the current project and the resolved vault's `AGENTS.md` over global `WRITING.md` preferences. Framework invariants — including schema, provenance, safety, and operation-specific requirements — always take precedence over all writing preferences.
+The effective precedence is framework invariants > current task/skill requirements > current project `AGENTS.md` > vault `AGENTS.md` > global `WRITING.md`. Framework invariants include schema, provenance, and safety; operation-specific requirements remain authoritative for the current task. Unspecified project and vault rules are inherited from less-specific layers, and more specific same-topic rules win.
 
-Writing preferences apply only to newly drafted or rewritten natural-language fields and body content. They do not change YAML frontmatter, JSON, structured logs, or pass-through content, which retain their required formats and source fidelity.
+Writing preferences apply only to newly drafted or rewritten natural-language fields and body content. This includes natural-language title and summary values in YAML frontmatter, but preferences cannot alter YAML syntax, required keys, structure, types, or machine-generated fields. JSON, structured logs, and pass-through content remain unchanged and retain their required formats and source fidelity.
 
 ## Environment Variables
 

--- a/.skills/llm-wiki/references/WRITING.md
+++ b/.skills/llm-wiki/references/WRITING.md
@@ -1,0 +1,28 @@
+# Wiki Writing Profile
+
+> These preferences apply to wiki content only.
+> Preserve framework schema, provenance, and safety requirements.
+
+## Language
+
+## Tone and Voice
+
+## Structure and Content Density
+
+## Formatting
+
+## Evidence and Uncertainty
+
+## Terminology
+
+## Linking and Citations
+
+## Avoid
+
+## Conditional Rules
+
+### Concepts
+
+### References
+
+### Project Pages

--- a/.skills/openclaw-history-ingest/SKILL.md
+++ b/.skills/openclaw-history-ingest/SKILL.md
@@ -16,6 +16,9 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OPENCLAW_HISTORY_PATH` (defaults to `~/.openclaw`)
 2. Read `.manifest.json` at the vault root to check what has already been ingested
 3. Read `index.md` at the vault root to understand what the wiki already contains

--- a/.skills/pi-history-ingest/SKILL.md
+++ b/.skills/pi-history-ingest/SKILL.md
@@ -18,6 +18,9 @@ This skill can be invoked directly or via the `wiki-history-ingest` router (`/wi
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `PI_HISTORY_PATH` (defaults to `~/.pi/agent/sessions`)
 2. Read `.manifest.json` at the vault root to check what has already been ingested
 3. Read `index.md` at the vault root to understand what the wiki already contains

--- a/.skills/wiki-agent/SKILL.md
+++ b/.skills/wiki-agent/SKILL.md
@@ -34,6 +34,9 @@ If no query is given, default to **recent sessions mode**: ingest the last 5 unp
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Read `$OBSIDIAN_VAULT_PATH/.manifest.json` → know what's already ingested.
 3. Read `$OBSIDIAN_VAULT_PATH/hot.md` if it exists → warm context on recent wiki activity.

--- a/.skills/wiki-capture/SKILL.md
+++ b/.skills/wiki-capture/SKILL.md
@@ -16,6 +16,9 @@ description: >
 
 You are preserving knowledge from the current conversation as a permanent wiki note. The goal is to extract the *substance* — the knowledge itself — not a summary of what was said.
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown in any mode, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 This skill has three modes:
 
 - **Full mode (default)** — classify the content and write a finished, cross-linked wiki page directly into the right category. This is the rest of this document (Steps 1–7).
@@ -98,9 +101,6 @@ After writing the derived correction, link the immutable source to the created/u
 ## Full Mode
 
 ## Before You Start
-
-**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
-`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
 
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand existing wiki content (avoid duplicates)

--- a/.skills/wiki-capture/SKILL.md
+++ b/.skills/wiki-capture/SKILL.md
@@ -99,6 +99,9 @@ After writing the derived correction, link the immutable source to the created/u
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand existing wiki content (avoid duplicates)
 3. Read `$OBSIDIAN_VAULT_PATH/hot.md` if it exists — it gives context on recent activity

--- a/.skills/wiki-dashboard/SKILL.md
+++ b/.skills/wiki-dashboard/SKILL.md
@@ -14,6 +14,9 @@ Two tools available: **Obsidian Bases** (native, GUI-driven, no plugin) and **Da
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+Apply `WRITING.md` preferences only to optional Markdown dashboard prose; `.base` syntax remains unchanged.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand what categories and pages exist.
 3. Ask the user what they want to view if not specified — folder, tag, category, date range?

--- a/.skills/wiki-dedup/SKILL.md
+++ b/.skills/wiki-dedup/SKILL.md
@@ -17,6 +17,9 @@ You are finding and merging wiki pages that cover the same concept under differe
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT`.
 2. Read `index.md` to get the full page inventory with one-line descriptions and tags.
 3. Read `log.md` briefly — if a dedup run just happened, note what was already merged.

--- a/.skills/wiki-digest/SKILL.md
+++ b/.skills/wiki-digest/SKILL.md
@@ -15,6 +15,9 @@ You are generating a human-readable digest of recent wiki activity: what was lea
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT`.
 2. **Parse the period** from the user's request:
    - "daily" / "today" / "yesterday" → last 24 hours

--- a/.skills/wiki-import/SKILL.md
+++ b/.skills/wiki-import/SKILL.md
@@ -19,6 +19,9 @@ Either way, the import writes pages with correct frontmatter and wikilinks, then
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+Preserve imported source prose; apply `WRITING.md` preferences only to newly generated metadata or stubs.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`.
 2. Read `$OBSIDIAN_VAULT_PATH/AGENTS.md` if it exists — apply any owner-specific conventions.
 

--- a/.skills/wiki-ingest/SKILL.md
+++ b/.skills/wiki-ingest/SKILL.md
@@ -20,6 +20,9 @@ You are ingesting source documents into an Obsidian wiki. Your job is not to sum
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `OBSIDIAN_LINK_FORMAT` (default: `wikilink`), and `WIKI_STAGED_WRITES`. Only read the specific variables you need — do not log, echo, or reference any other values from these files.
 2. **Check `WIKI_STAGED_WRITES`** — if set to `true`, all new and updated category pages go to `_staging/<category>/` instead of their final location. Tell the user at the start of the ingest: "Staged writes mode is enabled — pages will land in `_staging/` for your review. Run `/wiki-stage-commit` when ready to promote."
 3. Read `.manifest.json` at the vault root to check what's already been ingested

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -18,6 +18,9 @@ You are performing a health check on an Obsidian wiki. Your goal is to find and 
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+Apply `WRITING.md` preferences only to generated consolidation reports; deterministic findings and fixes keep their existing formats.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` plus any `OBSIDIAN_ALLOWED_LIFECYCLES`, `OBSIDIAN_ALLOWED_RELATIONSHIP_TYPES`, `OBSIDIAN_REQUIRED_TRUST_FIELDS`, and `OBSIDIAN_SCHEMA_SOURCE` values.
 2. **Read owner rules** — if `$OBSIDIAN_VAULT_PATH/AGENTS.md` exists, read it before interpreting any schema. Owner rules override framework defaults.
 3. **Form the effective schema** — record the schema source locator plus effective required/optional frontmatter, lifecycle values, relationship types, and provenance markers. Framework values are defaults; preserve owner extensions and relaxed requiredness exactly. Never coerce an owner type to a framework type.

--- a/.skills/wiki-narrate/SKILL.md
+++ b/.skills/wiki-narrate/SKILL.md
@@ -27,6 +27,9 @@ new compiled knowledge pages.
 
 ## Retrieval
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. Resolve configuration with the Config Resolution Protocol, including an inline
    `@name` vault override, then read the target vault's `AGENTS.md` when it exists.
    Load `OBSIDIAN_LINK_FORMAT` before drafting citations.

--- a/.skills/wiki-research/SKILL.md
+++ b/.skills/wiki-research/SKILL.md
@@ -13,6 +13,9 @@ You are running an autonomous research loop on a topic, synthesizing what you fi
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `$OBSIDIAN_VAULT_PATH/index.md` to understand what's already in the wiki — don't re-research things the wiki covers well
 3. Read `$OBSIDIAN_VAULT_PATH/hot.md` if it exists — it surfaces recent context

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -62,26 +62,50 @@ If `.env` doesn't exist, create it from `.env.example`. Ask the user for:
    - When enabled: all new/updated pages land in `_staging/` first; run `/wiki-stage-commit` to review and promote them
    - `wiki-status` shows a "Staged writes pending" count when files are waiting
 
-After resolving the global config directory using the Config Resolution Protocol in
-`.skills/llm-wiki/SKILL.md`, create the shared writing profile only when it does not
+After resolving config, assign the global config directory with the exact
+`obsidian_wiki_config_dir` algorithm from the Config Resolution Protocol in
+`.skills/llm-wiki/SKILL.md`. Create the shared writing profile only when it does not
 already exist. Preserve an existing `$GLOBAL_CONFIG_DIR/WRITING.md`; never overwrite it
 and do not ask additional writing-style questions.
 
-Resolve the canonical template from `OBSIDIAN_WIKI_REPO` as follows:
+Use `OBSIDIAN_WIKI_REPO` when it was loaded from config. When it is absent, derive the
+absolute repository/data root from this loaded skill's absolute path, distinguishing the
+packaged `<root>/skills/wiki-setup/SKILL.md` layout from the source
+`<root>/.skills/wiki-setup/SKILL.md` layout. Then check both canonical template layouts:
 
-- Packaged install: `$OBSIDIAN_WIKI_REPO/skills/llm-wiki/references/WRITING.md`
-- Source checkout: `$OBSIDIAN_WIKI_REPO/.skills/llm-wiki/references/WRITING.md`
-
-Copy the first layout whose template exists:
+- Packaged install: `<root>/skills/llm-wiki/references/WRITING.md`
+- Source checkout: `<root>/.skills/llm-wiki/references/WRITING.md`
 
 ```bash
+GLOBAL_CONFIG_DIR="$(obsidian_wiki_config_dir)"
+mkdir -p "$GLOBAL_CONFIG_DIR"
+
+SKILL_FILE="<absolute path of this loaded wiki-setup/SKILL.md>"
+SKILL_DIR="$(cd "$(dirname "$SKILL_FILE")" && pwd)"
+if [ -n "${OBSIDIAN_WIKI_REPO:-}" ]; then
+  WIKI_ROOT="${OBSIDIAN_WIKI_REPO%/}"
+else
+  case "$SKILL_DIR" in
+    */.skills/wiki-setup) WIKI_ROOT="${SKILL_DIR%/.skills/wiki-setup}" ;;
+    */skills/wiki-setup) WIKI_ROOT="${SKILL_DIR%/skills/wiki-setup}" ;;
+    *) echo "Cannot derive writing-profile template root from $SKILL_DIR" >&2; exit 1 ;;
+  esac
+fi
+
+WRITING_TEMPLATE=""
+for candidate in \
+  "$WIKI_ROOT/skills/llm-wiki/references/WRITING.md" \
+  "$WIKI_ROOT/.skills/llm-wiki/references/WRITING.md"
+do
+  if [ -f "$candidate" ]; then
+    WRITING_TEMPLATE="$candidate"
+    break
+  fi
+done
+[ -n "$WRITING_TEMPLATE" ] || { echo "Writing profile template not found under $WIKI_ROOT" >&2; exit 1; }
+
 WRITING_PROFILE="$GLOBAL_CONFIG_DIR/WRITING.md"
 if [ ! -e "$WRITING_PROFILE" ]; then
-  if [ -e "$OBSIDIAN_WIKI_REPO/skills/llm-wiki/references/WRITING.md" ]; then
-    WRITING_TEMPLATE="$OBSIDIAN_WIKI_REPO/skills/llm-wiki/references/WRITING.md"
-  else
-    WRITING_TEMPLATE="$OBSIDIAN_WIKI_REPO/.skills/llm-wiki/references/WRITING.md"
-  fi
   cp "$WRITING_TEMPLATE" "$WRITING_PROFILE"
 fi
 ```
@@ -218,9 +242,10 @@ Run a quick sanity check:
 - [ ] `.env` has `OBSIDIAN_VAULT_PATH` set
 - [ ] `.obsidian/` directory exists
 - [ ] `_staging/` directory exists (required even when `WIKI_STAGED_WRITES` is not set — created on setup for future use)
+- [ ] `WRITING_PROFILE` exists at the resolved global config directory
 - [ ] Source directories (if configured) exist and are readable
 
-Report the results and tell the user they can now:
+Report the results, including the resolved absolute `WRITING_PROFILE` path, and tell the user they can now:
 1. Open the vault in Obsidian (File → Open Vault → select the directory)
 2. Run `wiki-status` to see what's available to ingest
 3. Run `wiki-ingest` to add their first sources

--- a/.skills/wiki-setup/SKILL.md
+++ b/.skills/wiki-setup/SKILL.md
@@ -62,6 +62,30 @@ If `.env` doesn't exist, create it from `.env.example`. Ask the user for:
    - When enabled: all new/updated pages land in `_staging/` first; run `/wiki-stage-commit` to review and promote them
    - `wiki-status` shows a "Staged writes pending" count when files are waiting
 
+After resolving the global config directory using the Config Resolution Protocol in
+`.skills/llm-wiki/SKILL.md`, create the shared writing profile only when it does not
+already exist. Preserve an existing `$GLOBAL_CONFIG_DIR/WRITING.md`; never overwrite it
+and do not ask additional writing-style questions.
+
+Resolve the canonical template from `OBSIDIAN_WIKI_REPO` as follows:
+
+- Packaged install: `$OBSIDIAN_WIKI_REPO/skills/llm-wiki/references/WRITING.md`
+- Source checkout: `$OBSIDIAN_WIKI_REPO/.skills/llm-wiki/references/WRITING.md`
+
+Copy the first layout whose template exists:
+
+```bash
+WRITING_PROFILE="$GLOBAL_CONFIG_DIR/WRITING.md"
+if [ ! -e "$WRITING_PROFILE" ]; then
+  if [ -e "$OBSIDIAN_WIKI_REPO/skills/llm-wiki/references/WRITING.md" ]; then
+    WRITING_TEMPLATE="$OBSIDIAN_WIKI_REPO/skills/llm-wiki/references/WRITING.md"
+  else
+    WRITING_TEMPLATE="$OBSIDIAN_WIKI_REPO/.skills/llm-wiki/references/WRITING.md"
+  fi
+  cp "$WRITING_TEMPLATE" "$WRITING_PROFILE"
+fi
+```
+
 ## Step 2: Create Vault Directory Structure
 
 ```bash

--- a/.skills/wiki-status/SKILL.md
+++ b/.skills/wiki-status/SKILL.md
@@ -16,6 +16,9 @@ You are computing the current state of the wiki: what's been ingested, what's ne
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+Apply `WRITING.md` preferences only to generated `_insights.md` prose; keep the analyser snapshot verbatim.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_SOURCES_DIR`, `CLAUDE_HISTORY_PATH`, and `CODEX_HISTORY_PATH`.
 2. Read `.manifest.json` at the vault root — this is the ingest tracking ledger
 

--- a/.skills/wiki-synthesize/SKILL.md
+++ b/.skills/wiki-synthesize/SKILL.md
@@ -14,6 +14,9 @@ You are scanning the wiki for concepts that co-occur across many pages but have 
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH` and `OBSIDIAN_LINK_FORMAT` (default: `wikilink`).
 2. Read `index.md` to get the full page inventory.
 3. Read `hot.md` if it exists — it surfaces recent activity and active threads that may already point to synthesis opportunities.

--- a/.skills/wiki-update/SKILL.md
+++ b/.skills/wiki-update/SKILL.md
@@ -14,6 +14,9 @@ You are distilling knowledge from the current project into the user's Obsidian w
 
 ## Before You Start
 
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+`WRITING.md` preferences apply only to newly drafted or rewritten natural-language Markdown; preserve source content and structured records.
+
 1. **Resolve config** — follow the Config Resolution Protocol in `llm-wiki/SKILL.md` (inline `@name` override → walk up CWD for `.env` → global config → prompt setup). This gives `OBSIDIAN_VAULT_PATH`, `OBSIDIAN_WIKI_REPO`, `OBSIDIAN_LINK_FORMAT` (`wikilink` default or `markdown`), and optional QMD settings such as `QMD_WIKI_COLLECTION`. Works from any project directory.
 3. Read `$OBSIDIAN_VAULT_PATH/.manifest.json` to check if this project has been synced before.
 4. Read `$OBSIDIAN_VAULT_PATH/index.md` to know what the wiki already contains.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,6 +17,30 @@ Earlier versions used `~/.obsidian-wiki`. That location is still honored: if `~/
 
 After resolving, skills also read `$OBSIDIAN_VAULT_PATH/AGENTS.md` if it exists. That's where you put owner-specific conventions — domain vocabulary, ingest preferences, writing style, project scoping — which override framework defaults for every skill.
 
+## Global wiki writing profile
+
+Setup creates a global `WRITING.md` profile for preferences that should apply across projects. New installs use `~/.config/obsidian-wiki/WRITING.md`. When the legacy `~/.obsidian-wiki` directory is active, the profile is `~/.obsidian-wiki/WRITING.md` instead.
+
+Start with a small profile and edit it to suit your habits:
+
+```markdown
+## Language
+
+Write in English. Keep technical terms in their original form.
+
+## Tone and Voice
+
+Be clear, concise, and practical.
+
+## Avoid
+
+Avoid filler, repetition, and unsupported claims.
+```
+
+Writing preferences are applied in this order, from highest to lowest precedence: framework and task requirements, project `AGENTS.md`, vault `AGENTS.md`, then global `WRITING.md`. The global profile guides wiki Markdown prose only. It does not change lint rules or create blocking behavior.
+
+If the profile is missing, empty, or unreadable, skills fall back to the framework defaults and continue without custom global preferences.
+
 Both the global config and `.env` use the same `KEY=value` format. Start from [`.env.example`](../.env.example).
 
 The deterministic `lint`, `trust-record`, and `trust-check` commands use the same vault-scoped resolution: an explicit path uses no unrelated config, `@name` reads only `<config dir>/config.<name>`, otherwise the nearest CWD `.env` wins before global config. Schema settings are read from that same resolved config only, so one vault's lifecycle extensions cannot leak into another vault.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -2,6 +2,8 @@
 
 Four ways in. Pick one — they all end at the same place: your vault path in the global config (`~/.config/obsidian-wiki/config`) and the skills discoverable by your agent.
 
+All full setup entry points — `obsidian-wiki setup`, `setup.sh`, and an agent running the `wiki-setup` skill — also create the global writing profile at `~/.config/obsidian-wiki/WRITING.md` (or the active legacy config directory). Rerunning setup never overwrites an existing profile. Edit `WRITING.md` to define your writing habits for every project that uses wiki skills.
+
 > **Upgrading from an older version?** The config directory used to be `~/.obsidian-wiki`. If you already have it, everything keeps working — that path is still honored and nothing needs to move. See [Where the global config lives](configuration.md#where-the-global-config-lives).
 
 | Path | Best for | Writes global config | Installs into all agents |

--- a/docs/superpowers/plans/2026-08-25-global-writing-profile.md
+++ b/docs/superpowers/plans/2026-08-25-global-writing-profile.md
@@ -1,0 +1,537 @@
+# Global Wiki Writing Profile Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provision a global, user-editable `WRITING.md` profile during setup and make every wiki content-writing skill apply it as prompt guidance with vault/project overrides.
+
+**Architecture:** Reuse `GLOBAL_CONFIG_DIR` for the profile location and add one canonical starter asset under `.skills/llm-wiki/references/WRITING.md`. The CLI and shell setup copy that asset only when the global profile is absent; skills consume it through a shared contract in `llm-wiki/SKILL.md`, while `AGENTS.md` remains the more-specific owner layer.
+
+**Tech Stack:** Python 3.9+ standard library CLI, Markdown skill instructions, POSIX shell setup, pytest/unittest test suite, Hatch wheel packaging.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-global-writing-profile-design.md`
+
+## Global Constraints
+
+- Store the user profile as `<resolved global config directory>/WRITING.md`; do not add `OBSIDIAN_WRITING_PROFILE` in this version.
+- Preserve XDG-first resolution and the legacy `~/.obsidian-wiki` fallback.
+- Create the profile only when it is absent; never overwrite, merge, or rewrite a user-edited profile during setup.
+- Apply preferences only to wiki content generation/editing; do not affect ordinary agent replies, code, commits, or unrelated project documentation.
+- Keep framework invariants, task/skill requirements, safety, provenance, frontmatter, staged writes, and machine-readable tracking formats higher priority than user style preferences.
+- Do not add dependencies, a rule parser, deterministic style linting, or a migration of existing pages.
+- Preserve the existing unstaged `.gitignore` change in the worktree; do not include it in feature commits.
+
+---
+
+## File Map
+
+### Create
+
+- `.skills/llm-wiki/references/WRITING.md` — canonical starter profile copied by all setup paths.
+- `tests/test_writing_profile_contract.py` — regression checks for the shared skill contract and documented scope.
+
+### Modify
+
+- `obsidian_wiki/cli.py:367-407, 957-978` — create the profile during CLI setup without overwriting it.
+- `setup.sh:116-154` — keep source-install setup behavior in parity with the CLI.
+- `.skills/llm-wiki/SKILL.md:532-595` — define the shared profile resolution contract and precedence.
+- `.skills/wiki-setup/SKILL.md:12-70` — make agent-driven setup create the same profile from the canonical asset.
+- `tests/test_write_config_preserves_user_keys.py` — test XDG, legacy, and non-destructive CLI profile setup.
+- `tests/test_scripts_packaging.py` — ensure the canonical profile asset and bundled skills tree are package inputs.
+- `tests/test_sync_setup_parity.py` — pin the shell setup's profile-copy behavior.
+- `docs/configuration.md` — document path, precedence, scope, and fallback behavior.
+- `docs/installation.md` — document setup creation and post-setup editing.
+- Content-producing skill docs listed in Task 4 — reference the shared profile contract.
+
+### Explicitly unchanged
+
+- `obsidian_wiki/server.py` — API content remains pass-through.
+- `.skills/wiki-stage-commit/SKILL.md`, `.skills/wiki-export/SKILL.md`, `.skills/wiki-rebuild/SKILL.md`, and `.skills/graph-colorize/SKILL.md` behavior — these preserve, move, archive, serialize, or edit machine configuration rather than drafting wiki prose.
+- Existing `.gitignore` user changes.
+
+---
+
+### Task 1: Add the canonical writing-profile template
+
+**Files:**
+- Create: `.skills/llm-wiki/references/WRITING.md`
+- Modify: `tests/test_scripts_packaging.py`
+
+**Interfaces:**
+- Produces the exact starter content that CLI, shell setup, and agent-driven setup will copy.
+- The template is bundled automatically because `pyproject.toml` already force-includes the complete `.skills/` tree as `obsidian_wiki/_data/skills`.
+
+- [ ] **Step 1: Write the failing packaging/template tests**
+
+Add these constants and tests to `tests/test_scripts_packaging.py`:
+
+```python
+WRITING_PROFILE_TEMPLATE = ROOT / ".skills" / "llm-wiki" / "references" / "WRITING.md"
+
+
+def test_writing_profile_template_exists(self) -> None:
+    self.assertTrue(WRITING_PROFILE_TEMPLATE.is_file())
+    body = WRITING_PROFILE_TEMPLATE.read_text()
+    self.assertIn("# Wiki Writing Profile", body)
+    self.assertIn("## Language", body)
+    self.assertIn("## Conditional Rules", body)
+
+
+def test_wheel_force_includes_skills_tree(self) -> None:
+    mapping = self.pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+    self.assertEqual(mapping.get(".skills"), "obsidian_wiki/_data/skills")
+```
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+pytest tests/test_scripts_packaging.py -q
+```
+
+Expected: `test_writing_profile_template_exists` fails because the canonical asset does not yet exist.
+
+- [ ] **Step 3: Add the minimal canonical template**
+
+Create `.skills/llm-wiki/references/WRITING.md` with exactly this starter structure:
+
+```markdown
+# Wiki Writing Profile
+
+> These preferences apply to wiki content only.
+> Preserve framework schema, provenance, and safety requirements.
+
+## Language
+
+## Tone and Voice
+
+## Structure and Content Density
+
+## Formatting
+
+## Evidence and Uncertainty
+
+## Terminology
+
+## Linking and Citations
+
+## Avoid
+
+## Conditional Rules
+
+### Concepts
+
+### References
+
+### Project Pages
+```
+
+Do not add frontmatter or machine-only keys to this file.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run:
+
+```bash
+pytest tests/test_scripts_packaging.py -q
+```
+
+Expected: all packaging/template tests pass.
+
+- [ ] **Step 5: Commit the isolated asset change**
+
+```bash
+git add .skills/llm-wiki/references/WRITING.md tests/test_scripts_packaging.py
+git commit -m "feat: add wiki writing profile template"
+```
+
+### Task 2: Provision `WRITING.md` from `obsidian-wiki setup`
+
+**Files:**
+- Modify: `obsidian_wiki/cli.py:367-407, 957-978`
+- Modify: `tests/test_write_config_preserves_user_keys.py`
+
+**Interfaces:**
+- Add `ensure_global_writing_profile() -> Path` beside `write_config()`.
+- The function returns `GLOBAL_CONFIG_DIR / "WRITING.md"`; it copies from `skills_dir() / "llm-wiki" / "references" / "WRITING.md"` only when the destination does not exist.
+- `cmd_setup()` calls the helper immediately after `write_config(vault_path)` so `--project-only` and vault setup both provision the global profile.
+
+- [ ] **Step 1: Write failing CLI setup tests**
+
+Extend `tests/test_write_config_preserves_user_keys.py` with:
+
+```python
+def test_setup_creates_global_writing_profile(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    proc = _setup(home, vault)
+    assert proc.returncode == 0, proc.stderr
+
+    profile = _config_dir(home) / "WRITING.md"
+    template = REPO_ROOT / ".skills" / "llm-wiki" / "references" / "WRITING.md"
+    assert profile.read_text() == template.read_text()
+
+
+def test_setup_preserves_existing_writing_profile(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config_dir = home / ".config" / "obsidian-wiki"
+    config_dir.mkdir(parents=True)
+    profile = config_dir / "WRITING.md"
+    profile.write_text("# My custom profile\n\nUse concise Traditional Chinese.\n")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    proc = _setup(home, vault)
+    assert proc.returncode == 0, proc.stderr
+    assert profile.read_text() == "# My custom profile\n\nUse concise Traditional Chinese.\n"
+```
+
+Also assert `WRITING.md` exists in the legacy-config test after setup.
+
+- [ ] **Step 2: Run the focused tests to verify they fail**
+
+Run:
+
+```bash
+pytest tests/test_write_config_preserves_user_keys.py -q
+```
+
+Expected: the new profile tests fail because `cmd_setup()` does not create the file yet.
+
+- [ ] **Step 3: Implement the minimal CLI helper**
+
+Add this helper near `write_config()`:
+
+```python
+def ensure_global_writing_profile() -> Path:
+    target = GLOBAL_CONFIG_DIR / "WRITING.md"
+    if target.exists():
+        return target
+    template = skills_dir() / "llm-wiki" / "references" / "WRITING.md"
+    target.write_text(template.read_text(encoding="utf-8"), encoding="utf-8")
+    return target
+```
+
+Call it after `write_config(vault_path)` in `cmd_setup()` and print the resolved path in the setup summary. Do not add an environment variable or modify `write_config()`'s user-key preservation logic.
+
+- [ ] **Step 4: Run the focused tests to verify they pass**
+
+Run:
+
+```bash
+pytest tests/test_write_config_preserves_user_keys.py tests/test_xdg_config_location.py -q
+```
+
+Expected: all setup/config tests pass, including both XDG and legacy behavior.
+
+- [ ] **Step 5: Commit the CLI provisioning change**
+
+```bash
+git add obsidian_wiki/cli.py tests/test_write_config_preserves_user_keys.py
+git commit -m "feat: provision global wiki writing profile"
+```
+
+### Task 3: Keep shell and agent-driven setup in parity
+
+**Files:**
+- Modify: `setup.sh:116-154`
+- Modify: `.skills/wiki-setup/SKILL.md:12-70`
+- Modify: `tests/test_sync_setup_parity.py`
+
+**Interfaces:**
+- `setup.sh` copies `.skills/llm-wiki/references/WRITING.md` into `$GLOBAL_CONFIG_DIR/WRITING.md` only when the destination is absent.
+- The `wiki-setup` skill resolves the same global directory and copies the same canonical template. In a packaged install, use `$OBSIDIAN_WIKI_REPO/skills/llm-wiki/references/WRITING.md`; in a source checkout, use `$OBSIDIAN_WIKI_REPO/.skills/llm-wiki/references/WRITING.md`.
+
+- [ ] **Step 1: Write the parity assertions**
+
+Add to `SetupShDelegatesToCliTest` in `tests/test_sync_setup_parity.py`:
+
+```python
+def test_creates_global_writing_profile_from_canonical_template(self) -> None:
+    self.assertIn("WRITING.md", self.setup_sh)
+    self.assertIn("llm-wiki/references/WRITING.md", self.setup_sh)
+```
+
+- [ ] **Step 2: Run the parity test to verify it fails**
+
+Run:
+
+```bash
+pytest tests/test_sync_setup_parity.py -q
+```
+
+Expected: the new assertion fails because `setup.sh` does not copy the profile yet.
+
+- [ ] **Step 3: Add the non-destructive shell copy**
+
+After `GLOBAL_CONFIG_DIR` is created and before the shell setup writes its config, add:
+
+```bash
+WRITING_PROFILE="$GLOBAL_CONFIG_DIR/WRITING.md"
+WRITING_TEMPLATE="$SKILLS_DIR/llm-wiki/references/WRITING.md"
+if [ ! -e "$WRITING_PROFILE" ]; then
+  cp "$WRITING_TEMPLATE" "$WRITING_PROFILE"
+fi
+```
+
+Update `.skills/wiki-setup/SKILL.md` with the same behavior and explicit instructions to preserve an existing profile. Do not make setup ask additional writing-style questions.
+
+- [ ] **Step 4: Run shell and parity checks**
+
+Run:
+
+```bash
+bash -n setup.sh
+pytest tests/test_sync_setup_parity.py -q
+```
+
+Expected: shell syntax and setup parity tests pass.
+
+- [ ] **Step 5: Commit setup parity**
+
+```bash
+git add setup.sh .skills/wiki-setup/SKILL.md tests/test_sync_setup_parity.py
+git commit -m "feat: keep writing profile setup paths aligned"
+```
+
+### Task 4: Define the shared profile contract and wire every prose-writing skill
+
+**Files:**
+- Modify: `.skills/llm-wiki/SKILL.md:532-595`
+- Modify: `.skills/wiki-capture/SKILL.md`
+- Modify: `.skills/wiki-ingest/SKILL.md`
+- Modify: `.skills/wiki-update/SKILL.md`
+- Modify: `.skills/wiki-research/SKILL.md`
+- Modify: `.skills/wiki-synthesize/SKILL.md`
+- Modify: `.skills/wiki-agent/SKILL.md`
+- Modify: `.skills/wiki-narrate/SKILL.md`
+- Modify: `.skills/wiki-digest/SKILL.md`
+- Modify: `.skills/wiki-dashboard/SKILL.md`
+- Modify: `.skills/wiki-status/SKILL.md`
+- Modify: `.skills/wiki-lint/SKILL.md`
+- Modify: `.skills/wiki-import/SKILL.md`
+- Modify: `.skills/wiki-dedup/SKILL.md`
+- Modify: `.skills/cross-linker/SKILL.md`
+- Modify: `.skills/claude-history-ingest/SKILL.md`
+- Modify: `.skills/codex-history-ingest/SKILL.md`
+- Modify: `.skills/copilot-history-ingest/SKILL.md`
+- Modify: `.skills/hermes-history-ingest/SKILL.md`
+- Modify: `.skills/openclaw-history-ingest/SKILL.md`
+- Modify: `.skills/pi-history-ingest/SKILL.md`
+- Create: `tests/test_writing_profile_contract.py`
+
+**Interfaces:**
+- The central section is named `Writing Profile Resolution` in `.skills/llm-wiki/SKILL.md`.
+- Each listed skill adds this exact setup guidance before drafting or rewriting prose:
+
+```markdown
+**Writing profile:** Before drafting or rewriting natural-language Markdown, read and apply the `Writing Profile Resolution` section in `llm-wiki/SKILL.md`. Framework schema, provenance, safety, and operation-specific requirements take precedence.
+```
+
+- `wiki-status` applies the profile only to generated `_insights.md` prose; its analyser snapshot remains verbatim.
+- `wiki-lint` applies it only to generated consolidation reports; deterministic findings and fixes keep their existing formats.
+- `wiki-import` preserves imported source prose and applies the profile only to newly generated metadata or stubs.
+- `wiki-dashboard` applies it only to optional Markdown dashboard prose; `.base` syntax remains unchanged.
+
+- [ ] **Step 1: Write the contract regression test**
+
+Create `tests/test_writing_profile_contract.py` with a fixed inventory of current prose-writing skills and assertions that the shared contract is present:
+
+```python
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = "Writing Profile Resolution"
+REQUIRED_SKILLS = (
+    "wiki-capture",
+    "wiki-ingest",
+    "wiki-update",
+    "wiki-research",
+    "wiki-synthesize",
+    "wiki-agent",
+    "wiki-narrate",
+    "wiki-digest",
+    "wiki-dashboard",
+    "wiki-status",
+    "wiki-lint",
+    "wiki-import",
+    "wiki-dedup",
+    "cross-linker",
+    "claude-history-ingest",
+    "codex-history-ingest",
+    "copilot-history-ingest",
+    "hermes-history-ingest",
+    "openclaw-history-ingest",
+    "pi-history-ingest",
+)
+
+
+def test_llm_wiki_defines_writing_profile_resolution() -> None:
+    body = (ROOT / ".skills" / "llm-wiki" / "SKILL.md").read_text()
+    assert CONTRACT in body
+    assert "WRITING.md" in body
+    assert "AGENTS.md" in body
+
+
+def test_every_current_prose_writer_references_the_contract() -> None:
+    for skill in REQUIRED_SKILLS:
+        body = (ROOT / ".skills" / skill / "SKILL.md").read_text()
+        assert CONTRACT in body, skill
+        assert "WRITING.md" in body, skill
+```
+
+- [ ] **Step 2: Run the contract test to verify it fails**
+
+Run:
+
+```bash
+pytest tests/test_writing_profile_contract.py -q
+```
+
+Expected: the test fails because the central contract and skill references do not yet exist.
+
+- [ ] **Step 3: Add the central resolution contract**
+
+Add a `Writing Profile Resolution` section to `.skills/llm-wiki/SKILL.md` that specifies:
+
+1. Resolve the global config directory with the existing XDG/legacy algorithm.
+2. Read `WRITING.md` when present; missing/empty profiles mean no custom preferences.
+3. Apply project and vault `AGENTS.md` writing guidance over global preferences.
+4. Keep framework invariants and operation requirements above all user preferences.
+5. Apply the profile to natural-language fields and body content, not YAML, JSON, structured logs, or pass-through content.
+6. Warn and continue with defaults when an optional profile cannot be read.
+
+Keep this section declarative and tool-agnostic; do not add a runtime parser or environment variable.
+
+- [ ] **Step 4: Add the one-line contract reference to each listed skill**
+
+Insert the exact guidance from the Interfaces block into each skill's existing `Before You Start` or equivalent writing step. Preserve each skill's current order, frontmatter rules, staged-write behavior, provenance rules, and QMD handling.
+
+Do not add the profile reference to pass-through/machine-output skills. For skills with mixed behavior, document the narrow scope specified above rather than applying style to machine data.
+
+- [ ] **Step 5: Run the contract test to verify it passes**
+
+Run:
+
+```bash
+pytest tests/test_writing_profile_contract.py -q
+```
+
+Expected: all contract assertions pass.
+
+- [ ] **Step 6: Commit the shared contract and skill wiring**
+
+```bash
+git add .skills/llm-wiki/SKILL.md .skills/wiki-capture/SKILL.md .skills/wiki-ingest/SKILL.md .skills/wiki-update/SKILL.md .skills/wiki-research/SKILL.md .skills/wiki-synthesize/SKILL.md .skills/wiki-agent/SKILL.md .skills/wiki-narrate/SKILL.md .skills/wiki-digest/SKILL.md .skills/wiki-dashboard/SKILL.md .skills/wiki-status/SKILL.md .skills/wiki-lint/SKILL.md .skills/wiki-import/SKILL.md .skills/wiki-dedup/SKILL.md .skills/cross-linker/SKILL.md .skills/claude-history-ingest/SKILL.md .skills/codex-history-ingest/SKILL.md .skills/copilot-history-ingest/SKILL.md .skills/hermes-history-ingest/SKILL.md .skills/openclaw-history-ingest/SKILL.md .skills/pi-history-ingest/SKILL.md tests/test_writing_profile_contract.py
+git commit -m "docs: apply global writing profile contract"
+```
+
+### Task 5: Document the user-facing configuration
+
+**Files:**
+- Modify: `docs/configuration.md`
+- Modify: `docs/installation.md`
+
+**Interfaces:**
+- Documentation names the exact file `WRITING.md`, the XDG and legacy paths, the project/vault/global precedence, and the prompt-only scope.
+- Documentation explicitly says setup preserves an existing profile and missing profiles retain framework defaults.
+
+- [ ] **Step 1: Add the configuration documentation**
+
+Add a “Global wiki writing profile” section to `docs/configuration.md` immediately after global config resolution. Include:
+
+- `~/.config/obsidian-wiki/WRITING.md` as the new default.
+- `~/.obsidian-wiki/WRITING.md` when the legacy directory is active.
+- A short starter example with `## Language`, `## Tone and Voice`, and `## Avoid`.
+- Precedence: framework/task requirements, project `AGENTS.md`, vault `AGENTS.md`, global `WRITING.md`.
+- Scope: wiki Markdown prose only; no lint/blocking behavior.
+- Missing/empty/unreadable profile fallback.
+
+- [ ] **Step 2: Add the installation documentation**
+
+Update `docs/installation.md` to say that all setup entry points create the global profile, that the file is not overwritten on reruns, and that users can edit it to define their writing habits for every project using wiki skills.
+
+- [ ] **Step 3: Run documentation and existing sync checks**
+
+Run:
+
+```bash
+pytest tests/test_readme_sync.py tests/test_writing_profile_contract.py -q
+```
+
+Expected: documentation-related regression checks pass; no README translation change is required because this feature is documented under `docs/`.
+
+- [ ] **Step 4: Commit the documentation**
+
+```bash
+git add docs/configuration.md docs/installation.md
+git commit -m "docs: explain global wiki writing profile"
+```
+
+### Task 6: Run the complete verification pass
+
+**Files:**
+- Test: all existing `tests/` plus the new profile tests.
+- Inspect: `git status --short` and the commits created by Tasks 1–5.
+
+**Interfaces:**
+- No new runtime dependency is allowed.
+- The only expected pre-existing worktree change is the user's `.gitignore` modification.
+
+- [ ] **Step 1: Run focused feature tests**
+
+```bash
+pytest tests/test_scripts_packaging.py tests/test_write_config_preserves_user_keys.py tests/test_xdg_config_location.py tests/test_sync_setup_parity.py tests/test_writing_profile_contract.py -q
+```
+
+Expected: all focused tests pass.
+
+- [ ] **Step 2: Run shell and syntax checks**
+
+```bash
+bash -n setup.sh
+python -m compileall -q obsidian_wiki
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 3: Run the full test suite**
+
+```bash
+pytest -q
+```
+
+Expected: the full suite passes with no new warnings or failures.
+
+- [ ] **Step 4: Run a temporary-home setup smoke test**
+
+Use a temporary home and vault so the real global profile is not changed:
+
+```bash
+TEST_HOME="$(mktemp -d)"
+TEST_VAULT="$(mktemp -d)"
+HOME="$TEST_HOME" PYTHONPATH="$(pwd)" python -m obsidian_wiki.cli setup --vault "$TEST_VAULT" --project-only
+test -s "$TEST_HOME/.config/obsidian-wiki/WRITING.md"
+```
+
+Expected: setup reports the profile path and the file contains `# Wiki Writing Profile`.
+
+- [ ] **Step 5: Verify the worktree and commits**
+
+```bash
+git status --short
+git log --oneline -6
+```
+
+Expected: the feature commits contain only the planned files; the pre-existing `.gitignore` change remains uncommitted and intact.
+
+## Plan Self-Review Checklist
+
+- Spec coverage: storage, template, setup parity, precedence, loading, error handling, scope, docs, tests, compatibility, and acceptance criteria are covered by Tasks 1–6.
+- Placeholder scan: no `TODO`, `TBD`, “implement later”, or unspecified edge-case steps remain.
+- Type consistency: `ensure_global_writing_profile() -> Path` is the only new Python interface; all callers use its returned path only for reporting.
+- Scope: one subsystem—global wiki writing guidance—implemented through the existing config/setup/skill documentation surfaces.

--- a/docs/superpowers/specs/2026-08-25-global-writing-profile-design.md
+++ b/docs/superpowers/specs/2026-08-25-global-writing-profile-design.md
@@ -1,0 +1,206 @@
+# Global Wiki Writing Profile
+
+- Status: Approved design
+- Date: 2026-08-25
+
+## Summary
+
+Add a user-editable global `WRITING.md` profile that supplies writing preferences to every wiki skill used from any project. The profile is loaded through the existing configuration and owner-rule model, with more specific project and vault guidance taking precedence over the global defaults.
+
+The feature is prompt guidance only. It does not add a rule language, deterministic style linting, or content transformation.
+
+## Goals
+
+- Let a user define language, tone, structure, terminology, evidence, and other wiki-writing habits once.
+- Create the profile during `obsidian-wiki setup` without requiring a questionnaire.
+- Apply the profile to wiki content generated or edited from any project.
+- Preserve the existing XDG global-config path and legacy `~/.obsidian-wiki` fallback.
+- Support vault- and project-specific overrides through the existing `AGENTS.md` conventions.
+- Keep machine-readable metadata, safety constraints, and provenance requirements intact.
+- Make setup reruns non-destructive.
+
+## Non-goals
+
+- The profile does not affect ordinary agent replies, code, commit messages, or unrelated project documentation.
+- The profile does not validate or block a write when a preference is missed.
+- The profile does not replace `AGENTS.md`, the Config Resolution Protocol, or the wiki schema.
+- The profile does not rewrite existing pages or migrate existing style.
+- The HTTP/MCP server does not reinterpret or transform API-provided content.
+- No `OBSIDIAN_WRITING_PROFILE` environment variable is introduced in the first version.
+
+## Existing extension points
+
+The implementation reuses three existing mechanisms:
+
+1. `GLOBAL_CONFIG_DIR` already resolves the XDG path and the legacy fallback.
+2. `llm-wiki/SKILL.md` already owns the Config Resolution Protocol and tells skills to read the vault's `AGENTS.md`.
+3. Skills already share the framework schema through `llm-wiki`, while individual write skills define operation-specific behavior.
+
+The global profile is therefore a new file in the existing global config directory, not a second configuration system.
+
+## Design
+
+### 1. Profile storage
+
+The user-facing profile is:
+
+```text
+<global-config-dir>/WRITING.md
+```
+
+For a new installation this resolves to:
+
+```text
+~/.config/obsidian-wiki/WRITING.md
+```
+
+If the legacy global config directory is active, the profile is stored beside its existing `config` file:
+
+```text
+~/.obsidian-wiki/WRITING.md
+```
+
+The repository contains one canonical starter template at:
+
+```text
+.skills/llm-wiki/references/WRITING.md
+```
+
+The packaged CLI can locate the same asset through its bundled skills directory. `setup.sh`, the CLI setup command, and the agent-driven `wiki-setup` flow all use this template so their behavior cannot drift.
+
+`WRITING.md` is created only when it does not already exist. Re-running setup never overwrites it.
+
+### 2. Profile format
+
+The profile is ordinary Markdown. There is no YAML schema, DSL, required frontmatter, or parser-specific syntax. The starter template provides useful headings while allowing the user to write, remove, rename, or extend them:
+
+```markdown
+# Wiki Writing Profile
+
+> These preferences apply to wiki content only.
+> Preserve framework schema, provenance, and safety requirements.
+
+## Language
+
+## Tone and Voice
+
+## Structure and Content Density
+
+## Formatting
+
+## Evidence and Uncertainty
+
+## Terminology
+
+## Linking and Citations
+
+## Avoid
+
+## Conditional Rules
+
+### Concepts
+
+### References
+
+### Project Pages
+```
+
+Natural-language rules such as “先講結論” or “技術名詞保留英文，第一次出現時補中文說明” are valid. Empty sections have no effect.
+
+### 3. Effective rule precedence
+
+The effective instruction stack is:
+
+```text
+framework invariants
+  > current task and skill requirements
+  > current project AGENTS.md guidance
+  > vault AGENTS.md guidance
+  > global WRITING.md preferences
+```
+
+The first two layers are not user-style preferences and cannot be disabled. They cover safety, data preservation, required frontmatter, provenance, source tracking, staged writes, paper-specific templates, and other operation contracts.
+
+Within user-defined writing guidance, unspecified rules are inherited and a more specific rule wins when it addresses the same topic. A project may therefore say “for this project, use English headings” without replacing the rest of the global profile.
+
+The vault's `AGENTS.md` keeps its current owner-authority semantics. Project-specific writing guidance follows the host agent's existing `AGENTS.md` context; the documentation recommends a `## Wiki Writing Rules` section so writing preferences remain distinguishable from build and code instructions.
+
+### 4. Loading contract
+
+Every skill that composes or edits natural-language Markdown in the vault follows this sequence:
+
+1. Resolve the vault and config using the existing Config Resolution Protocol.
+2. Resolve the global config directory using the existing XDG/legacy rule.
+3. Read `<global-config-dir>/WRITING.md` when present.
+4. Apply the vault `AGENTS.md` and current project `AGENTS.md` writing guidance.
+5. Apply the effective guidance while performing the skill's existing operation.
+
+`llm-wiki/SKILL.md` owns the common loading contract. Each write-capable skill references that contract in its setup section rather than duplicating the profile algorithm. The rule is capability-based: any future skill that writes wiki Markdown must load the contract, so a fixed list of skill names does not become a missed-update trap.
+
+The profile applies to natural-language fields and body content, including page titles, summaries, headings, link display text, index descriptions, hot-cache takeaways, and readouts. It does not alter YAML syntax, JSON manifests, structured log records, or existing staged content being promoted unchanged.
+
+Read-only skills do not need to load the profile. A skill that only moves, archives, exports, or promotes already-written content preserves that content instead of regenerating it. The API server remains a pass-through writer because it has no LLM prompt stage.
+
+### 5. Setup behavior
+
+`obsidian-wiki setup` performs the following after resolving the global config directory:
+
+1. Create the directory if needed.
+2. Copy the canonical `WRITING.md` template only when the destination is absent.
+3. Report the profile path in the setup summary.
+4. Leave an existing profile byte-for-byte unchanged.
+
+`setup.sh` and the agent-driven `wiki-setup` instructions provide the same behavior and path. No editor is launched and no detailed writing questionnaire is required; the user edits the template when ready.
+
+Existing installations remain valid. If the profile is absent, skills use current framework defaults exactly as they do today.
+
+### 6. Error handling
+
+- Missing profile: silently use framework defaults; setup may report that the file was not present before creation.
+- Empty profile: treat it as no custom preferences.
+- Read failure or invalid text encoding: warn the user, skip the profile, and continue with framework defaults. Do not block a wiki write solely because an optional preference file is unreadable.
+- Conflicting user preferences: use the more specific project/vault rule when the intent is clear; preserve framework and task requirements regardless.
+- Existing profile during setup: never overwrite, merge, or rewrite it.
+
+### 7. Documentation and verification
+
+Update the following documentation surfaces:
+
+- `docs/configuration.md`: profile path, precedence, scope, and fallback behavior.
+- `docs/installation.md`: setup creates `WRITING.md` and the user edits it after installation.
+- `.skills/llm-wiki/SKILL.md`: loading contract and profile scope.
+- `.skills/wiki-setup/SKILL.md`: setup behavior and starter template reference.
+- Relevant write-capable skill instructions: reference the shared contract.
+
+Automated checks should cover:
+
+- Fresh XDG setup creates `<config-dir>/WRITING.md`.
+- Existing legacy setup creates the profile beside `~/.obsidian-wiki/config`.
+- Re-running setup preserves a user-edited profile.
+- The packaged/source canonical template is available to setup.
+- The documented write-capable skill contract is present for the skills that generate or edit wiki prose.
+
+Natural-language adherence is not unit-tested because this feature intentionally provides prompt guidance rather than deterministic validation. A manual acceptance check should customize the profile with a distinctive language or tone rule, run a wiki-writing skill from a separate project, and verify that the generated prose follows the rule while frontmatter and tracking files remain valid.
+
+## Compatibility and rollout
+
+The change is additive and backward-compatible:
+
+- No existing vault files are migrated.
+- No existing config keys are removed or rewritten.
+- No profile means no behavior change.
+- Legacy global config locations continue to work.
+- Existing `AGENTS.md` owner rules remain authoritative.
+- Staged-write review and all existing provenance/trust workflows remain unchanged.
+
+## Acceptance criteria
+
+The design is complete when all of the following are true:
+
+1. A fresh `obsidian-wiki setup` creates `WRITING.md` at the resolved global config directory.
+2. A user can edit that Markdown file and have its preferences available to wiki-writing skills from another project.
+3. Vault and project `AGENTS.md` guidance can override global preferences without replacing unrelated inherited rules.
+4. Framework invariants and operation-specific requirements remain effective even when a profile conflicts with them.
+5. Missing or unreadable optional profile content never causes data loss or blocks a write.
+6. Re-running setup preserves user customizations.
+7. The behavior is documented consistently for CLI, shell, and agent-driven setup.

--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -407,6 +407,15 @@ def write_config(vault_path: str) -> None:
     print(f"✅  Global config written to {GLOBAL_CONFIG}")
 
 
+def ensure_global_writing_profile() -> Path:
+    target = GLOBAL_CONFIG_DIR / "WRITING.md"
+    if target.exists():
+        return target
+    template = skills_dir() / "llm-wiki" / "references" / "WRITING.md"
+    target.write_text(template.read_text(encoding="utf-8"), encoding="utf-8")
+    return target
+
+
 VAULT_SUBDIRS = (
     "concepts",
     "entities",
@@ -962,6 +971,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
 
     vault_path = resolve_vault_path(args.vault)
     write_config(vault_path)
+    writing_profile = ensure_global_writing_profile()
     if not vault_path:
         print("    → Vault path not set yet. Re-run with `--vault /path/to/vault`")
         print(f"      or edit OBSIDIAN_VAULT_PATH in {GLOBAL_CONFIG}.")
@@ -991,6 +1001,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     print(f" Skills installed: {n}  (mode: {mode})")
     if vault_path:
         print(f" Vault:            {vault_path}")
+    print(f" Writing profile:  {writing_profile.resolve()}")
     if sync_configured:
         print(" GitHub sync:      obsidian-wiki sync")
     print("\n Next steps:")

--- a/setup.sh
+++ b/setup.sh
@@ -126,6 +126,12 @@ fi
 GLOBAL_CONFIG="$GLOBAL_CONFIG_DIR/config"
 mkdir -p "$GLOBAL_CONFIG_DIR"
 
+WRITING_PROFILE="$GLOBAL_CONFIG_DIR/WRITING.md"
+WRITING_TEMPLATE="$SKILLS_DIR/llm-wiki/references/WRITING.md"
+if [ ! -e "$WRITING_PROFILE" ]; then
+  cp "$WRITING_TEMPLATE" "$WRITING_PROFILE"
+fi
+
 # Read vault path from .env if it's already set
 VAULT_PATH=""
 if [ -f "$SCRIPT_DIR/.env" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -297,6 +297,7 @@ echo "────────────────────────�
 echo " Setup complete!"
 echo ""
 echo " Skills found:    $SKILL_COUNT"
+echo " Writing profile:  $WRITING_PROFILE"
 echo " Agents ready:    Claude Code, Cursor, Windsurf, Gemini CLI, Antigravity,"
 echo "                  Codex, Hermes, OpenClaw, OpenCode, Aider, Factory Droid,"
 echo "                  Trae, Trae CN, Kiro, Pi, GitHub Copilot (CLI + VS Code Chat)"

--- a/tests/test_scripts_packaging.py
+++ b/tests/test_scripts_packaging.py
@@ -23,6 +23,7 @@ except ModuleNotFoundError:  # Python < 3.11
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPTS_DIR = ROOT / "scripts"
 PACKAGED_SCRIPTS_DEST = "obsidian_wiki/_data/scripts"
+WRITING_PROFILE_TEMPLATE = ROOT / ".skills" / "llm-wiki" / "references" / "WRITING.md"
 
 REFERENCED_SCRIPTS = (
     "daily-update.sh",
@@ -48,6 +49,17 @@ class ScriptsPackagingTest(unittest.TestCase):
             PACKAGED_SCRIPTS_DEST,
             "wheel must force-include scripts/ under _data/scripts/",
         )
+
+    def test_writing_profile_template_exists(self) -> None:
+        self.assertTrue(WRITING_PROFILE_TEMPLATE.is_file())
+        body = WRITING_PROFILE_TEMPLATE.read_text()
+        self.assertIn("# Wiki Writing Profile", body)
+        self.assertIn("## Language", body)
+        self.assertIn("## Conditional Rules", body)
+
+    def test_wheel_force_includes_skills_tree(self) -> None:
+        mapping = self.pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+        self.assertEqual(mapping.get(".skills"), "obsidian_wiki/_data/skills")
 
     def test_scripts_dir_not_excluded_from_sdist(self) -> None:
         # Unlike /.claude, scripts/ isn't pruned, so the default VCS-tracked

--- a/tests/test_sync_setup_parity.py
+++ b/tests/test_sync_setup_parity.py
@@ -26,6 +26,9 @@ class SetupShDelegatesToCliTest(unittest.TestCase):
         self.assertIn("WRITING.md", self.setup_sh)
         self.assertIn("llm-wiki/references/WRITING.md", self.setup_sh)
 
+    def test_reports_resolved_writing_profile_path(self) -> None:
+        self.assertIn('Writing profile:  $WRITING_PROFILE', self.setup_sh)
+
     def test_calls_cli_module_not_a_standalone_git_flow(self) -> None:
         self.assertIn("obsidian_wiki.cli", self.setup_sh)
 

--- a/tests/test_sync_setup_parity.py
+++ b/tests/test_sync_setup_parity.py
@@ -22,6 +22,10 @@ class SetupShDelegatesToCliTest(unittest.TestCase):
     def test_calls_sync_setup_subcommand(self) -> None:
         self.assertIn("sync-setup", self.setup_sh)
 
+    def test_creates_global_writing_profile_from_canonical_template(self) -> None:
+        self.assertIn("WRITING.md", self.setup_sh)
+        self.assertIn("llm-wiki/references/WRITING.md", self.setup_sh)
+
     def test_calls_cli_module_not_a_standalone_git_flow(self) -> None:
         self.assertIn("obsidian_wiki.cli", self.setup_sh)
 

--- a/tests/test_write_config_preserves_user_keys.py
+++ b/tests/test_write_config_preserves_user_keys.py
@@ -92,6 +92,7 @@ def test_setup_on_legacy_config_preserves_keys(tmp_path: Path) -> None:
     values = _values(config)
     assert values["OBSIDIAN_LINK_FORMAT"] == "markdown"
     assert values["OBSIDIAN_VAULT_PATH"] == str(vault)
+    assert (legacy / "WRITING.md").exists()
 
 
 def test_setup_writes_managed_keys_on_a_fresh_config(tmp_path: Path) -> None:
@@ -107,6 +108,34 @@ def test_setup_writes_managed_keys_on_a_fresh_config(tmp_path: Path) -> None:
     assert values["OBSIDIAN_VAULT_PATH"] == str(vault)
     assert values["OBSIDIAN_WIKI_REPO"]
     assert values["OBSIDIAN_WIKI_VERSION"]
+
+
+def test_setup_creates_global_writing_profile(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    proc = _setup(home, vault)
+    assert proc.returncode == 0, proc.stderr
+
+    profile = _config_dir(home) / "WRITING.md"
+    template = REPO_ROOT / ".skills" / "llm-wiki" / "references" / "WRITING.md"
+    assert profile.read_text() == template.read_text()
+
+
+def test_setup_preserves_existing_writing_profile(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    config_dir = home / ".config" / "obsidian-wiki"
+    config_dir.mkdir(parents=True)
+    profile = config_dir / "WRITING.md"
+    profile.write_text("# My custom profile\n\nUse concise Traditional Chinese.\n")
+    vault = tmp_path / "vault"
+    vault.mkdir()
+
+    proc = _setup(home, vault)
+    assert proc.returncode == 0, proc.stderr
+    assert profile.read_text() == "# My custom profile\n\nUse concise Traditional Chinese.\n"
 
 
 def test_setup_collapses_duplicate_managed_keys(tmp_path: Path) -> None:

--- a/tests/test_writing_profile_contract.py
+++ b/tests/test_writing_profile_contract.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONTRACT = "Writing Profile Resolution"
+REQUIRED_SKILLS = (
+    "wiki-capture",
+    "wiki-ingest",
+    "wiki-update",
+    "wiki-research",
+    "wiki-synthesize",
+    "wiki-agent",
+    "wiki-narrate",
+    "wiki-digest",
+    "wiki-dashboard",
+    "wiki-status",
+    "wiki-lint",
+    "wiki-import",
+    "wiki-dedup",
+    "cross-linker",
+    "claude-history-ingest",
+    "codex-history-ingest",
+    "copilot-history-ingest",
+    "hermes-history-ingest",
+    "openclaw-history-ingest",
+    "pi-history-ingest",
+)
+
+
+def test_llm_wiki_defines_writing_profile_resolution() -> None:
+    body = (ROOT / ".skills" / "llm-wiki" / "SKILL.md").read_text()
+    assert CONTRACT in body
+    assert "WRITING.md" in body
+    assert "AGENTS.md" in body
+
+
+def test_every_current_prose_writer_references_the_contract() -> None:
+    for skill in REQUIRED_SKILLS:
+        body = (ROOT / ".skills" / skill / "SKILL.md").read_text()
+        assert CONTRACT in body, skill
+        assert "WRITING.md" in body, skill

--- a/tests/test_writing_profile_contract.py
+++ b/tests/test_writing_profile_contract.py
@@ -34,6 +34,47 @@ def test_llm_wiki_defines_writing_profile_resolution() -> None:
     assert "AGENTS.md" in body
 
 
+def test_llm_wiki_defines_exact_precedence_and_inheritance() -> None:
+    body = (ROOT / ".skills" / "llm-wiki" / "SKILL.md").read_text()
+    assert (
+        "framework invariants > current task/skill requirements > current project "
+        "`AGENTS.md` > vault `AGENTS.md` > global `WRITING.md`"
+    ) in body
+    assert "Unspecified project and vault rules are inherited" in body
+    assert "more specific same-topic rules win" in body
+
+
+def test_llm_wiki_scopes_frontmatter_and_structured_content() -> None:
+    body = (ROOT / ".skills" / "llm-wiki" / "SKILL.md").read_text()
+    assert "natural-language title and summary values in YAML frontmatter" in body
+    assert (
+        "cannot alter YAML syntax, required keys, structure, types, or machine-generated fields"
+    ) in body
+    assert "JSON, structured logs, and pass-through content remain unchanged" in body
+
+
+def test_wiki_setup_resolves_global_path_and_template_without_repo_config() -> None:
+    body = (ROOT / ".skills" / "wiki-setup" / "SKILL.md").read_text()
+    assert 'GLOBAL_CONFIG_DIR="$(obsidian_wiki_config_dir)"' in body
+    assert 'SKILL_FILE="<absolute path of this loaded wiki-setup/SKILL.md>"' in body
+    assert 'if [ -n "${OBSIDIAN_WIKI_REPO:-}" ]; then' in body
+    assert "${SKILL_DIR%/skills/wiki-setup}" in body
+    assert "${SKILL_DIR%/.skills/wiki-setup}" in body
+    assert "/skills/llm-wiki/references/WRITING.md" in body
+    assert "/.skills/llm-wiki/references/WRITING.md" in body
+
+
+def test_wiki_capture_applies_profile_before_every_mode() -> None:
+    body = (ROOT / ".skills" / "wiki-capture" / "SKILL.md").read_text()
+    hook = body.index("**Writing profile:**")
+    for heading in (
+        "## Quick Mode (`--quick`)",
+        "## Correction Mode (`--correction`)",
+        "## Full Mode",
+    ):
+        assert hook < body.index(heading), heading
+
+
 def test_every_current_prose_writer_references_the_contract() -> None:
     for skill in REQUIRED_SKILLS:
         body = (ROOT / ".skills" / skill / "SKILL.md").read_text()


### PR DESCRIPTION
## Summary
- provision a user-editable global WRITING.md during setup
- apply shared writing-profile guidance across wiki prose-writing skills
- document precedence, scope, fallback, and setup behavior

## Verification
- python3 -m pytest -q: 655 passed, 14 skipped
- bash -n setup.sh
- python3 -m compileall -q obsidian_wiki

The direct push to upstream was unavailable, so this PR uses the writable mike840609 fork branch as its head.