### PR TITLE
feat(lint): report pages that share a slugged stem

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,6 +54,26 @@ obsidian-wiki lint --allow-lifecycle active --allow-relationship-type synthesize
 
 Lint resolves its vault and schema together: explicit path (no config inheritance), positional `@name`, nearest CWD `.env`, then global config. CLI schema flags extend/replace that resolved vault's settings and are recorded in the JSON `schema` block.
 
+### Colliding page stems
+
+`duplicate_stems` reports two or more pages whose filename stems are equal after slugging —
+`concepts/vector-search.md` and `entities/vector-search.md` across folders, or `Vector Search.md`
+beside `vector-search.md` inside one. The graph
+identifies a page by its bare stem, so those pages are a single node in every graph metric:
+degree, communities, betweenness, and the `graph-analyse --around` blast radius. The check keys
+on the same slug and the same page selection `graph_analysis` uses, so what it reports is exactly
+what the graph will merge — root `index.md`/`log.md`/`hot.md`/`_insights.md` are excluded, and a
+legitimate `concepts/index.md` is not.
+
+It is independent of how any link is written: the collision is between the pages, not between
+references to them, so a vault where nothing links to the stem is still reported.
+
+`duplicate_titles` does not cover this — it keys on the `title:` value, and stems can collide
+while titles differ (`"Vector Search"` and `"vector-search"` slug to the same stem).
+
+The check warns. A vault carrying a collision moves from `pass` to `warn`, which leaves
+`obsidian-wiki lint` at exit 0 and takes `obsidian-wiki lint --strict` to exit 1.
+
 ### Lifecycle transition checking
 
 `illegal_lifecycle_transitions` compares each page's current `lifecycle` against the value recorded in `_meta/trust-ledger.json` at its last review, and flags moves the state machine forbids: any state falling back to `draft` (only ingest sets `draft`), and any exit from `archived` (a restore is a deliberate delete-and-recreate, not a transition).

--- a/obsidian_wiki/lint.py
+++ b/obsidian_wiki/lint.py
@@ -8,6 +8,8 @@ from collections.abc import Collection
 from pathlib import Path
 from typing import Any
 
+from obsidian_wiki.graph_analysis import _page_slug as graph_page_slug
+from obsidian_wiki.graph_analysis import iter_pages as iter_graph_pages
 from obsidian_wiki.trust import (
     ALLOWED_LIFECYCLES,
     TRUST_LEDGER_RELATIVE_PATH,
@@ -245,6 +247,23 @@ def lint_vault(
         except ValueError as exc:
             trust_metadata_errors.append({"page": page["path"], "issue": str(exc)})
 
+    # `graph_analysis` identifies a page by its slugged stem (`_page_slug`), so
+    # two pages with the same slugged stem are ONE node in the graph metrics:
+    # degree, communities, betweenness, and the `neighborhood` blast radius.
+    # `Vector Search.md` and `vector-search.md` collide, in one folder or two.
+    # Key this check with that module's own slug and page selection, borrowed
+    # rather than reimplemented, so the report keys as the merge does.
+    stem_index: dict[str, list[str]] = defaultdict(list)
+    for graph_page in iter_graph_pages(vault):
+        stem_index[graph_page_slug(graph_page, vault)].append(
+            graph_page.relative_to(vault).as_posix()
+        )
+    duplicate_stems = [
+        {"stem": stem, "pages": sorted(paths)}
+        for stem, paths in sorted(stem_index.items())
+        if len(paths) > 1
+    ]
+
     title_index: dict[str, list[str]] = defaultdict(list)
     for page in pages:
         title_index[page["title"].strip().lower()].append(page["path"])
@@ -353,6 +372,7 @@ def lint_vault(
         "broken_links": broken_links,
         "missing_frontmatter": missing_frontmatter,
         "duplicate_titles": duplicate_titles,
+        "duplicate_stems": duplicate_stems,
         "missing_summaries": sorted(missing_summaries),
         "orphan_pages": sorted(orphan_pages),
         "typed_relationship_issues": typed_relationship_issues,
@@ -401,7 +421,13 @@ def lint_vault(
     elif (
         any(
             counts[name]
-            for name in ("duplicate_titles", "missing_summaries", "orphan_pages", "typed_relationship_issues")
+            for name in (
+                "duplicate_titles",
+                "duplicate_stems",
+                "missing_summaries",
+                "orphan_pages",
+                "typed_relationship_issues",
+            )
         )
         or trust_findings_present
     ):

--- a/tests/test_lint.py
+++ b/tests/test_lint.py
@@ -724,3 +724,114 @@ def test_no_ledger_means_no_transition_findings(tmp_path: Path) -> None:
     report = lint_vault(vault, require_trust_ledger=False)
 
     assert report["findings"]["illegal_lifecycle_transitions"] == []
+
+
+def test_lint_vault_warns_on_pages_sharing_a_stem(tmp_path: Path) -> None:
+    """`graph_analysis` keys a page by its bare stem, so these two are one node.
+
+    Nothing in the vault references the stem: the collision is the defect, not
+    the reference to it.
+    """
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/mercury.md", title="Mercury the concept", links=["alpha"])
+    _page(vault, "entities/mercury.md", title="Mercury the planet", links=["beta"])
+    _page(vault, "concepts/alpha.md", title="Alpha")
+    _page(vault, "concepts/beta.md", title="Beta")
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["status"] == "warn"
+    assert report["findings"]["duplicate_stems"] == [
+        {"stem": "mercury", "pages": ["concepts/mercury.md", "entities/mercury.md"]}
+    ]
+
+
+def test_duplicate_stems_ignores_how_the_link_was_written(tmp_path: Path) -> None:
+    """Both documented link formats carry a folder; neither creates a collision."""
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/vector-search.md", title="Vector Search")
+    _page(
+        vault,
+        "projects/renewal.md",
+        title="Renewal",
+        links=["concepts/vector-search|Vector Search"],
+    )
+    _page(vault, "projects/rollout.md", title="Rollout")
+    (vault / "projects/rollout.md").write_text(
+        (vault / "projects/rollout.md").read_text(encoding="utf-8")
+        + "\n[Vector Search](../concepts/vector-search.md)\n",
+        encoding="utf-8",
+    )
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["duplicate_stems"] == []
+    assert report["status"] == "pass"
+
+
+def test_duplicate_stems_follows_the_graph_page_selection(tmp_path: Path) -> None:
+    """Root `index.md` is not a graph page; `_bootstrap/` is."""
+    vault = tmp_path / "vault"
+    _page(vault, "index.md", title="Index")
+    _page(vault, "concepts/index.md", title="Concepts index")
+    _page(vault, "_bootstrap/vector-search.md", title="Bootstrap copy")
+    _page(vault, "concepts/vector-search.md", title="Vector Search")
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["duplicate_stems"] == [
+        {
+            "stem": "vector-search",
+            "pages": ["_bootstrap/vector-search.md", "concepts/vector-search.md"],
+        }
+    ]
+
+
+def test_duplicate_stems_rows_and_pages_are_sorted(tmp_path: Path) -> None:
+    """Neither ordering follows the page walk: `concepts/` precedes `concepts-x/`
+    by path but not by string, and `zebra` is walked before `dup`."""
+    vault = tmp_path / "vault"
+    _page(vault, "a-dir/zebra.md", title="Zebra one")
+    _page(vault, "b-dir/zebra.md", title="Zebra two")
+    _page(vault, "concepts/dup.md", title="Dup one")
+    _page(vault, "concepts-x/dup.md", title="Dup two")
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["duplicate_stems"] == [
+        {"stem": "dup", "pages": ["concepts-x/dup.md", "concepts/dup.md"]},
+        {"stem": "zebra", "pages": ["a-dir/zebra.md", "b-dir/zebra.md"]},
+    ]
+
+
+def test_duplicate_stems_slugs_the_filename(tmp_path: Path) -> None:
+    """`Vector Search.md` and `vector-search.md` are the same node; a raw
+    `Path.stem` would not see it."""
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/Vector Search.md", title="Vector Search")
+    _page(vault, "entities/vector-search.md", title="The Pinecone product")
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["duplicate_stems"] == [
+        {
+            "stem": "vector-search",
+            "pages": ["concepts/Vector Search.md", "entities/vector-search.md"],
+        }
+    ]
+
+
+def test_duplicate_stems_reports_a_collision_inside_one_folder(tmp_path: Path) -> None:
+    """A hand-named page beside a tool-written one: same folder, same node."""
+    vault = tmp_path / "vault"
+    _page(vault, "concepts/Vector Search.md", title="Vector Search")
+    _page(vault, "concepts/vector-search.md", title="Vector search notes")
+
+    report = lint_vault(vault, require_trust_ledger=False)
+
+    assert report["findings"]["duplicate_stems"] == [
+        {
+            "stem": "vector-search",
+            "pages": ["concepts/Vector Search.md", "concepts/vector-search.md"],
+        }
+    ]


### PR DESCRIPTION

A page can disappear from search and nothing reports it.

Two pages whose filenames slug to the same stem are one node to `graph_analysis`, and one entry to
`graphrag`. Measured on a three-page vault holding `concepts/vector-search.md` ("The retrieval
technique") and `entities/vector-search.md` ("Pinecone (the product)"):

```
graphrag.build_index(vault)  ->  slugs ['embeddings', 'vector-search']
   'vector-search'           ->  'Pinecone (the product)'  entities/vector-search.md
```

`concepts/vector-search.md` is absent from the index that `memory_search` and `graph-query` read. The same merge runs through `god_nodes`, `detect_communities`,
`betweenness_centrality` / `bridge_pages`, `shortest_path`, `neighborhood` and `_insights.md`.

`duplicate_titles` does not cover it, because it keys on the `title:` value while identity keys on
the stem — the two pages above have different titles.

## Where the collision comes from

`graph_analysis._page_slug(path, root)` returns `_slug(path.stem)` (`graph_analysis.py:64-65`), so
identity is the slugged filename. `write_page` builds `f"{_slug(category)}/{_slug(title)}.md"`
(`server.py:77`); `category` is a required parameter of `write_page` (`server.py:69`), exposed as the
`memory_write` MCP tool (`server.py:160`) and over HTTP, where `PageWrite` defaults it to `concepts`
(`server.py:141`).

Two `write_page` calls into a fresh vault, nothing else:

```python
write_page("Vector Search", "concepts", "The technique.")
write_page("vector-search", "entities", "The Pinecone product.")
```

```
files written      concepts/vector-search.md   entities/vector-search.md   log.md
graph              2 pages -> 1 node  ['vector-search']       (root log.md is graph-excluded)
duplicate_titles   []
duplicate_stems    [{'stem': 'vector-search',
                     'pages': ['concepts/vector-search.md', 'entities/vector-search.md']}]
```

A hand-authored vault reaches it too: `Vector Search.md` beside `vector-search.md` slugs to one stem,
in one folder or two.

## The change

Build a stem index over `graph_analysis.iter_pages` using `graph_analysis._page_slug`, and report
stems holding more than one page. Both are borrowed from that module rather than reimplemented, so
the report keys as the merge does. It reads pages rather than links, so a collision nothing
references is still reported.

Severity is `warn`, beside `duplicate_titles`. **Migration:** a vault carrying a collision moves
`pass` → `warn`, so `obsidian-wiki lint` stays exit 0 while `obsidian-wiki lint --strict` becomes
exit 1. If you run `--strict` in CI, an existing collision will surface there on upgrade.

Six tests in `tests/test_lint.py`. Suite: **687 passed, 5 skipped (681 before, +6 new)**. Each test
fails against unpatched `lint.py`. Mutants run at the call sites this patch adds, all caught:
dropping either sort; `> 1` → `> 0`; `iter_graph_pages` → a raw `rglob`; the borrowed slug → a raw
`Path.stem`; the borrowed slug → `stem.lower()`; restricting to different folders; and removing the
key from the `warn` tuple.

## Two things worth your call rather than mine

**`_bootstrap/` becomes visible to this one check.** `lint.SKIP_DIRS` (`lint.py:19`) skips
`_bootstrap` and `.git`; `graph_analysis.SKIP_DIRS` skips `_meta` and `_readouts` instead. Borrowing
the graph's selection is what makes the report match the merge, but it does mean a collision *inside*
`_bootstrap/` is now reported, and `test_lint_excludes_bootstrap_scaffolding_from_page_health`
(`tests/test_trust.py:840`) exists because you wanted that directory out of page health. That test
still passes — its one file has a unique stem — so this is a question rather than a breakage: keep
the graph's selection, or intersect it with `lint.SKIP_DIRS` and lose collisions that the graph does
merge. One line either way; I did not want to pick it quietly.

**`lint`'s own `by_slug` is stem-keyed too** (`lint.py:214`), so a collision the graph excludes — two
pages inside `_meta/`, say — can still absorb one page's in-links into the other and affect
`orphan_pages`. This patch does not touch that, and does not report it.

## What I did not change

- **Page identity.** Making `_page_slug` path-aware would change what `[[name]]` resolves to and what
  a stored `_insights.md` snapshot means. This reports the condition instead of deciding it.
- **`.skills/wiki-lint/SKILL.md`**, which enumerates the checks. #177 is open on that file's
  divergence from `lint.py`, so I left it alone — with the consequence that an agent running the
  skill will not surface this finding until the spec catches up.
- **Link collection.** #176 and #177 concern `_parse_page`'s wikilink harvest; this check reads no
  links.

`wiki-dedup` is the neighboring tool and does not overlap: it scores candidates on title similarity,
and it exists to *merge* pages that are the same concept. The case here is two pages that are
legitimately different and should stay separate while the graph merges them anyway. Its own
`node_id` is the vault-relative path, which is the identity this check is pointing at.

## Limits

`write_page` was executed with `fastapi`, `pydantic` and `mcp` stubbed — it imports none of them, but
the server was not run for real. The vaults above were constructed; I have not seen this in a vault
of yours, and it does not need observing: two `memory_write` calls with different categories produce
it mechanically. On Python 3.12 the page-ordering half of one test may be satisfied by the walk order
rather than by the sort; the assertion holds either way, and I ran 3.9, 3.11 and 3.14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
