### PR TITLE
fix: preserve reserved leading-underscore categories in write_page's slug

### DIFF
--- a/obsidian_wiki/server.py
+++ b/obsidian_wiki/server.py
@@ -53,6 +53,12 @@ def _slug(title: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-") or "untitled"
 
 
+def _category_slug(category: str) -> str:
+    """Slugify a category, preserving a reserved leading underscore."""
+    slug = _slug(category)
+    return f"_{slug}" if category.lower().startswith("_") else slug
+
+
 def search(q: str, limit: int = 8) -> dict[str, Any]:
     return graph_query(VAULT, q, top_n=limit)
 
@@ -74,7 +80,7 @@ def write_page(
     summary: str = "",
     upsert: bool = True,
 ) -> dict[str, Any]:
-    rel = f"{_slug(category)}/{_slug(title)}.md"
+    rel = f"{_category_slug(category)}/{_slug(title)}.md"
     target = _resolve(rel)
     if target.exists() and not upsert:
         raise HTTPException(409, f"page already exists: {rel}")
@@ -88,7 +94,7 @@ def write_page(
         [
             "---",
             f"title: {title}",
-            f"category: {_slug(category)}",
+            f"category: {_category_slug(category)}",
             "tags: [" + ", ".join(tags or []) + "]",
             "sources: [" + ", ".join(sources or []) + "]",
             f"summary: {summary}" if summary else "summary:",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -84,3 +84,12 @@ def test_write_cannot_escape_the_vault(client, tmp_path):
     # The category is slugified before it becomes a directory, so dots never survive.
     assert ".." not in resp.json()["path"]
     assert not (tmp_path.parent / "escape.md").exists()
+
+
+def test_reserved_raw_category_keeps_its_underscore(client):
+    # The four skip lists exclude a page by exact path match against "_raw";
+    # a dropped leading underscore would land it in "raw/" instead.
+    written = client.post("/v1/pages", json={
+        "title": "Clipped Note", "category": "_raw", "content": "x",
+    }).json()
+    assert written["path"] == "_raw/clipped-note.md"


### PR DESCRIPTION
`write_page`'s rel-path build calls `_slug(category)` directly, and `_slug()` strips
every leading non-alphanumeric character (`re.sub(r"[^a-z0-9]+", "-", ...)`). A page
written with `category="_raw"` therefore lands at `raw/<title>.md`, not `_raw/<title>.md`.

That matters because four separate skip lists (`graph_analysis.SKIP_DIRS`,
`lint.SKIP_DIRS`, `context_pack.SKIP_DIRS`, `trust.TRUST_SKIP_DIRS`) all exclude an
unreviewed capture by an exact match against `"_raw"` (and its siblings, e.g.
`"_archived"`). None of them match `"raw"`, so a page meant to be excluded from graph
analysis, linting, context packing and trust scoring gets pulled into all four as if
it were reviewed knowledge.

Added `_category_slug()`, which slugifies the category and re-adds the leading
underscore when the caller's category started with one, and pointed both of
`write_page`'s uses of `_slug(category)` (the path build and the frontmatter
`category:` field) at it. `_slug(title)` is unchanged; only the category segment is
reserved-name-aware.

**Verified:**
- New regression test (`test_reserved_raw_category_keeps_its_underscore`) fails on
  main (`written["path"] == "raw/clipped-note.md"`) and passes on this branch.
- Full `pytest tests/` green on Python 3.12 with the `[server]` extra installed
  (690 passed, 4 skipped, one pre-existing failure in
  `test_code_understand_codegraph_via_bin_env` unrelated to this change and present
  on main before this diff, a `python3` PATH-resolution artifact of my minimal
  container image, not of the repo).
- Did not verify against Python 3.9: `mcp>=2.0` (the `[server]` extra) has no
  distribution for 3.9, so `tests/test_server.py` is skipped by `importorskip` on
  that interpreter both on main and on this branch, in CI and locally.

Fixes #199