### PR TITLE
fix: normalize relative paths in manifest delta matching

### DIFF
--- a/scripts/manifest.py
+++ b/scripts/manifest.py
@@ -112,6 +112,12 @@ def _skip_patterns(cli_skip: str | None) -> list[str]:
     return pats
 
 
+def _normalize_for_match(path: str) -> str:
+    """Normalize either slash style for host-independent path comparison."""
+    portable = path.replace("\\", os.sep).replace("/", os.sep)
+    return os.path.normcase(os.path.normpath(portable))
+
+
 def _relative_key_index(sources: dict) -> dict[str, list[tuple[str, dict]]]:
     """Index relative source keys by basename for suffix matching.
 
@@ -124,14 +130,20 @@ def _relative_key_index(sources: dict) -> dict[str, list[tuple[str, dict]]]:
     index: dict[str, list[tuple[str, dict]]] = {}
     for k, v in sources.items():
         if not os.path.isabs(k):
-            index.setdefault(os.path.basename(k), []).append((k, v))
+            basename = os.path.basename(_normalize_for_match(k))
+            index.setdefault(basename, []).append((k, v))
     return index
 
 
 def _match_relative(path: str, index: dict[str, list[tuple[str, dict]]]) -> dict | None:
     """Return the manifest entry whose relative key is a suffix of `path`."""
-    for relkey, entry in index.get(os.path.basename(path), ()):
-        if path == relkey or path.endswith(os.sep + relkey):
+    normalized_path = _normalize_for_match(path)
+    basename = os.path.basename(normalized_path)
+    for relkey, entry in index.get(basename, ()):
+        normalized_relkey = _normalize_for_match(relkey)
+        if normalized_path == normalized_relkey or normalized_path.endswith(
+            os.sep + normalized_relkey
+        ):
             return entry
     return None
 

--- a/tests/test_manifest_delta.py
+++ b/tests/test_manifest_delta.py
@@ -14,6 +14,32 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import manifest  # noqa: E402
 
 
+class ManifestRelativePathMatchingTest(unittest.TestCase):
+    def test_windows_path_matches_posix_manifest_key(self) -> None:
+        entry = {"ingested_at": "2026-08-31T00:00:00Z"}
+        index = manifest._relative_key_index(
+            {"projects/demo/session.jsonl": entry}
+        )
+
+        matched = manifest._match_relative(
+            r"C:\Users\米格\projects\demo\session.jsonl", index
+        )
+
+        self.assertIs(matched, entry)
+
+    def test_posix_path_matches_windows_manifest_key(self) -> None:
+        entry = {"ingested_at": "2026-08-31T00:00:00Z"}
+        index = manifest._relative_key_index(
+            {r"projects\demo\session.jsonl": entry}
+        )
+
+        matched = manifest._match_relative(
+            "/home/user/projects/demo/session.jsonl", index
+        )
+
+        self.assertIs(matched, entry)
+
+
 class ManifestDeltaRelativeKeyTest(unittest.TestCase):
     """cmd_delta must recognize sources stored under relative keys.
 


### PR DESCRIPTION
## Summary

- Normalize mixed `/` and `\` separators before indexing and matching relative manifest paths.
- Apply host-specific path normalization and case handling during comparison.
- Add cross-platform regression tests, including a Windows path with a non-ASCII username.

## Problem

On Windows, manifest entries stored with POSIX-style separators were not matched against scanned paths using backslashes. As a result, previously ingested sources could be reported as `NEW` instead of `MOD` or unchanged.

## Testing

- `python -m pytest tests/test_manifest_delta.py -q`
  - 8 passed
- `python -m pytest tests/test_manifest_delta.py tests/test_cache_manifest_shapes.py tests/test_cache.py -q`
  - 55 passed