### PR TITLE
docs: document uv/pipx install paths (and the uvx footgun)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ pip install obsidian-wiki
 obsidian-wiki setup --vault ~/brain
 ```
 
+Using `uv` or `pipx`? `uv tool install obsidian-wiki` and `pipx install obsidian-wiki` work the same way. (Not `uvx` — see [Installation](https://github.com/Ar9av/obsidian-wiki/blob/main/docs/installation.md#install-via-pip-uv-or-pipx-recommended).)
+
 Then open any project in your agent and say **"set up my wiki"**.
 
 Prefer not to touch a terminal? Give your agent this and it'll do the whole thing:

--- a/README_TW.md
+++ b/README_TW.md
@@ -39,6 +39,8 @@ pip install obsidian-wiki
 obsidian-wiki setup --vault ~/brain
 ```
 
+使用 `uv` 或 `pipx`？`uv tool install obsidian-wiki` 與 `pipx install obsidian-wiki` 的效果相同。（不要用 `uvx`，原因見[安裝說明](https://github.com/Ar9av/obsidian-wiki/blob/main/docs/installation.md#install-via-pip-uv-or-pipx-recommended)。）
+
 然後在你的 agent 裡打開任何專案，說 **「set up my wiki」**。
 
 不想碰終端機？把下面這行交給你的 agent，它會全部處理好：

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,17 +8,28 @@ All full setup entry points — `obsidian-wiki setup`, `setup.sh`, and an agent 
 
 | Path | Best for | Writes global config | Installs into all agents |
 |---|---|---|---|
-| [pip](#install-via-pip-recommended) | Most people | ✅ | ✅ |
+| [pip / uv / pipx](#install-via-pip-uv-or-pipx-recommended) | Most people | ✅ | ✅ |
 | [Let your agent do it](#let-your-agent-set-it-up) | No terminal required | ✅ | ✅ |
 | [git clone + `setup.sh`](#install-via-git-clone) | Contributors, hackers | ✅ | ✅ |
 | [Skills CLI](#install-via-skills-cli-deprecated) | Deprecated — partial install | ❌ | ❌ (current agent only) |
 
-## Install via pip (recommended)
+## Install via pip, uv, or pipx (recommended)
 
 ```bash
 pip install obsidian-wiki
 obsidian-wiki setup --vault /path/to/your/digital/brain
 ```
+
+`uv` and `pipx` work just as well — use whichever you already have:
+
+```bash
+uv tool install obsidian-wiki     # or: uv pip install obsidian-wiki
+pipx install obsidian-wiki
+```
+
+Upgrades are `uv tool upgrade obsidian-wiki` / `pipx upgrade obsidian-wiki`; re-run `obsidian-wiki setup` afterwards to pick up new skills.
+
+> **Don't use `uvx obsidian-wiki setup`.** `uvx` runs from a throwaway environment, and setup symlinks skills *into the installed package*. When the environment is discarded, every skill link in `~/.claude/skills/`, `~/.codex/skills/`, and the rest points at a path that no longer exists. If you must run it that way, use `uvx obsidian-wiki setup --copy`, which copies the skill files instead.
 
 `obsidian-wiki setup` writes the config to `~/.config/obsidian-wiki/config` and installs every wiki skill into all your AI agents (Claude Code, Cursor, Codex, Gemini, Hermes, Pi, and more). Skills are symlinked to the installed package, so `pip install -U obsidian-wiki` upgrades them everywhere — just re-run `obsidian-wiki setup` to pick up new skills.
 


### PR DESCRIPTION
Closes #201.

`pip` was never a requirement — the package is a pure-stdlib CLI with an entry point, so `uv tool install` / `uv pip install` / `pipx install` all work today. The docs just never said so.

- `docs/installation.md`: section renamed to "Install via pip, uv, or pipx", with uv/pipx install + upgrade commands.
- Warning about `uvx obsidian-wiki setup`: setup symlinks skills **into the installed package**, so a throwaway uvx env leaves dangling links in every agent's skills dir. `--copy` is the escape hatch.
- One-line pointer in `README.md` + `README_TW.md` (translation parity).

Docs-only, no code changes.