### PR TITLE
fix(cli): report the install mode that actually happened

### DIFF
--- a/obsidian_wiki/cli.py
+++ b/obsidian_wiki/cli.py
@@ -138,6 +138,11 @@ def _is_symlink_privilege_error(error: OSError) -> bool:
     return os.name == "nt" and getattr(error, "winerror", None) == 1314
 
 
+# Set when a symlink install falls back to copying, so the warning prints once
+# and the setup summary can report the mode that actually happened.
+_SYMLINK_FALLBACK = False
+
+
 def install_skills(
     target_dir: Path,
     label: str,
@@ -149,9 +154,9 @@ def install_skills(
     """Install bundled skills into *target_dir*. Returns the count installed."""
     src_root = skills_dir()
     target_dir.mkdir(parents=True, exist_ok=True)
+    global _SYMLINK_FALLBACK
     installed = 0
-    install_mode = mode
-    warned_copy_fallback = False
+    install_mode = "copy" if _SYMLINK_FALLBACK else mode
     for skill in sorted(p for p in src_root.iterdir() if p.is_dir()):
         name = skill.name
         if subset is not None and name not in subset:
@@ -176,13 +181,13 @@ def install_skills(
                 if not _is_symlink_privilege_error(error):
                     raise
                 install_mode = "copy"
-                if not warned_copy_fallback:
+                if not _SYMLINK_FALLBACK:
                     print(
                         "Warning: symbolic links are unavailable; "
                         "copying skills instead. Use Developer Mode or "
                         "--copy to choose this explicitly."
                     )
-                    warned_copy_fallback = True
+                _SYMLINK_FALLBACK = True
                 shutil.copytree(skill, link_path)
         else:  # copy
             shutil.copytree(skill, link_path)
@@ -998,7 +1003,7 @@ def cmd_setup(args: argparse.Namespace) -> int:
     n = len(list_skills())
     print("\n───────────────────────────────────────────────────")
     print(" Setup complete!\n")
-    print(f" Skills installed: {n}  (mode: {mode})")
+    print(f" Skills installed: {n}  (mode: {'copy' if _SYMLINK_FALLBACK else mode})")
     if vault_path:
         print(f" Vault:            {vault_path}")
     print(f" Writing profile:  {writing_profile.resolve()}")

--- a/tests/test_cli_install.py
+++ b/tests/test_cli_install.py
@@ -102,3 +102,32 @@ def test_install_skills_keeps_unrelated_symlink_errors(
 
     with pytest.raises(OSError, match="access denied"):
         cli.install_skills(tmp_path / "target-skills", "test")
+
+
+def test_symlink_fallback_reports_copy_mode_once(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    source_root = tmp_path / "bundled-skills"
+    for name in ("a-skill", "b-skill"):
+        skill = source_root / name
+        skill.mkdir(parents=True)
+        (skill / "SKILL.md").write_text(f"---\nname: {name}\n---\n", encoding="utf-8")
+
+    monkeypatch.setattr(cli, "skills_dir", lambda: source_root)
+    monkeypatch.setattr(cli, "_SYMLINK_FALLBACK", False)
+
+    def deny_symlink(self, target, target_is_directory=False):  # noqa: ANN001
+        error = OSError(1314, "A required privilege is not held by the client")
+        error.winerror = 1314
+        raise error
+
+    monkeypatch.setattr(Path, "symlink_to", deny_symlink)
+    monkeypatch.setattr(cli, "_is_symlink_privilege_error", lambda error: True)
+
+    for target in ("agent-one", "agent-two"):
+        assert cli.install_skills(tmp_path / target, target, mode="symlink") == 2
+
+    out = capsys.readouterr().out
+    assert out.count("symbolic links are unavailable") == 1
+    assert cli._SYMLINK_FALLBACK is True
+    assert (tmp_path / "agent-two" / "a-skill" / "SKILL.md").is_file()


### PR DESCRIPTION
When Windows rejects symlink creation (`WinError 1314`), `install_skills` falls back to copying. That fallback was tracked in a local, and `install_skills` runs once per agent directory — so on a non-admin account the warning printed **12 times** and the setup summary still claimed `mode: symlink` while it had actually copied everything.

Hoisted the flag to a module-level `_SYMLINK_FALLBACK`: warn once, skip the doomed `symlink_to` on subsequent directories, and report `mode: copy` in the summary.

## Test plan

- New regression test in `tests/test_cli_install.py`: two agent directories with symlinks denied → warning printed once, flag set, skills still installed as real directories.
- `python -m pytest -q` → 682 passed, 4 skipped (the 9 `test_server.py` errors are pre-existing — `fastapi`/`mcp` not installed).
- Verified on Windows Server 2022 as a non-admin user (ACP 936): before, 12 warnings + `mode: symlink`; after, one warning + `Skills installed: 40  (mode: copy)`.

Same run also confirmed #188 is fixed on a real GBK console — setup exits 0 there.