### PR TITLE
fix(wiki-lint): correct SKILL.md's broken-wikilink and relationship-target recipes

### DIFF
--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -57,7 +57,8 @@ Find `[[wikilinks]]` that point to pages that don't exist.
 **How to check:**
 - Grep for `\[\[.*?\]\]` across all pages
 - Extract the link target: drop everything from the first `|` (alias) or `#` (heading/block anchor), and strip a trailing backslash left by an escaped `\|` inside a table cell
-- Skip a target whose extension isn't `.md` (images, PDFs, `.canvas`, `.base`, and other attachment types): it's an embed, not a page link, and has no entry in the `.md` inventory this check compares against
+- Skip a target whose extension is an attachment type (`.png`, `.jpg`, `.gif`, `.svg`, `.webp`, `.pdf`, `.canvas`, `.base`, audio and video): it's an embed, not a page link, and has no entry in the `.md` inventory this check compares against
+- Do **not** treat every dot as an extension — `[[Node.js]]`, `[[Next.js]]`, and `[[v1.2 release notes]]` are page links whose names happen to contain a dot, and dropping them would both miss real broken links and make the target page look like an orphan
 - Strip an explicit `.md` suffix from what remains, then check if a corresponding `.md` file exists
 
 **How to fix:**

--- a/.skills/wiki-lint/SKILL.md
+++ b/.skills/wiki-lint/SKILL.md
@@ -56,8 +56,9 @@ Find `[[wikilinks]]` that point to pages that don't exist.
 
 **How to check:**
 - Grep for `\[\[.*?\]\]` across all pages
-- Extract the link targets
-- Check if a corresponding `.md` file exists
+- Extract the link target: drop everything from the first `|` (alias) or `#` (heading/block anchor), and strip a trailing backslash left by an escaped `\|` inside a table cell
+- Skip a target whose extension isn't `.md` (images, PDFs, `.canvas`, `.base`, and other attachment types): it's an embed, not a page link, and has no entry in the `.md` inventory this check compares against
+- Strip an explicit `.md` suffix from what remains, then check if a corresponding `.md` file exists
 
 **How to fix:**
 - If the target was renamed, update the link
@@ -330,6 +331,7 @@ Validate `relationships:` frontmatter blocks. Skip pages that have no `relations
 - For each entry in the block:
   1. **Type validation** — flag any `type:` value not in the allowed set above
   2. **Broken target** — strip `[[` and `]]` from the `target:` string, normalize (lowercase, spaces→hyphens, strip `.md`), and check whether a `.md` file at that path exists in the vault. Flag unresolved targets.
+     Before normalizing, drop everything from the first `|` (alias) or `#` (heading/block anchor): a pipe-aliased or heading-anchored target is not broken just because the literal bracket contents don't match a filename.
   3. **Self-reference** — flag any entry where the resolved target equals the page's own node id
 
 **How to fix:**


### PR DESCRIPTION
Fixes #177

Check 2 ("Broken Wikilinks") told an agent to grep `[[wikilinks]]`, extract
the whole bracket contents as the target, and check that against the `.md`
inventory. Check 13's "Broken target" step for `relationships[].target` did
the same strip-and-normalize with no mention of a pipe or a heading anchor.
Neither matches what `obsidian_wiki/lint.py` actually does: `_WIKILINK_RE`
and `_wikilink_page_target` already exclude an alias/heading segment and
skip non-`.md` embeds, and `_normalise_node_id` already splits on `|` and
`#` before comparing. Following the prose literally flags `[[page|Display]]`,
`[[page#Heading]]`, `[[page#^blockid]]`, a table-escaped `[[page\|A]]`, and
any image/PDF/`.canvas`/`.base` embed as broken.

This matters beyond a wrong report: Consolidate mode's Action 1 reads
Check 2's flagged list and either rewrites a flagged target to the nearest
existing page name or strips the brackets to plain text. A false positive
there is not just noise, it is a link an operator can end up losing on a
`--consolidate` run they approved from the preview.

Updated both checks' recipe to match the code: drop everything from the
first `|` or `#` before comparing, skip non-`.md` extensions, and strip an
explicit `.md` suffix.

Verified by implementing both the old and new prose literally against the
reporter's own fixture ([[page|Display]], [[page#Heading]],
[[page#^blockid]], [[dashboard.base]], [[page\|A]], [[ghost]]): the old
recipe flags 5 of 6 as broken, matching the report; the new recipe flags
only `[[ghost]]`, byte-for-byte matching `lint_vault()`'s real
`broken_links` output on the same fixture, and `_normalise_node_id`'s
actual output on an aliased relationship target. Ran the full `pytest
tests/` suite on Python 3.9 and 3.12, this repo's own CI matrix; both show
the same 3 failures in `tests/test_code_understand_cli.py`, a
`python3`-on-PATH issue in the codegraph subprocess that this change does
not touch.

This is a documentation-only change (`.skills/wiki-lint/SKILL.md`); there
is no importable module to attach a unit test to, so the verification
above stands in its place.
